### PR TITLE
Optimize Cosmos fee collection for parallel BlockSTM execution

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -24,10 +24,12 @@ type FeePolicyKeeper interface {
 }
 
 // HandlerOptions combines the complete upstream Cosmos EVM options with the
-// one dependency used only by Guru's Cosmos transaction path.
+// dependencies and immutable mode selection used only by Guru's Cosmos path.
 type HandlerOptions struct {
-	EVMOptions      evmante.HandlerOptions
-	FeePolicyKeeper FeePolicyKeeper
+	EVMOptions                 evmante.HandlerOptions
+	CosmosFeeBankKeeper        CosmosFeeBankKeeper
+	CosmosVirtualFeeCollection bool
+	FeePolicyKeeper            FeePolicyKeeper
 }
 
 // Validate checks all dependencies used by both routed ante handlers.
@@ -38,6 +40,9 @@ func (options HandlerOptions) Validate() error {
 	if options.FeePolicyKeeper == nil {
 		return errorsmod.Wrap(sdkerrors.ErrLogic, "fee policy keeper is required for AnteHandler")
 	}
+	if options.CosmosFeeBankKeeper == nil {
+		return errorsmod.Wrap(sdkerrors.ErrLogic, "Cosmos fee bank keeper is required for AnteHandler")
+	}
 
 	return nil
 }
@@ -47,6 +52,13 @@ func (options HandlerOptions) Validate() error {
 // transactions to Guru's fee-policy-aware Cosmos chain.
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	if err := options.Validate(); err != nil {
+		return nil, err
+	}
+	feeCollector, err := selectCosmosFeeCollector(
+		options.CosmosFeeBankKeeper,
+		options.CosmosVirtualFeeCollection,
+	)
+	if err != nil {
 		return nil, err
 	}
 
@@ -65,7 +77,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 					// pending transaction listener behavior from Cosmos EVM v0.7.
 					return upstreamHandler(ctx, tx, simulate)
 				case dynamicFeeExtension:
-					return newCosmosAnteHandler(ctx, options)(ctx, tx, simulate)
+					return newCosmosAnteHandler(ctx, options, feeCollector)(ctx, tx, simulate)
 				default:
 					// Let upstream produce the canonical unsupported-extension
 					// error and preserve its routing semantics.
@@ -78,6 +90,28 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 			return upstreamHandler(ctx, tx, simulate)
 		}
 
-		return newCosmosAnteHandler(ctx, options)(ctx, tx, simulate)
+		return newCosmosAnteHandler(ctx, options, feeCollector)(ctx, tx, simulate)
 	}, nil
+}
+
+// selectCosmosFeeCollector snapshots the binary-selected Cosmos collection
+// mode into an immutable method value. EVM virtual fee configuration is neither
+// read nor changed here.
+func selectCosmosFeeCollector(
+	bankKeeper CosmosFeeBankKeeper,
+	virtualFeeCollection bool,
+) (CosmosFeeCollector, error) {
+	if !virtualFeeCollection {
+		return bankKeeper.SendCoinsFromAccountToModule, nil
+	}
+
+	virtualFeeBankKeeper, ok := bankKeeper.(VirtualFeeBankKeeper)
+	if !ok {
+		return nil, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"bank keeper must support virtual Cosmos fee collection",
+		)
+	}
+
+	return virtualFeeBankKeeper.SendCoinsFromAccountToModuleVirtual, nil
 }

--- a/app/ante/cosmos.go
+++ b/app/ante/cosmos.go
@@ -13,7 +13,11 @@ import (
 // newCosmosAnteHandler mirrors the Cosmos EVM v0.7 Cosmos ante chain. The fee
 // market parameters are read in the transaction context, rather than captured
 // when the application constructs its ante handler.
-func newCosmosAnteHandler(ctx sdk.Context, options HandlerOptions) sdk.AnteHandler {
+func newCosmosAnteHandler(
+	ctx sdk.Context,
+	options HandlerOptions,
+	feeCollector CosmosFeeCollector,
+) sdk.AnteHandler {
 	evmOptions := options.EVMOptions
 	feemarketParams := evmOptions.FeeMarketKeeper.GetParams(ctx)
 
@@ -37,7 +41,7 @@ func newCosmosAnteHandler(ctx sdk.Context, options HandlerOptions) sdk.AnteHandl
 		authante.NewConsumeGasForTxSizeDecorator(evmOptions.AccountKeeper),
 		NewDeductFeeDecorator(
 			evmOptions.AccountKeeper,
-			evmOptions.BankKeeper,
+			feeCollector,
 			evmOptions.FeegrantKeeper,
 			txFeeChecker,
 			options.FeePolicyKeeper,

--- a/app/ante/cosmos_fees.go
+++ b/app/ante/cosmos_fees.go
@@ -36,11 +36,43 @@ type EffectiveFeeBreakdown struct {
 // computed from fee-cap inputs, never inferred from the truncated priority.
 type TxFeeChecker func(ctx sdk.Context, tx sdk.Tx) (EffectiveFeeBreakdown, error)
 
+// CosmosFeeBankKeeper is the normal bank capability used when Cosmos virtual
+// fee collection is not enabled for a binary.
+type CosmosFeeBankKeeper interface {
+	SendCoinsFromAccountToModule(
+		ctx context.Context,
+		senderAddr sdk.AccAddress,
+		recipientModule string,
+		amt sdk.Coins,
+	) error
+}
+
+// VirtualFeeBankKeeper is the additional bank capability required when Cosmos
+// virtual fee collection is enabled independently from the EVM fee path.
+type VirtualFeeBankKeeper interface {
+	SendCoinsFromAccountToModuleVirtual(
+		ctx context.Context,
+		senderAddr sdk.AccAddress,
+		recipientModule string,
+		amt sdk.Coins,
+	) error
+}
+
+// CosmosFeeCollector is selected exactly once during ante construction. This
+// prevents later mutations of application keeper settings from changing the
+// transaction state transition function.
+type CosmosFeeCollector func(
+	ctx context.Context,
+	senderAddr sdk.AccAddress,
+	recipientModule string,
+	amt sdk.Coins,
+) error
+
 // DeductFeeDecorator applies a policy only to the Cosmos effective base fee,
 // consumes any fee grant with the resulting actual fee, and collects that fee.
 type DeductFeeDecorator struct {
 	accountKeeper      authante.AccountKeeper
-	bankKeeper         authtypes.BankKeeper
+	feeCollector       CosmosFeeCollector
 	feegrantKeeper     authante.FeegrantKeeper
 	txFeeChecker       TxFeeChecker
 	feePolicyKeeper    FeePolicyKeeper
@@ -48,11 +80,11 @@ type DeductFeeDecorator struct {
 }
 
 // NewDeductFeeDecorator is the application-local extension point for Cosmos
-// fee accounting. Collection currently remains a normal bank transfer to the
-// SDK fee_collector module account.
+// fee accounting. Its collector is selected independently from the EVM fee
+// path when the ante handler is constructed.
 func NewDeductFeeDecorator(
 	accountKeeper authante.AccountKeeper,
-	bankKeeper authtypes.BankKeeper,
+	feeCollector CosmosFeeCollector,
 	feegrantKeeper authante.FeegrantKeeper,
 	txFeeChecker TxFeeChecker,
 	feePolicyKeeper FeePolicyKeeper,
@@ -63,7 +95,7 @@ func NewDeductFeeDecorator(
 
 	return DeductFeeDecorator{
 		accountKeeper:      accountKeeper,
-		bankKeeper:         bankKeeper,
+		feeCollector:       feeCollector,
 		feegrantKeeper:     feegrantKeeper,
 		txFeeChecker:       txFeeChecker,
 		feePolicyKeeper:    feePolicyKeeper,
@@ -137,8 +169,8 @@ func (dfd DeductFeeDecorator) validate() error {
 	if dfd.accountKeeper == nil {
 		return errorsmod.Wrap(sdkerrors.ErrLogic, "account keeper is required for fee deduction")
 	}
-	if dfd.bankKeeper == nil {
-		return errorsmod.Wrap(sdkerrors.ErrLogic, "bank keeper is required for fee deduction")
+	if dfd.feeCollector == nil {
+		return errorsmod.Wrap(sdkerrors.ErrLogic, "fee collector is required for fee deduction")
 	}
 	if dfd.txFeeChecker == nil {
 		return errorsmod.Wrap(sdkerrors.ErrLogic, "tx fee checker is required for fee deduction")
@@ -248,14 +280,13 @@ func (dfd DeductFeeDecorator) checkDeductFee(
 }
 
 // collectFees is the single collection side-effect boundary for Cosmos fees.
-// Replacing the collection mechanism in a future task is intentionally local
-// to this helper and NewDeductFeeDecorator.
+// A zero fee must not create an object-store entry.
 func (dfd DeductFeeDecorator) collectFees(ctx context.Context, payer sdk.AccAddress, fee sdk.Coins) error {
 	if fee.IsZero() {
 		return nil
 	}
 
-	if err := dfd.bankKeeper.SendCoinsFromAccountToModule(
+	if err := dfd.feeCollector(
 		ctx,
 		payer,
 		dfd.feeRecipientModule,

--- a/app/ante/cosmos_fees_test.go
+++ b/app/ante/cosmos_fees_test.go
@@ -2,6 +2,7 @@ package ante
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -53,6 +54,34 @@ func (keeper staticFeePolicyKeeper) ResolveDiscount(
 	[]sdk.Msg,
 ) (feepolicytypes.Discount, error) {
 	return keeper.discount, nil
+}
+
+type virtualFeeBankKeeperSpy struct {
+	calls           int
+	ctx             context.Context
+	senderAddr      sdk.AccAddress
+	recipientModule string
+	amount          sdk.Coins
+	err             error
+	onSend          func(context.Context, sdk.AccAddress, string, sdk.Coins) error
+}
+
+func (keeper *virtualFeeBankKeeperSpy) SendCoinsFromAccountToModuleVirtual(
+	ctx context.Context,
+	senderAddr sdk.AccAddress,
+	recipientModule string,
+	amount sdk.Coins,
+) error {
+	keeper.calls++
+	keeper.ctx = ctx
+	keeper.senderAddr = senderAddr
+	keeper.recipientModule = recipientModule
+	keeper.amount = amount
+	if keeper.onSend != nil {
+		return keeper.onSend(ctx, senderAddr, recipientModule, amount)
+	}
+
+	return keeper.err
 }
 
 func feeDecoratorTestPayer() sdk.AccAddress {
@@ -116,7 +145,7 @@ func TestApplyDiscountToBaseFee(t *testing.T) {
 	}
 }
 
-func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
+func TestDeductFeeDecoratorNoPolicyMatchesUpstreamFeeAmountPriorityAndEvents(t *testing.T) {
 	payer := feeDecoratorTestPayer()
 	fee := parityFee(200)
 	tx := parityFeeTx{gas: 10, fee: fee, payer: payer}
@@ -124,10 +153,10 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 	ethConfig := parityLondonConfig(0)
 
 	type observation struct {
-		payerBalance     sdkmath.Int
-		collectorBalance sdkmath.Int
-		priority         int64
-		events           sdk.Events
+		payerBalance sdkmath.Int
+		collectedFee sdkmath.Int
+		priority     int64
+		events       sdk.Events
 	}
 	run := func(local bool) observation {
 		controller := gomock.NewController(t)
@@ -146,14 +175,20 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 		}
 
 		payerBalance := sdkmath.NewInt(1_000)
-		collectorBalance := sdkmath.ZeroInt()
-		bankKeeper.EXPECT().
-			SendCoinsFromAccountToModule(gomock.Any(), payer, authtypes.FeeCollectorName, fee).
-			DoAndReturn(func(context.Context, sdk.AccAddress, string, sdk.Coins) error {
-				payerBalance = payerBalance.Sub(fee.AmountOf(parityFeeDenom))
-				collectorBalance = collectorBalance.Add(fee.AmountOf(parityFeeDenom))
-				return nil
-			})
+		collectedFee := sdkmath.ZeroInt()
+		recordCollection := func(_ context.Context, _ sdk.AccAddress, _ string, amount sdk.Coins) error {
+			payerBalance = payerBalance.Sub(amount.AmountOf(parityFeeDenom))
+			collectedFee = collectedFee.Add(amount.AmountOf(parityFeeDenom))
+			return nil
+		}
+		virtualBankKeeper := &virtualFeeBankKeeperSpy{onSend: recordCollection}
+		if !local {
+			bankKeeper.EXPECT().
+				SendCoinsFromAccountToModule(gomock.Any(), payer, authtypes.FeeCollectorName, fee).
+				DoAndReturn(func(ctx context.Context, sender sdk.AccAddress, module string, amount sdk.Coins) error {
+					return recordCollection(ctx, sender, module, amount)
+				})
+		}
 
 		ctx := parityFeeContext(1, false)
 		var (
@@ -166,7 +201,7 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 			}
 			newCtx, err = NewDeductFeeDecorator(
 				accountKeeper,
-				bankKeeper,
+				virtualBankKeeper.SendCoinsFromAccountToModuleVirtual,
 				nil,
 				checker,
 				staticFeePolicyKeeper{},
@@ -187,18 +222,24 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 			})
 		}
 		require.NoError(t, err)
+		if local {
+			require.Equal(t, 1, virtualBankKeeper.calls)
+			require.Equal(t, payer, virtualBankKeeper.senderAddr)
+			require.Equal(t, authtypes.FeeCollectorName, virtualBankKeeper.recipientModule)
+			require.Equal(t, fee, virtualBankKeeper.amount)
+		}
 		return observation{
-			payerBalance:     payerBalance,
-			collectorBalance: collectorBalance,
-			priority:         newCtx.Priority(),
-			events:           newCtx.EventManager().Events(),
+			payerBalance: payerBalance,
+			collectedFee: collectedFee,
+			priority:     newCtx.Priority(),
+			events:       newCtx.EventManager().Events(),
 		}
 	}
 
 	local := run(true)
 	upstream := run(false)
 	require.Equal(t, sdkmath.NewInt(800), local.payerBalance)
-	require.Equal(t, sdkmath.NewInt(200), local.collectorBalance)
+	require.Equal(t, sdkmath.NewInt(200), local.collectedFee)
 	require.Equal(t, upstream, local)
 	require.Len(t, local.events, 1)
 }
@@ -206,7 +247,7 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 func TestDeductFeeDecoratorPreservesCheckerPriority(t *testing.T) {
 	controller := gomock.NewController(t)
 	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
-	bankKeeper := authtestutil.NewMockBankKeeper(controller)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{}
 	payer := feeDecoratorTestPayer()
 	accountKeeper.EXPECT().
 		GetModuleAddress(authtypes.FeeCollectorName).
@@ -223,7 +264,7 @@ func TestDeductFeeDecoratorPreservesCheckerPriority(t *testing.T) {
 	fee := parityFee(60)
 	ctx, err := NewDeductFeeDecorator(
 		accountKeeper,
-		bankKeeper,
+		virtualBankKeeper.SendCoinsFromAccountToModuleVirtual,
 		nil,
 		staticFeeBreakdownChecker(fee, priority),
 		staticFeePolicyKeeper{discount: feepolicytypes.Discount{
@@ -243,6 +284,7 @@ func TestDeductFeeDecoratorPreservesCheckerPriority(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, priority, nextPriority)
 	require.Equal(t, priority, ctx.Priority())
+	require.Zero(t, virtualBankKeeper.calls, "zero fees must not create a virtual collection entry")
 	require.Len(t, ctx.EventManager().Events(), 1)
 	require.Equal(t, sdk.Coins{}.String(), ctx.EventManager().Events()[0].Attributes[0].Value)
 }
@@ -251,13 +293,13 @@ func TestDeductFeeDecoratorMissingFeeCollectorFailsBeforeSideEffects(t *testing.
 	controller := gomock.NewController(t)
 	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
 	accountKeeper.EXPECT().GetModuleAddress(authtypes.FeeCollectorName).Return(nil)
-	bankKeeper := authtestutil.NewMockBankKeeper(controller)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{}
 	nextCalled := false
 	ctx := parityFeeContext(1, false)
 
 	_, err := NewDeductFeeDecorator(
 		accountKeeper,
-		bankKeeper,
+		virtualBankKeeper.SendCoinsFromAccountToModuleVirtual,
 		nil,
 		staticFeeBreakdownChecker(parityFee(60), 1),
 		noCallFeePolicyKeeper{t: t},
@@ -279,7 +321,7 @@ func TestDeductFeeDecoratorMissingFeeCollectorFailsBeforeSideEffects(t *testing.
 func TestDeductFeeDecoratorMissingPayerFailsBeforeBankSideEffects(t *testing.T) {
 	controller := gomock.NewController(t)
 	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
-	bankKeeper := authtestutil.NewMockBankKeeper(controller)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{}
 	payer := feeDecoratorTestPayer()
 	accountKeeper.EXPECT().
 		GetModuleAddress(authtypes.FeeCollectorName).
@@ -293,7 +335,7 @@ func TestDeductFeeDecoratorMissingPayerFailsBeforeBankSideEffects(t *testing.T) 
 
 	_, err := NewDeductFeeDecorator(
 		accountKeeper,
-		bankKeeper,
+		virtualBankKeeper.SendCoinsFromAccountToModuleVirtual,
 		nil,
 		staticFeeBreakdownChecker(parityFee(60), 1),
 		staticFeePolicyKeeper{},
@@ -308,6 +350,50 @@ func TestDeductFeeDecoratorMissingPayerFailsBeforeBankSideEffects(t *testing.T) 
 	)
 
 	require.ErrorIs(t, err, sdkerrors.ErrUnknownAddress)
+	require.False(t, nextCalled)
+	require.Empty(t, ctx.EventManager().Events())
+}
+
+func TestDeductFeeDecoratorVirtualCollectionFailureStopsAnteChain(t *testing.T) {
+	controller := gomock.NewController(t)
+	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
+	payer := feeDecoratorTestPayer()
+	fee := parityFee(60)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{err: errors.New("virtual collection failed")}
+	accountKeeper.EXPECT().
+		GetModuleAddress(authtypes.FeeCollectorName).
+		Return(authtypes.NewModuleAddress(authtypes.FeeCollectorName))
+	accountKeeper.EXPECT().
+		AddressCodec().
+		Return(evmaddress.NewEvmCodec(sdk.GetConfig().GetBech32AccountAddrPrefix()))
+	accountKeeper.EXPECT().
+		GetAccount(gomock.Any(), payer).
+		Return(authtypes.NewBaseAccountWithAddress(payer))
+
+	nextCalled := false
+	ctx := parityFeeContext(1, false)
+	_, err := NewDeductFeeDecorator(
+		accountKeeper,
+		virtualBankKeeper.SendCoinsFromAccountToModuleVirtual,
+		nil,
+		staticFeeBreakdownChecker(fee, 1),
+		staticFeePolicyKeeper{},
+	).AnteHandle(
+		ctx,
+		parityFeeTx{gas: 1, fee: fee, payer: payer},
+		false,
+		func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			nextCalled = true
+			return ctx, nil
+		},
+	)
+
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+	require.ErrorContains(t, err, "virtual collection failed")
+	require.Equal(t, 1, virtualBankKeeper.calls)
+	require.Equal(t, payer, virtualBankKeeper.senderAddr)
+	require.Equal(t, authtypes.FeeCollectorName, virtualBankKeeper.recipientModule)
+	require.Equal(t, fee, virtualBankKeeper.amount)
 	require.False(t, nextCalled)
 	require.Empty(t, ctx.EventManager().Events())
 }
@@ -364,7 +450,7 @@ func TestDeductFeeDecoratorRejectsInvalidCheckerBreakdownBeforeSideEffects(t *te
 			controller := gomock.NewController(t)
 			decorator := NewDeductFeeDecorator(
 				authantetestutil.NewMockAccountKeeper(controller),
-				authtestutil.NewMockBankKeeper(controller),
+				new(virtualFeeBankKeeperSpy).SendCoinsFromAccountToModuleVirtual,
 				authantetestutil.NewMockFeegrantKeeper(controller),
 				func(sdk.Context, sdk.Tx) (EffectiveFeeBreakdown, error) {
 					return test.breakdown, nil

--- a/app/ante/router_nonregression_test.go
+++ b/app/ante/router_nonregression_test.go
@@ -3,6 +3,7 @@ package ante
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -87,27 +88,32 @@ func TestAnteRouterEthereumDelegatesToUpstreamWithoutPolicyResolution(t *testing
 	ethereumOption, err := codectypes.NewAnyWithValue(&evmtypes.ExtensionOptionsEthereumTx{})
 	require.NoError(t, err)
 
-	options, policy, evmKeeper, feeMarketKeeper := newRouterHandlerOptions()
-	handler, err := NewAnteHandler(options)
-	require.NoError(t, err)
+	for _, cosmosVirtual := range []bool{false, true} {
+		t.Run(fmt.Sprintf("Cosmos virtual=%t", cosmosVirtual), func(t *testing.T) {
+			options, policy, evmKeeper, feeMarketKeeper := newRouterHandlerOptions()
+			options.CosmosVirtualFeeCollection = cosmosVirtual
+			handler, err := NewAnteHandler(options)
+			require.NoError(t, err)
 
-	// This deliberately is not a ProtoTxProvider. The important observable is
-	// that Guru returns the exact upstream mono-ante error before fee policy is
-	// consulted, while still entering the upstream EVM keeper/fee-market path.
-	tx := routerTestTx{
-		msgs:       []sdk.Msg{&evmtypes.MsgEthereumTx{}},
-		gas:        1_000_000,
-		extensions: []*codectypes.Any{ethereumOption},
+			// This deliberately is not a ProtoTxProvider. The important observable is
+			// that Guru returns the exact upstream mono-ante error before fee policy is
+			// consulted, while still entering the upstream EVM keeper/fee-market path.
+			tx := routerTestTx{
+				msgs:       []sdk.Msg{&evmtypes.MsgEthereumTx{}},
+				gas:        1_000_000,
+				extensions: []*codectypes.Any{ethereumOption},
+			}
+			_, localErr := handler(routerContext(false), tx, false)
+			require.Error(t, localErr)
+			require.Zero(t, policy.calls)
+			require.Equal(t, 1, evmKeeper.paramsCalls)
+			require.Equal(t, 1, feeMarketKeeper.paramsCalls)
+
+			_, upstreamErr := evmante.NewAnteHandler(options.EVMOptions)(routerContext(false), tx, false)
+			require.EqualError(t, localErr, upstreamErr.Error())
+			require.ErrorIs(t, localErr, sdkerrors.ErrUnknownRequest)
+		})
 	}
-	_, localErr := handler(routerContext(false), tx, false)
-	require.Error(t, localErr)
-	require.Zero(t, policy.calls)
-	require.Equal(t, 1, evmKeeper.paramsCalls)
-	require.Equal(t, 1, feeMarketKeeper.paramsCalls)
-
-	_, upstreamErr := evmante.NewAnteHandler(options.EVMOptions)(routerContext(false), tx, false)
-	require.EqualError(t, localErr, upstreamErr.Error())
-	require.ErrorIs(t, localErr, sdkerrors.ErrUnknownRequest)
 }
 
 func TestAnteRouterReadsFeeMarketParamsForEveryCosmosTransaction(t *testing.T) {
@@ -163,6 +169,59 @@ func TestAnteRouterHandlerOptionsValidation(t *testing.T) {
 		require.ErrorIs(t, err, sdkerrors.ErrLogic)
 		require.ErrorContains(t, err, "fee policy keeper is required for AnteHandler")
 	})
+
+	t.Run("Cosmos fee bank dependency", func(t *testing.T) {
+		options, _, _, _ := newRouterHandlerOptions()
+		options.CosmosFeeBankKeeper = nil
+		_, err := NewAnteHandler(options)
+		require.ErrorIs(t, err, sdkerrors.ErrLogic)
+		require.ErrorContains(t, err, "Cosmos fee bank keeper is required for AnteHandler")
+	})
+
+	t.Run("virtual Cosmos fee collection capability", func(t *testing.T) {
+		options, _, _, _ := newRouterHandlerOptions()
+		options.CosmosFeeBankKeeper = &routerBankKeeperWithoutVirtual{}
+		_, err := NewAnteHandler(options)
+		require.ErrorIs(t, err, sdkerrors.ErrLogic)
+		require.ErrorContains(t, err, "bank keeper must support virtual Cosmos fee collection")
+	})
+
+	t.Run("normal Cosmos collection does not require virtual capability", func(t *testing.T) {
+		options, _, _, _ := newRouterHandlerOptions()
+		options.CosmosVirtualFeeCollection = false
+		options.CosmosFeeBankKeeper = &routerBankKeeperWithoutVirtual{}
+		_, err := NewAnteHandler(options)
+		require.NoError(t, err)
+	})
+}
+
+func TestSelectCosmosFeeCollectorSnapshotsIndependentMode(t *testing.T) {
+	payer := sdk.AccAddress(strings.Repeat("p", 20))
+	fee := sdk.NewCoins(sdk.NewInt64Coin("aguru", 7))
+
+	t.Run("normal", func(t *testing.T) {
+		keeper := &routerBankKeeper{}
+		collector, err := selectCosmosFeeCollector(keeper, false)
+		require.NoError(t, err)
+		require.NoError(t, collector(context.Background(), payer, authtypes.FeeCollectorName, fee))
+		require.Equal(t, 1, keeper.normalCalls)
+		require.Zero(t, keeper.virtualCalls)
+	})
+
+	t.Run("virtual snapshot", func(t *testing.T) {
+		keeper := &routerBankKeeper{}
+		virtualEnabled := true
+		collector, err := selectCosmosFeeCollector(keeper, virtualEnabled)
+		require.NoError(t, err)
+
+		// Changing the source option after construction cannot alter the selected
+		// transaction path.
+		virtualEnabled = false
+		require.False(t, virtualEnabled)
+		require.NoError(t, collector(context.Background(), payer, authtypes.FeeCollectorName, fee))
+		require.Zero(t, keeper.normalCalls)
+		require.Equal(t, 1, keeper.virtualCalls)
+	})
 }
 
 func configureRouterEVM(t *testing.T) {
@@ -206,7 +265,9 @@ func newRouterHandlerOptions() (HandlerOptions, *routerPolicyKeeper, *routerEVMK
 			},
 			PendingTxListener: func(common.Hash) {},
 		},
-		FeePolicyKeeper: policy,
+		CosmosFeeBankKeeper:        &routerBankKeeper{},
+		CosmosVirtualFeeCollection: true,
+		FeePolicyKeeper:            policy,
 	}, policy, evmKeeper, feeMarketKeeper
 }
 
@@ -249,6 +310,41 @@ func (keeper *routerAccountKeeper) AddressCodec() coreaddress.Codec {
 
 type routerBankKeeper struct {
 	anteinterfaces.BankKeeper
+	normalCalls  int
+	virtualCalls int
+}
+
+func (keeper *routerBankKeeper) SendCoinsFromAccountToModule(
+	context.Context,
+	sdk.AccAddress,
+	string,
+	sdk.Coins,
+) error {
+	keeper.normalCalls++
+	return nil
+}
+
+func (keeper *routerBankKeeper) SendCoinsFromAccountToModuleVirtual(
+	context.Context,
+	sdk.AccAddress,
+	string,
+	sdk.Coins,
+) error {
+	keeper.virtualCalls++
+	return nil
+}
+
+type routerBankKeeperWithoutVirtual struct {
+	anteinterfaces.BankKeeper
+}
+
+func (*routerBankKeeperWithoutVirtual) SendCoinsFromAccountToModule(
+	context.Context,
+	sdk.AccAddress,
+	string,
+	sdk.Coins,
+) error {
+	return nil
 }
 
 type routerEVMKeeper struct {

--- a/app/ante_handler.go
+++ b/app/ante_handler.go
@@ -32,7 +32,9 @@ func (app *App) setAnteHandler(txConfig client.TxConfig, maxGasWanted uint64) er
 			DynamicFeeChecker:      true,
 			PendingTxListener:      app.onPendingTx,
 		},
-		FeePolicyKeeper: app.FeePolicyKeeper,
+		CosmosFeeBankKeeper:        app.BankKeeper,
+		CosmosVirtualFeeCollection: app.CosmosVirtualFeeCollectionEnabled(),
+		FeePolicyKeeper:            app.FeePolicyKeeper,
 	}
 
 	anteHandler, err := appante.NewAnteHandler(options)

--- a/app/blockstm_cosmos_virtual_fee_benchmark_test.go
+++ b/app/blockstm_cosmos_virtual_fee_benchmark_test.go
@@ -1,0 +1,600 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log/v2"
+	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/server"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
+	appparams "github.com/gurufinglobal/guru/v3/app/params"
+	constitutiontypes "github.com/gurufinglobal/guru/v3/x/constitution/types"
+	feepolicytypes "github.com/gurufinglobal/guru/v3/x/feepolicy/types"
+)
+
+const (
+	blockSTMCosmosFeeBenchmarkChainID = "guru-blockstm-cosmos-fee-benchmark-1"
+	blockSTMCosmosFeeBenchmarkTxEnv   = "GURU_BLOCKSTM_BENCH_TXS"
+	blockSTMCosmosFeeBenchmarkWorkEnv = "GURU_BLOCKSTM_BENCH_WORKERS"
+
+	blockSTMCosmosFeeBenchmarkDefaultTxs = 128
+	blockSTMCosmosFeeBenchmarkMaxTxs     = 20_000
+	blockSTMCosmosFeeBenchmarkGas        = uint64(200_000)
+	blockSTMCosmosFeeBenchmarkFee        = int64(200_000)
+	blockSTMCosmosFeeBenchmarkFunds      = int64(1_000_000_000_000_000_000)
+)
+
+type blockSTMCosmosFeeBenchmarkWorkload uint8
+
+const (
+	blockSTMCosmosFeeBenchmarkIndependent blockSTMCosmosFeeBenchmarkWorkload = iota
+	blockSTMCosmosFeeBenchmarkSameAccount
+)
+
+type blockSTMCosmosFeeBenchmarkAccount struct {
+	priv          *secp256k1.PrivKey
+	address       sdk.AccAddress
+	addressString string
+	accountNumber uint64
+}
+
+type blockSTMCosmosFeeBenchmarkFixture struct {
+	app                 *App
+	payers              []blockSTMCosmosFeeBenchmarkAccount
+	recipients          []sdk.AccAddress
+	nextHeight          int64
+	startTime           time.Time
+	independentSequence uint64
+	sameAccountSequence uint64
+}
+
+// BenchmarkBlockSTMCosmosFeeCollection exercises the production BlockSTM,
+// FeePolicy, signed Cosmos transaction, FinalizeBlock, and Commit paths. The
+// exact same source file can be copied to an unpatched dev-v3 worktree to
+// compare normal fee collection with virtual fee collection.
+//
+// GURU_BLOCKSTM_BENCH_TXS controls transactions per block (default 128).
+// GURU_BLOCKSTM_BENCH_WORKERS controls BlockSTM workers (default min(10,
+// GOMAXPROCS)). For stable comparisons, pin GOMAXPROCS and run with a fixed
+// -benchtime count, for example:
+//
+//	GOMAXPROCS=10 GURU_BLOCKSTM_BENCH_TXS=1000 \
+//	  go test ./app -run '^$' -bench '^BenchmarkBlockSTMCosmosFeeCollection$' \
+//	  -benchmem -benchtime=10x -count=5
+func BenchmarkBlockSTMCosmosFeeCollection(b *testing.B) {
+	configureBlockSTMCosmosFeeBenchmarkPrefixes(b)
+
+	txCount := blockSTMCosmosFeeBenchmarkEnvInt(
+		b,
+		blockSTMCosmosFeeBenchmarkTxEnv,
+		blockSTMCosmosFeeBenchmarkDefaultTxs,
+		1,
+		blockSTMCosmosFeeBenchmarkMaxTxs,
+	)
+	defaultWorkers := runtime.GOMAXPROCS(0)
+	if defaultWorkers > 10 {
+		defaultWorkers = 10
+	}
+	workers := blockSTMCosmosFeeBenchmarkEnvInt(
+		b,
+		blockSTMCosmosFeeBenchmarkWorkEnv,
+		defaultWorkers,
+		1,
+		1_024,
+	)
+	fixture := newBlockSTMCosmosFeeBenchmarkFixture(b, txCount, workers)
+
+	for _, workload := range []struct {
+		name string
+		kind blockSTMCosmosFeeBenchmarkWorkload
+	}{
+		{name: "independent_payers", kind: blockSTMCosmosFeeBenchmarkIndependent},
+		{name: "same_account", kind: blockSTMCosmosFeeBenchmarkSameAccount},
+	} {
+		b.Run(fmt.Sprintf("%s/txs_%d/workers_%d", workload.name, txCount, workers), func(b *testing.B) {
+			blockSTMCosmosFeeBenchmarkRun(b, fixture, workload.kind, txCount)
+		})
+	}
+}
+
+func blockSTMCosmosFeeBenchmarkRun(
+	b *testing.B,
+	fixture *blockSTMCosmosFeeBenchmarkFixture,
+	workload blockSTMCosmosFeeBenchmarkWorkload,
+	txCount int,
+) {
+	b.Helper()
+
+	blocks := make([][][]byte, b.N)
+	for blockIndex := 0; blockIndex < b.N; blockIndex++ {
+		blocks[blockIndex] = fixture.signedBlock(b, workload, txCount, blockIndex)
+	}
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var finalizeDuration, commitDuration time.Duration
+	for blockIndex := 0; blockIndex < b.N; blockIndex++ {
+		finalizeStarted := time.Now()
+		response, err := fixture.app.FinalizeBlock(&abci.RequestFinalizeBlock{
+			Height: fixture.nextHeight,
+			Time:   fixture.startTime.Add(time.Duration(fixture.nextHeight) * time.Second),
+			Txs:    blocks[blockIndex],
+		})
+		finalizeDuration += time.Since(finalizeStarted)
+		if err != nil {
+			b.Fatalf("FinalizeBlock at height %d: %v", fixture.nextHeight, err)
+		}
+		if len(response.TxResults) != txCount {
+			b.Fatalf("FinalizeBlock returned %d results, want %d", len(response.TxResults), txCount)
+		}
+		for txIndex, result := range response.TxResults {
+			if result.Code != abci.CodeTypeOK {
+				b.Fatalf("tx %d at height %d failed with code %d: %s", txIndex, fixture.nextHeight, result.Code, result.Log)
+			}
+		}
+
+		commitStarted := time.Now()
+		if _, err := fixture.app.Commit(); err != nil {
+			b.Fatalf("Commit at height %d: %v", fixture.nextHeight, err)
+		}
+		commitDuration += time.Since(commitStarted)
+		fixture.nextHeight++
+	}
+
+	b.StopTimer()
+	runtime.ReadMemStats(&after)
+	totalTxs := float64(b.N * txCount)
+	totalDuration := finalizeDuration + commitDuration
+	b.ReportMetric(float64(totalDuration.Nanoseconds())/totalTxs, "ns/tx")
+	b.ReportMetric(float64(finalizeDuration.Nanoseconds())/totalTxs, "finalize_ns/tx")
+	b.ReportMetric(float64(commitDuration.Nanoseconds())/totalTxs, "commit_ns/tx")
+	b.ReportMetric(totalTxs/totalDuration.Seconds(), "tx/s")
+	b.ReportMetric(float64(after.Mallocs-before.Mallocs)/totalTxs, "allocs/tx")
+	b.ReportMetric(float64(after.TotalAlloc-before.TotalAlloc)/totalTxs, "B/tx")
+	if workload == blockSTMCosmosFeeBenchmarkIndependent {
+		fixture.independentSequence += uint64(b.N)
+	} else {
+		fixture.sameAccountSequence += uint64(b.N * txCount)
+	}
+}
+
+func newBlockSTMCosmosFeeBenchmarkFixture(
+	b *testing.B,
+	txCount int,
+	workers int,
+) *blockSTMCosmosFeeBenchmarkFixture {
+	b.Helper()
+
+	// One extra payer is reserved for the same-account workload. Keeping both
+	// workloads in one App avoids relying on Cosmos EVM's test-only global reset
+	// hooks and also keeps the benchmark command valid without custom build tags.
+	payerCount := txCount + 1
+	payers := make([]blockSTMCosmosFeeBenchmarkAccount, payerCount)
+	for i := range payers {
+		payers[i] = newBlockSTMCosmosFeeBenchmarkAccount(b, "payer", i, uint64(i))
+	}
+	recipients := make([]sdk.AccAddress, txCount)
+	for i := range recipients {
+		recipients[i] = newBlockSTMCosmosFeeBenchmarkAccount(b, "recipient", i, 0).address
+	}
+
+	options := simtestutil.AppOptionsMap{
+		"oracle.enabled":               false,
+		server.FlagMempoolMaxTxs:       -1,
+		server.FlagBlockExecutor:       serverconfig.BlockExecutorBlockSTM,
+		server.FlagBlockSTMWorkers:     workers,
+		server.FlagBlockSTMPreEstimate: true,
+	}
+	testApp := NewApp(
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		true,
+		options,
+		baseapp.SetChainID(blockSTMCosmosFeeBenchmarkChainID),
+	)
+	b.Cleanup(func() {
+		if err := testApp.Close(); err != nil {
+			b.Errorf("close benchmark app: %v", err)
+		}
+	})
+
+	fixture := &blockSTMCosmosFeeBenchmarkFixture{
+		app:        testApp,
+		payers:     payers,
+		recipients: recipients,
+		nextHeight: 2,
+		startTime:  time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+	}
+	genesis := testApp.BuildChainDefaultGenesis()
+	fixture.setConstitutionGenesis(b, genesis)
+	fixture.setAuthGenesis(b, genesis)
+	fixture.setStakingGenesis(b, genesis)
+	fixture.setBankGenesis(b, genesis)
+	fixture.setFeeMarketGenesis(b, genesis)
+	fixture.setMintGenesis(b, genesis)
+	fixture.setFeePolicyGenesis(b, genesis)
+	if err := testApp.ValidateChainGenesis(genesis); err != nil {
+		b.Fatalf("validate benchmark genesis: %v", err)
+	}
+
+	appState, err := json.Marshal(genesis)
+	if err != nil {
+		b.Fatalf("marshal benchmark genesis: %v", err)
+	}
+	if _, err := testApp.InitChain(&abci.RequestInitChain{
+		ChainId:         blockSTMCosmosFeeBenchmarkChainID,
+		InitialHeight:   1,
+		Time:            fixture.startTime,
+		AppStateBytes:   appState,
+		ConsensusParams: simtestutil.DefaultConsensusParams,
+	}); err != nil {
+		b.Fatalf("InitChain benchmark app: %v", err)
+	}
+	initialBlock, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: 1,
+		Time:   fixture.startTime.Add(time.Second),
+	})
+	if err != nil {
+		b.Fatalf("initial FinalizeBlock: %v", err)
+	}
+	if len(initialBlock.TxResults) != 0 {
+		b.Fatalf("initial FinalizeBlock returned %d tx results", len(initialBlock.TxResults))
+	}
+	if _, err := testApp.Commit(); err != nil {
+		b.Fatalf("initial Commit: %v", err)
+	}
+
+	return fixture
+}
+
+func newBlockSTMCosmosFeeBenchmarkAccount(
+	b *testing.B,
+	role string,
+	index int,
+	accountNumber uint64,
+) blockSTMCosmosFeeBenchmarkAccount {
+	b.Helper()
+
+	priv := secp256k1.GenPrivKeyFromSecret([]byte(fmt.Sprintf(
+		"%s/%s/%d",
+		blockSTMCosmosFeeBenchmarkChainID,
+		role,
+		index,
+	)))
+	address := sdk.AccAddress(priv.PubKey().Address())
+	addressString, err := sdk.Bech32ifyAddressBytes(appparams.Bech32PrefixAccAddr, address)
+	if err != nil {
+		b.Fatalf("encode %s %d address: %v", role, index, err)
+	}
+	return blockSTMCosmosFeeBenchmarkAccount{
+		priv:          priv,
+		address:       address,
+		addressString: addressString,
+		accountNumber: accountNumber,
+	}
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setConstitutionGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := &constitutiontypes.GenesisState{}
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[constitutiontypes.ModuleName], state)
+	state.BaseAddress = fixture.payers[0].addressString
+	state.ModeratorAddress = fixture.payers[0].addressString
+	genesis[constitutiontypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setAuthGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := authtypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[authtypes.ModuleName], state)
+	accounts := make(authtypes.GenesisAccounts, len(fixture.payers))
+	for i, payer := range fixture.payers {
+		accounts[i] = authtypes.NewBaseAccount(
+			payer.address,
+			payer.priv.PubKey(),
+			payer.accountNumber,
+			0,
+		)
+	}
+	state = authtypes.NewGenesisState(state.Params, accounts)
+	genesis[authtypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setStakingGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	bond := sdk.TokensFromConsensusPower(1, sdk.DefaultPowerReduction)
+	pubKey := simtestutil.CreateTestPubKeys(1)[0]
+	validatorBytes := sdk.ValAddress(pubKey.Address().Bytes())
+	validatorAddress, err := fixture.app.StakingKeeper.ValidatorAddressCodec().BytesToString(validatorBytes)
+	if err != nil {
+		b.Fatalf("encode benchmark validator address: %v", err)
+	}
+	validator, err := stakingtypes.NewValidator(
+		validatorAddress,
+		pubKey,
+		stakingtypes.Description{Moniker: "blockstm-cosmos-fee-benchmark-validator"},
+	)
+	if err != nil {
+		b.Fatalf("create benchmark validator: %v", err)
+	}
+	validator.Status = stakingtypes.Bonded
+	validator.Tokens = bond
+	validator.DelegatorShares = sdkmath.LegacyNewDecFromInt(bond)
+
+	delegatorAddress, err := fixture.app.AccountKeeper.AddressCodec().BytesToString(
+		sdk.AccAddress(validatorBytes),
+	)
+	if err != nil {
+		b.Fatalf("encode benchmark delegator address: %v", err)
+	}
+	state := stakingtypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[stakingtypes.ModuleName], state)
+	state.Validators = []stakingtypes.Validator{validator}
+	state.Delegations = []stakingtypes.Delegation{
+		stakingtypes.NewDelegation(
+			delegatorAddress,
+			validatorAddress,
+			sdkmath.LegacyNewDecFromInt(bond),
+		),
+	}
+	genesis[stakingtypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setBankGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := banktypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[banktypes.ModuleName], state)
+	state.Balances = make([]banktypes.Balance, 0, len(fixture.payers)+1)
+	for _, payer := range fixture.payers {
+		state.Balances = append(state.Balances, banktypes.Balance{
+			Address: payer.addressString,
+			Coins: sdk.NewCoins(sdk.NewInt64Coin(
+				appparams.BaseDenom,
+				blockSTMCosmosFeeBenchmarkFunds,
+			)),
+		})
+	}
+	bondedPoolAddress, err := fixture.app.AccountKeeper.AddressCodec().BytesToString(
+		authtypes.NewModuleAddress(stakingtypes.BondedPoolName),
+	)
+	if err != nil {
+		b.Fatalf("encode bonded pool address: %v", err)
+	}
+	state.Balances = append(state.Balances, banktypes.Balance{
+		Address: bondedPoolAddress,
+		Coins: sdk.NewCoins(sdk.NewCoin(
+			appparams.BaseDenom,
+			sdk.TokensFromConsensusPower(1, sdk.DefaultPowerReduction),
+		)),
+	})
+	state.Supply = nil
+	genesis[banktypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setMintGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := minttypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[minttypes.ModuleName], state)
+	state.Minter = minttypes.InitialMinter(sdkmath.LegacyZeroDec())
+	state.Params.InflationRateChange = sdkmath.LegacyZeroDec()
+	state.Params.InflationMax = sdkmath.LegacyZeroDec()
+	state.Params.InflationMin = sdkmath.LegacyZeroDec()
+	genesis[minttypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setFeeMarketGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := feemarkettypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[feemarkettypes.ModuleName], state)
+	state.Params.NoBaseFee = true
+	state.Params.BaseFee = sdkmath.LegacyZeroDec()
+	state.Params.MinGasPrice = sdkmath.LegacyOneDec()
+	genesis[feemarkettypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setFeePolicyGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := &feepolicytypes.GenesisState{
+		ModeratorAddress: fixture.payers[0].addressString,
+		Discounts: []feepolicytypes.AccountDiscount{
+			feePolicyTestBankSendDiscount(
+				"",
+				feepolicytypes.FeeDiscountTypeFixed,
+				sdkmath.LegacyNewDec(12_345),
+			),
+		},
+	}
+	genesis[feepolicytypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) signedBlock(
+	b *testing.B,
+	workload blockSTMCosmosFeeBenchmarkWorkload,
+	txCount int,
+	blockIndex int,
+) [][]byte {
+	b.Helper()
+
+	txs := make([][]byte, txCount)
+	for txIndex := 0; txIndex < txCount; txIndex++ {
+		payerIndex := txIndex
+		sequence := fixture.independentSequence + uint64(blockIndex)
+		if workload == blockSTMCosmosFeeBenchmarkSameAccount {
+			payerIndex = len(fixture.payers) - 1
+			sequence = fixture.sameAccountSequence + uint64(blockIndex*txCount+txIndex)
+		}
+		txs[txIndex] = fixture.signTx(
+			b,
+			fixture.payers[payerIndex],
+			fixture.recipients[txIndex],
+			sequence,
+		)
+	}
+	return txs
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) signTx(
+	b *testing.B,
+	signer blockSTMCosmosFeeBenchmarkAccount,
+	recipient sdk.AccAddress,
+	sequence uint64,
+) []byte {
+	b.Helper()
+
+	builder := fixture.app.TxConfig().NewTxBuilder()
+	msg := banktypes.NewMsgSend(
+		signer.address,
+		recipient,
+		sdk.NewCoins(sdk.NewInt64Coin(appparams.BaseDenom, 1)),
+	)
+	if err := builder.SetMsgs(msg); err != nil {
+		b.Fatalf("set MsgSend: %v", err)
+	}
+	builder.SetGasLimit(blockSTMCosmosFeeBenchmarkGas)
+	builder.SetFeeAmount(sdk.NewCoins(sdk.NewInt64Coin(
+		appparams.BaseDenom,
+		blockSTMCosmosFeeBenchmarkFee,
+	)))
+
+	signMode, err := authsigning.APISignModeToInternal(
+		fixture.app.TxConfig().SignModeHandler().DefaultMode(),
+	)
+	if err != nil {
+		b.Fatalf("resolve sign mode: %v", err)
+	}
+	signature := signing.SignatureV2{
+		PubKey: signer.priv.PubKey(),
+		Data: &signing.SingleSignatureData{
+			SignMode: signMode,
+		},
+		Sequence: sequence,
+	}
+	if err := builder.SetSignatures(signature); err != nil {
+		b.Fatalf("set placeholder signature: %v", err)
+	}
+
+	signerData := authsigning.SignerData{
+		Address:       signer.addressString,
+		ChainID:       blockSTMCosmosFeeBenchmarkChainID,
+		AccountNumber: signer.accountNumber,
+		Sequence:      sequence,
+		PubKey:        signer.priv.PubKey(),
+	}
+	signBytes, err := authsigning.GetSignBytesAdapter(
+		context.Background(),
+		fixture.app.TxConfig().SignModeHandler(),
+		signMode,
+		signerData,
+		builder.GetTx(),
+	)
+	if err != nil {
+		b.Fatalf("build sign bytes: %v", err)
+	}
+	rawSignature, err := signer.priv.Sign(signBytes)
+	if err != nil {
+		b.Fatalf("sign transaction: %v", err)
+	}
+	signature.Data.(*signing.SingleSignatureData).Signature = rawSignature
+	if err := builder.SetSignatures(signature); err != nil {
+		b.Fatalf("set final signature: %v", err)
+	}
+
+	txBytes, err := fixture.app.TxConfig().TxEncoder()(builder.GetTx())
+	if err != nil {
+		b.Fatalf("encode transaction: %v", err)
+	}
+	return txBytes
+}
+
+func blockSTMCosmosFeeBenchmarkEnvInt(
+	b *testing.B,
+	name string,
+	defaultValue int,
+	minimum int,
+	maximum int,
+) int {
+	b.Helper()
+
+	raw := os.Getenv(name)
+	if raw == "" {
+		return defaultValue
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < minimum || value > maximum {
+		b.Fatalf("%s must be an integer in [%d, %d], got %q", name, minimum, maximum, raw)
+	}
+	return value
+}
+
+func configureBlockSTMCosmosFeeBenchmarkPrefixes(b *testing.B) {
+	b.Helper()
+
+	config := sdk.GetConfig()
+	accountAddress := config.GetBech32AccountAddrPrefix()
+	accountPubKey := config.GetBech32AccountPubPrefix()
+	validatorAddress := config.GetBech32ValidatorAddrPrefix()
+	validatorPubKey := config.GetBech32ValidatorPubPrefix()
+	consensusAddress := config.GetBech32ConsensusAddrPrefix()
+	consensusPubKey := config.GetBech32ConsensusPubPrefix()
+
+	config.SetBech32PrefixForAccount(appparams.Bech32PrefixAccAddr, appparams.Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(appparams.Bech32PrefixValAddr, appparams.Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(appparams.Bech32PrefixConsAddr, appparams.Bech32PrefixConsPub)
+	b.Cleanup(func() {
+		config.SetBech32PrefixForAccount(accountAddress, accountPubKey)
+		config.SetBech32PrefixForValidator(validatorAddress, validatorPubKey)
+		config.SetBech32PrefixForConsensusNode(consensusAddress, consensusPubKey)
+	})
+}

--- a/app/blockstm_cosmos_virtual_fee_determinism_test.go
+++ b/app/blockstm_cosmos_virtual_fee_determinism_test.go
@@ -1,0 +1,489 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log/v2"
+	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	server "github.com/cosmos/cosmos-sdk/server"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	blockSTMCosmosVirtualFeeWorkerEnv = "GURU_BLOCKSTM_COSMOS_VIRTUAL_FEE_WORKER"
+	blockSTMCosmosVirtualFeeOutputEnv = "GURU_BLOCKSTM_COSMOS_VIRTUAL_FEE_OUTPUT"
+)
+
+type blockSTMCosmosVirtualFeeExecutor struct {
+	name        string
+	executor    string
+	workers     int
+	preEstimate bool
+}
+
+type blockSTMCosmosVirtualFeeOutcome struct {
+	finalize          *abci.ResponseFinalizeBlock
+	commitHash        []byte
+	balances          map[string]string
+	sequences         map[string]uint64
+	allowances        map[string]string
+	emptyFinalize     *abci.ResponseFinalizeBlock
+	emptyCommitHash   []byte
+	emptyBalances     map[string]string
+	emptySequences    map[string]uint64
+	emptyAllowances   map[string]string
+	collectorAfterTxs string
+	collectorAfterGap string
+}
+
+type blockSTMCosmosVirtualFeeProcessResult struct {
+	GenesisHash []byte                      `json:"genesis_hash"`
+	Txs         [][]byte                    `json:"txs"`
+	Finalize    *abci.ResponseFinalizeBlock `json:"finalize"`
+	CommitHash  []byte                      `json:"commit_hash"`
+	Balances    map[string]string           `json:"balances"`
+	Sequences   map[string]uint64           `json:"sequences"`
+	Allowances  map[string]string           `json:"allowances"`
+	Empty       *abci.ResponseFinalizeBlock `json:"empty_finalize"`
+	EmptyHash   []byte                      `json:"empty_commit_hash"`
+	EmptyFunds  map[string]string           `json:"empty_balances"`
+	EmptySeqs   map[string]uint64           `json:"empty_sequences"`
+	EmptyGrants map[string]string           `json:"empty_allowances"`
+}
+
+// TestBlockSTMCosmosVirtualFeeDeterminism is a differential consensus test. It
+// initializes independent applications from identical genesis state and feeds
+// each one the exact same ordered signed transaction bytes. Sequential execution
+// is the oracle; every supported BlockSTM worker/pre-estimation combination must
+// produce byte-for-byte equivalent transaction results and identical state roots.
+func TestBlockSTMCosmosVirtualFeeDeterminism(t *testing.T) {
+	executors := blockSTMCosmosVirtualFeeExecutors()
+	if rawIndex := os.Getenv(blockSTMCosmosVirtualFeeWorkerEnv); rawIndex != "" {
+		index, err := strconv.Atoi(rawIndex)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, index, 0)
+		require.Less(t, index, len(executors))
+		runBlockSTMCosmosVirtualFeeWorker(t, executors[index])
+		return
+	}
+
+	results := make([]blockSTMCosmosVirtualFeeProcessResult, len(executors))
+	outputDir := t.TempDir()
+	for index, executor := range executors {
+		outputPath := filepath.Join(outputDir, fmt.Sprintf("executor-%d.json", index))
+		cmd := exec.Command(os.Args[0], "-test.run=^"+t.Name()+"$", "-test.count=1")
+		cmd.Env = append(
+			os.Environ(),
+			blockSTMCosmosVirtualFeeWorkerEnv+"="+strconv.Itoa(index),
+			blockSTMCosmosVirtualFeeOutputEnv+"="+outputPath,
+		)
+		output, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "%s subprocess failed:\n%s", executor.name, output)
+		encoded, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(encoded, &results[index]))
+	}
+
+	reference := results[0]
+	require.NotEmpty(t, reference.GenesisHash)
+	for index := 1; index < len(results); index++ {
+		executor := executors[index]
+		candidate := results[index]
+		require.Equalf(t, reference.GenesisHash, candidate.GenesisHash, "%s genesis AppHash", executor.name)
+		require.Equalf(t, reference.Txs, candidate.Txs, "%s exact ordered signed transaction bytes", executor.name)
+		require.Equalf(t, reference.Finalize.TxResults, candidate.Finalize.TxResults, "%s transaction results (including gas and events)", executor.name)
+		require.Equalf(t, reference.Finalize.Events, candidate.Finalize.Events, "%s block events", executor.name)
+		require.Equalf(t, reference.Finalize.AppHash, candidate.Finalize.AppHash, "%s FinalizeBlock AppHash", executor.name)
+		require.Equalf(t, reference.CommitHash, candidate.CommitHash, "%s committed AppHash", executor.name)
+		require.Equalf(t, reference.Balances, candidate.Balances, "%s post-block balances", executor.name)
+		require.Equalf(t, reference.Allowances, candidate.Allowances, "%s post-block feegrant allowances", executor.name)
+		require.Equalf(t, reference.Sequences, candidate.Sequences, "%s post-block account sequences", executor.name)
+
+		require.Equalf(t, reference.Empty.TxResults, candidate.Empty.TxResults, "%s empty-block transaction results", executor.name)
+		require.Equalf(t, reference.Empty.Events, candidate.Empty.Events, "%s empty-block events", executor.name)
+		require.Equalf(t, reference.Empty.AppHash, candidate.Empty.AppHash, "%s empty-block FinalizeBlock AppHash", executor.name)
+		require.Equalf(t, reference.EmptyHash, candidate.EmptyHash, "%s empty-block committed AppHash", executor.name)
+		require.Equalf(t, reference.EmptyFunds, candidate.EmptyFunds, "%s post-empty-block balances", executor.name)
+		require.Equalf(t, reference.EmptyGrants, candidate.EmptyGrants, "%s post-empty-block feegrant allowances", executor.name)
+		require.Equalf(t, reference.EmptySeqs, candidate.EmptySeqs, "%s post-empty-block account sequences", executor.name)
+	}
+}
+
+func blockSTMCosmosVirtualFeeExecutors() []blockSTMCosmosVirtualFeeExecutor {
+	return []blockSTMCosmosVirtualFeeExecutor{
+		{name: "sequential", executor: serverconfig.BlockExecutorSequential},
+		{name: "block-stm/workers=1/pre-estimate=false", executor: serverconfig.BlockExecutorBlockSTM, workers: 1, preEstimate: false},
+		{name: "block-stm/workers=1/pre-estimate=true", executor: serverconfig.BlockExecutorBlockSTM, workers: 1, preEstimate: true},
+		{name: "block-stm/workers=4/pre-estimate=false", executor: serverconfig.BlockExecutorBlockSTM, workers: 4, preEstimate: false},
+		{name: "block-stm/workers=4/pre-estimate=true", executor: serverconfig.BlockExecutorBlockSTM, workers: 4, preEstimate: true},
+	}
+}
+
+func runBlockSTMCosmosVirtualFeeWorker(t *testing.T, executor blockSTMCosmosVirtualFeeExecutor) {
+	t.Helper()
+	genesisOptions := feePolicyRuntimeGenesisOptions{
+		noBaseFee:   true,
+		baseFee:     sdkmath.LegacyZeroDec(),
+		minGasPrice: sdkmath.LegacyOneDec(),
+	}
+	fixture := newBlockSTMCosmosVirtualFeeFixture(t, genesisOptions, executor)
+	genesisHash := append([]byte(nil), fixture.app.LastCommitID().Hash...)
+	require.NotEmpty(t, genesisHash)
+	txs := blockSTMCosmosVirtualFeeTransactions(t, fixture)
+	outcome := executeBlockSTMCosmosVirtualFeeScenario(t, fixture, txs)
+	requireBlockSTMCosmosVirtualFeeSemantics(t, fixture, outcome)
+
+	result := blockSTMCosmosVirtualFeeProcessResult{
+		GenesisHash: genesisHash,
+		Txs:         txs,
+		Finalize:    outcome.finalize,
+		CommitHash:  outcome.commitHash,
+		Balances:    outcome.balances,
+		Sequences:   outcome.sequences,
+		Allowances:  outcome.allowances,
+		Empty:       outcome.emptyFinalize,
+		EmptyHash:   outcome.emptyCommitHash,
+		EmptyFunds:  outcome.emptyBalances,
+		EmptySeqs:   outcome.emptySequences,
+		EmptyGrants: outcome.emptyAllowances,
+	}
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	outputPath := os.Getenv(blockSTMCosmosVirtualFeeOutputEnv)
+	require.NotEmpty(t, outputPath)
+	require.NoError(t, os.WriteFile(outputPath, encoded, 0o600))
+}
+
+func newBlockSTMCosmosVirtualFeeFixture(
+	t *testing.T,
+	genesisOptions feePolicyRuntimeGenesisOptions,
+	executor blockSTMCosmosVirtualFeeExecutor,
+) *feePolicyRuntimeFixture {
+	t.Helper()
+	configureFeePolicyTestBech32Prefixes(t, false)
+
+	appOptions := feePolicyTestAppOptions()
+	appOptions[server.FlagBlockExecutor] = executor.executor
+	appOptions[server.FlagBlockSTMWorkers] = executor.workers
+	appOptions[server.FlagBlockSTMPreEstimate] = executor.preEstimate
+	testApp := NewApp(
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		true,
+		appOptions,
+		baseapp.SetChainID(feePolicyRuntimeChainID),
+	)
+	t.Cleanup(func() { require.NoError(t, testApp.Close()) })
+
+	fixture := &feePolicyRuntimeFixture{
+		app:       testApp,
+		actors:    make(map[string]feePolicyRuntimeSigner, len(feePolicyRuntimeActorNames)),
+		nextBlock: 2,
+		startTime: time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC),
+	}
+	for accountNumber, name := range feePolicyRuntimeActorNames {
+		fixture.actors[name] = newFeePolicyRuntimeSigner(t, testApp, name, uint64(accountNumber))
+	}
+
+	genesis := testApp.BuildChainDefaultGenesis()
+	setFeePolicyRuntimeConstitutionGenesis(t, fixture, genesis)
+	setFeePolicyRuntimeAuthGenesis(t, fixture, genesis)
+	setFeePolicyRuntimeStakingGenesis(t, fixture, genesis)
+	setFeePolicyRuntimeBankGenesis(t, fixture, genesis)
+	setFeePolicyRuntimeFeeMarketGenesis(t, fixture, genesis)
+	setFeePolicyRuntimeMintGenesis(t, fixture, genesis)
+	setFeePolicyRuntimePolicyGenesis(t, fixture, genesis)
+	setFeePolicyRuntimeFeeGrantGenesis(t, fixture, genesis)
+	require.NoError(t, testApp.ValidateChainGenesis(genesis))
+
+	appState, err := json.Marshal(genesis)
+	require.NoError(t, err)
+	_, err = testApp.InitChain(&abci.RequestInitChain{
+		ChainId:         feePolicyRuntimeChainID,
+		InitialHeight:   1,
+		Time:            fixture.startTime,
+		AppStateBytes:   appState,
+		ConsensusParams: simtestutil.DefaultConsensusParams,
+	})
+	require.NoError(t, err)
+
+	initialBlock, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: 1,
+		Time:   fixture.startTime.Add(time.Second),
+	})
+	require.NoError(t, err)
+	require.Empty(t, initialBlock.TxResults)
+	_, err = testApp.Commit()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), testApp.LastBlockHeight())
+
+	if !genesisOptions.noBaseFee || !genesisOptions.baseFee.IsZero() ||
+		!genesisOptions.minGasPrice.Equal(sdkmath.LegacyOneDec()) {
+		panic("blockstm virtual-fee determinism fixture only supports canonical fee-market genesis")
+	}
+
+	return fixture
+}
+
+func blockSTMCosmosVirtualFeeTransactions(t *testing.T, fixture *feePolicyRuntimeFixture) [][]byte {
+	t.Helper()
+	recipient := fixture.actor(feePolicyActorRecipient)
+	normal := fixture.actor(feePolicyActorNormal)
+	grantPayer := fixture.actor(feePolicyActorGrantPayer)
+	grantGranter := fixture.actor(feePolicyActorGrantGranter)
+	messageFailurePayer := fixture.actor(feePolicyActorGrantMsgPayer)
+	messageFailureGranter := fixture.actor(feePolicyActorGrantMsgGranter)
+	signatureFailurePayer := fixture.actor(feePolicyActorGrantSigPayer)
+	signatureFailureGranter := fixture.actor(feePolicyActorGrantSigGranter)
+
+	return [][]byte{
+		fixture.signTx(t, normal, []sdk.Msg{
+			banktypes.NewMsgSend(normal.address, recipient.address, feePolicyRuntimeCoins(7)),
+		}, feePolicyRuntimeTxOptions{}),
+		fixture.signTx(t, grantPayer, []sdk.Msg{
+			banktypes.NewMsgSend(grantPayer.address, recipient.address, feePolicyRuntimeCoins(1)),
+		}, feePolicyRuntimeTxOptions{feeGranter: grantGranter.address}),
+		fixture.signTx(t, messageFailurePayer, []sdk.Msg{
+			banktypes.NewMsgSend(
+				messageFailurePayer.address,
+				recipient.address,
+				feePolicyRuntimeCoins(feePolicyRuntimeInitialFunds+1),
+			),
+		}, feePolicyRuntimeTxOptions{feeGranter: messageFailureGranter.address}),
+		fixture.signTx(t, signatureFailurePayer, []sdk.Msg{
+			banktypes.NewMsgSend(signatureFailurePayer.address, recipient.address, feePolicyRuntimeCoins(1)),
+		}, feePolicyRuntimeTxOptions{feeGranter: signatureFailureGranter.address, corruptSig: true}),
+	}
+}
+
+func executeBlockSTMCosmosVirtualFeeScenario(
+	t *testing.T,
+	fixture *feePolicyRuntimeFixture,
+	txs [][]byte,
+) blockSTMCosmosVirtualFeeOutcome {
+	t.Helper()
+
+	response, err := fixture.app.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: fixture.nextBlock,
+		Time:   fixture.startTime.Add(time.Duration(fixture.nextBlock) * time.Second),
+		Txs:    txs,
+	})
+	require.NoError(t, err)
+	require.Len(t, response.TxResults, len(txs))
+	_, err = fixture.app.Commit()
+	require.NoError(t, err)
+	fixture.nextBlock++
+
+	commitHash := append([]byte(nil), fixture.app.LastCommitID().Hash...)
+	require.Equal(t, response.AppHash, commitHash, "FinalizeBlock and Commit must expose the same state root")
+	balances, sequences, allowances := blockSTMCosmosVirtualFeeState(t, fixture)
+	collectorAfterTxs := fixture.collectorBalance().String()
+
+	emptyResponse, err := fixture.app.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: fixture.nextBlock,
+		Time:   fixture.startTime.Add(time.Duration(fixture.nextBlock) * time.Second),
+	})
+	require.NoError(t, err)
+	require.Empty(t, emptyResponse.TxResults)
+	_, err = fixture.app.Commit()
+	require.NoError(t, err)
+	fixture.nextBlock++
+
+	emptyCommitHash := append([]byte(nil), fixture.app.LastCommitID().Hash...)
+	require.Equal(t, emptyResponse.AppHash, emptyCommitHash, "empty FinalizeBlock and Commit must expose the same state root")
+	emptyBalances, emptySequences, emptyAllowances := blockSTMCosmosVirtualFeeState(t, fixture)
+	collectorAfterGap := fixture.collectorBalance().String()
+
+	return blockSTMCosmosVirtualFeeOutcome{
+		finalize:          response,
+		commitHash:        commitHash,
+		balances:          balances,
+		sequences:         sequences,
+		allowances:        allowances,
+		emptyFinalize:     emptyResponse,
+		emptyCommitHash:   emptyCommitHash,
+		emptyBalances:     emptyBalances,
+		emptySequences:    emptySequences,
+		emptyAllowances:   emptyAllowances,
+		collectorAfterTxs: collectorAfterTxs,
+		collectorAfterGap: collectorAfterGap,
+	}
+}
+
+func blockSTMCosmosVirtualFeeState(
+	t *testing.T,
+	fixture *feePolicyRuntimeFixture,
+) (map[string]string, map[string]uint64, map[string]string) {
+	t.Helper()
+
+	balances := make(map[string]string, len(feePolicyRuntimeActorNames)+1)
+	sequences := make(map[string]uint64, len(feePolicyRuntimeActorNames))
+	for _, name := range feePolicyRuntimeActorNames {
+		actor := fixture.actor(name)
+		balances[name] = fixture.balance(actor.address).String()
+		sequences[name] = fixture.sequence(actor.address)
+	}
+	balances[authtypes.FeeCollectorName] = fixture.collectorBalance().String()
+
+	allowances := map[string]string{
+		"successful": fixture.allowance(
+			t,
+			fixture.actor(feePolicyActorGrantGranter),
+			fixture.actor(feePolicyActorGrantPayer),
+		).String(),
+		"message-failure": fixture.allowance(
+			t,
+			fixture.actor(feePolicyActorGrantMsgGranter),
+			fixture.actor(feePolicyActorGrantMsgPayer),
+		).String(),
+		"signature-failure": fixture.allowance(
+			t,
+			fixture.actor(feePolicyActorGrantSigGranter),
+			fixture.actor(feePolicyActorGrantSigPayer),
+		).String(),
+	}
+	return balances, sequences, allowances
+}
+
+func requireBlockSTMCosmosVirtualFeeSemantics(
+	t *testing.T,
+	fixture *feePolicyRuntimeFixture,
+	outcome blockSTMCosmosVirtualFeeOutcome,
+) {
+	t.Helper()
+	require.Len(t, outcome.finalize.TxResults, 4)
+	require.Equal(t, abci.CodeTypeOK, outcome.finalize.TxResults[0].Code, outcome.finalize.TxResults[0].Log)
+	require.Equal(t, abci.CodeTypeOK, outcome.finalize.TxResults[1].Code, outcome.finalize.TxResults[1].Log)
+	require.NotEqual(t, abci.CodeTypeOK, outcome.finalize.TxResults[2].Code)
+	require.Contains(t, outcome.finalize.TxResults[2].Log, "insufficient funds")
+	require.NotEqual(t, abci.CodeTypeOK, outcome.finalize.TxResults[3].Code)
+	require.Contains(t, outcome.finalize.TxResults[3].Log, "signature verification failed")
+
+	normal := fixture.actor(feePolicyActorNormal)
+	grantGranter := fixture.actor(feePolicyActorGrantGranter)
+	messageFailureGranter := fixture.actor(feePolicyActorGrantMsgGranter)
+	signatureFailureGranter := fixture.actor(feePolicyActorGrantSigGranter)
+
+	fixture.requireFeeEvent(t, outcome.finalize.TxResults[0], 150_000, normal.addressString)
+	fixture.requireFeeEvent(t, outcome.finalize.TxResults[1], 150_000, grantGranter.addressString)
+	fixture.requireFeeEvent(t, outcome.finalize.TxResults[2], 150_000, messageFailureGranter.addressString)
+	fixture.requireNoFeeEvent(t, outcome.finalize.TxResults[3])
+
+	collectorAddress := fixture.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+	collectorAddressString, err := fixture.app.AccountKeeper.AddressCodec().BytesToString(collectorAddress)
+	require.NoError(t, err)
+	fee := feePolicyRuntimeCoins(150_000).String()
+	for index, payer := range []string{
+		normal.addressString,
+		grantGranter.addressString,
+		messageFailureGranter.addressString,
+	} {
+		result := outcome.finalize.TxResults[index]
+		requireABCIEvent(t, result.Events, banktypes.EventTypeCoinSpent, map[string]string{
+			banktypes.AttributeKeySpender: payer,
+			sdk.AttributeKeyAmount:        fee,
+		})
+		requireABCIEvent(t, result.Events, banktypes.EventTypeTransfer, map[string]string{
+			banktypes.AttributeKeyRecipient: collectorAddressString,
+			banktypes.AttributeKeySender:    payer,
+			sdk.AttributeKeyAmount:          fee,
+		})
+		requireABCIEvent(t, result.Events, sdk.EventTypeMessage, map[string]string{
+			sdk.AttributeKeySender: payer,
+		})
+		requireNoABCIEvent(t, result.Events, banktypes.EventTypeCoinReceived, map[string]string{
+			banktypes.AttributeKeyReceiver: collectorAddressString,
+		})
+	}
+	requireNoABCIEvent(t, outcome.finalize.TxResults[3].Events, banktypes.EventTypeCoinSpent, map[string]string{
+		banktypes.AttributeKeySpender: signatureFailureGranter.addressString,
+	})
+
+	totalFee := feePolicyRuntimeCoins(450_000).String()
+	requireABCIEvent(t, outcome.finalize.Events, banktypes.EventTypeCoinReceived, map[string]string{
+		banktypes.AttributeKeyReceiver: collectorAddressString,
+		sdk.AttributeKeyAmount:         totalFee,
+	})
+	requireNoABCIEvent(t, outcome.emptyFinalize.Events, banktypes.EventTypeCoinReceived, map[string]string{
+		banktypes.AttributeKeyReceiver: collectorAddressString,
+		sdk.AttributeKeyAmount:         totalFee,
+	})
+
+	require.Equal(t, sdkmath.NewInt(1_849_993).String(), outcome.balances[feePolicyActorNormal])
+	require.Equal(t, sdkmath.NewInt(1_999_999).String(), outcome.balances[feePolicyActorGrantPayer])
+	require.Equal(t, sdkmath.NewInt(1_850_000).String(), outcome.balances[feePolicyActorGrantGranter])
+	require.Equal(t, sdkmath.NewInt(feePolicyRuntimeInitialFunds).String(), outcome.balances[feePolicyActorGrantMsgPayer])
+	require.Equal(t, sdkmath.NewInt(1_850_000).String(), outcome.balances[feePolicyActorGrantMsgGranter])
+	require.Equal(t, sdkmath.NewInt(feePolicyRuntimeInitialFunds).String(), outcome.balances[feePolicyActorGrantSigPayer])
+	require.Equal(t, sdkmath.NewInt(feePolicyRuntimeInitialFunds).String(), outcome.balances[feePolicyActorGrantSigGranter])
+	require.Equal(t, sdkmath.NewInt(8).String(), outcome.balances[feePolicyActorRecipient])
+	require.Equal(t, sdkmath.NewInt(450_000).String(), outcome.balances[authtypes.FeeCollectorName])
+
+	require.Equal(t, uint64(1), outcome.sequences[feePolicyActorNormal])
+	require.Equal(t, uint64(1), outcome.sequences[feePolicyActorGrantPayer])
+	require.Equal(t, uint64(1), outcome.sequences[feePolicyActorGrantMsgPayer])
+	require.Equal(t, uint64(0), outcome.sequences[feePolicyActorGrantSigPayer])
+	require.Equal(t, "250000", outcome.allowances["successful"])
+	require.Equal(t, "250000", outcome.allowances["message-failure"])
+	require.Equal(t, "400000", outcome.allowances["signature-failure"])
+
+	for _, name := range feePolicyRuntimeActorNames {
+		require.Equalf(t, outcome.balances[name], outcome.emptyBalances[name], "empty block actor balance %s", name)
+	}
+	require.Equal(t, outcome.sequences, outcome.emptySequences, "the empty block must not change actor sequences")
+	require.Equal(t, outcome.allowances, outcome.emptyAllowances, "the empty block must not consume feegrant twice")
+	require.Equal(t, sdkmath.NewInt(450_000).String(), outcome.collectorAfterTxs)
+	require.Equal(t, "0", outcome.collectorAfterGap, "distribution must drain the prior block's settled fees before bank EndBlock; stale virtual entries would re-credit them")
+	require.Equal(t, sdkmath.NewInt(8).String(), outcome.emptyBalances[feePolicyActorRecipient])
+}
+
+func requireABCIEvent(t *testing.T, events []abci.Event, eventType string, attributes map[string]string) {
+	t.Helper()
+	require.Truef(t, hasABCIEvent(events, eventType, attributes), "missing %s event with attributes %v in %v", eventType, attributes, events)
+}
+
+func requireNoABCIEvent(t *testing.T, events []abci.Event, eventType string, attributes map[string]string) {
+	t.Helper()
+	require.Falsef(t, hasABCIEvent(events, eventType, attributes), "unexpected %s event with attributes %v in %v", eventType, attributes, events)
+}
+
+func hasABCIEvent(events []abci.Event, eventType string, attributes map[string]string) bool {
+	for _, event := range events {
+		if event.Type != eventType {
+			continue
+		}
+		matched := true
+		for key, expected := range attributes {
+			found := false
+			for _, attribute := range event.Attributes {
+				if attribute.Key == key && attribute.Value == expected {
+					found = true
+					break
+				}
+			}
+			if !found {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/app/blockstm_cosmos_virtual_fee_visibility_test.go
+++ b/app/blockstm_cosmos_virtual_fee_visibility_test.go
@@ -1,0 +1,248 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	appparams "github.com/gurufinglobal/guru/v3/app/params"
+	"github.com/stretchr/testify/require"
+)
+
+const blockSTMCosmosVirtualFeeVisibilityWorkerEnv = "GURU_BLOCKSTM_COSMOS_VIRTUAL_FEE_VISIBILITY_WORKER"
+
+// TestBlockSTMCosmosVirtualFeeVisibility documents the consensus-visible semantic
+// boundary introduced by virtual fee collection:
+//
+//   - ante deducts the payer's real balance immediately, but credits the fee
+//     collector's real balance only from x/bank EndBlock;
+//   - coin_spent/transfer remain transaction events, while the matching
+//     coin_received is an aggregated block event;
+//   - a later ante failure discards both the real debit and virtual credit; and
+//   - the per-block virtual accumulator cannot credit the next block again.
+func TestBlockSTMCosmosVirtualFeeVisibility(t *testing.T) {
+	if !runFeePolicyRuntimeWorker(t, blockSTMCosmosVirtualFeeVisibilityWorkerEnv) {
+		return
+	}
+
+	fixture := newFeePolicyRuntimeFixture(t, feePolicyRuntimeGenesisOptions{
+		noBaseFee:   true,
+		baseFee:     sdkmath.LegacyZeroDec(),
+		minGasPrice: sdkmath.LegacyOneDec(),
+	})
+	collector := fixture.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+	collectorString := collector.String()
+	expectedFee := feePolicyRuntimeCoins(150_000)
+	recipient := fixture.actor(feePolicyActorRecipient)
+
+	t.Run("late ante failure rolls back real and virtual fee state", func(t *testing.T) {
+		payer := fixture.actor(feePolicyActorGrantSigPayer)
+		granter := fixture.actor(feePolicyActorGrantSigGranter)
+		beforePayer := fixture.balance(payer.address)
+		beforeGranter := fixture.balance(granter.address)
+		beforeCollector := fixture.collectorBalance()
+		beforeAllowance := fixture.allowance(t, granter, payer)
+
+		msg := banktypes.NewMsgSend(payer.address, recipient.address, feePolicyRuntimeCoins(1))
+		response := finalizeBlockSTMCosmosVirtualFeeVisibility(t, fixture, fixture.signTx(
+			t,
+			payer,
+			[]sdk.Msg{msg},
+			feePolicyRuntimeTxOptions{feeGranter: granter.address, corruptSig: true},
+		))
+
+		require.Len(t, response.TxResults, 1)
+		require.NotEqual(t, abci.CodeTypeOK, response.TxResults[0].Code)
+		requireIntEqual(t, beforePayer, fixture.balance(payer.address))
+		requireIntEqual(t, beforeGranter, fixture.balance(granter.address))
+		requireIntEqual(t, beforeCollector, fixture.collectorBalance())
+		requireIntEqual(t, beforeAllowance, fixture.allowance(t, granter, payer))
+		require.Equal(t, uint64(0), fixture.sequence(payer.address))
+		require.False(t, blockSTMCosmosVirtualFeeHasEvent(
+			response.Events,
+			banktypes.EventTypeCoinReceived,
+			map[string]string{
+				banktypes.AttributeKeyReceiver: collectorString,
+				sdk.AttributeKeyAmount:         expectedFee.String(),
+			},
+		))
+	})
+
+	t.Run("fee receiver becomes real only in end block and only once", func(t *testing.T) {
+		payer := fixture.actor(feePolicyActorNormal)
+		beforePayer := fixture.balance(payer.address)
+		beforeCollector := fixture.collectorBalance()
+
+		msg := banktypes.NewMsgSend(payer.address, recipient.address, feePolicyRuntimeCoins(7))
+		response := finalizeBlockSTMCosmosVirtualFeeVisibility(
+			t,
+			fixture,
+			fixture.signTx(t, payer, []sdk.Msg{msg}, feePolicyRuntimeTxOptions{}),
+		)
+
+		require.Len(t, response.TxResults, 1)
+		require.Equal(t, abci.CodeTypeOK, response.TxResults[0].Code, response.TxResults[0].Log)
+		requireIntEqual(t, beforePayer.SubRaw(150_007), fixture.balance(payer.address))
+		requireIntEqual(t, beforeCollector.AddRaw(150_000), fixture.collectorBalance())
+
+		// The fee collector has not received real coins while this transaction's
+		// result is assembled. MsgSend's unrelated recipient coin_received event
+		// may still be present, so match the receiver and amount exactly.
+		require.False(t, blockSTMCosmosVirtualFeeHasEvent(
+			response.TxResults[0].Events,
+			banktypes.EventTypeCoinReceived,
+			map[string]string{
+				banktypes.AttributeKeyReceiver: collectorString,
+				sdk.AttributeKeyAmount:         expectedFee.String(),
+			},
+		))
+		require.True(t, blockSTMCosmosVirtualFeeHasEvent(
+			response.Events,
+			banktypes.EventTypeCoinReceived,
+			map[string]string{
+				banktypes.AttributeKeyReceiver: collectorString,
+				sdk.AttributeKeyAmount:         expectedFee.String(),
+			},
+		), "fee collector credit must be emitted by x/bank EndBlock")
+
+		afterFirstCredit := fixture.collectorBalance()
+		requireIntEqual(t, sdkmath.NewInt(150_000), afterFirstCredit)
+		emptyResponse := finalizeBlockSTMCosmosVirtualFeeVisibility(t, fixture)
+		require.Empty(t, emptyResponse.TxResults)
+		// x/constitution consumes the preceding block's collector balance in
+		// BeginBlock. A stale virtual object entry would then credit 150_000 back
+		// in bank EndBlock, so an exact zero proves that entry did not survive the
+		// block boundary.
+		requireIntEqual(t, sdkmath.ZeroInt(), fixture.collectorBalance())
+		require.False(t, blockSTMCosmosVirtualFeeHasEvent(
+			emptyResponse.Events,
+			banktypes.EventTypeCoinReceived,
+			map[string]string{
+				banktypes.AttributeKeyReceiver: collectorString,
+				sdk.AttributeKeyAmount:         expectedFee.String(),
+			},
+		), "the previous block's virtual accumulator must not be replayed")
+	})
+
+	t.Run("ante exposes the real debit before the end block credit", func(t *testing.T) {
+		payer := fixture.actor(feePolicyActorSelfGranter)
+		beforePayer := fixture.balance(payer.address)
+		beforeCollector := fixture.collectorBalance()
+		msg := banktypes.NewMsgSend(payer.address, recipient.address, feePolicyRuntimeCoins(1))
+		txBytes := fixture.signTx(t, payer, []sdk.Msg{msg}, feePolicyRuntimeTxOptions{})
+		tx, err := fixture.app.TxConfig().TxDecoder()(txBytes)
+		require.NoError(t, err)
+
+		ctx := fixture.app.NewNextBlockContext(cmtproto.Header{
+			ChainID: feePolicyRuntimeChainID,
+			Height:  fixture.nextBlock,
+			Time:    fixture.startTime.Add(time.Duration(fixture.nextBlock) * time.Second),
+		}).WithTxIndex(0)
+		anteCtx, _ := ctx.CacheContext()
+		anteCtx, err = fixture.app.AnteHandler()(anteCtx, tx, false)
+		require.NoError(t, err)
+
+		requireIntEqual(t, beforePayer.SubRaw(150_000), fixture.app.BankKeeper.GetBalance(
+			anteCtx,
+			payer.address,
+			appparams.BaseDenom,
+		).Amount)
+		requireIntEqual(t, beforeCollector, fixture.app.BankKeeper.GetBalance(
+			anteCtx,
+			collector,
+			appparams.BaseDenom,
+		).Amount)
+		anteEvents := anteCtx.EventManager().ABCIEvents()
+		require.True(t, blockSTMCosmosVirtualFeeHasEvent(
+			anteEvents,
+			banktypes.EventTypeCoinSpent,
+			map[string]string{
+				banktypes.AttributeKeySpender: payer.address.String(),
+				sdk.AttributeKeyAmount:        expectedFee.String(),
+			},
+		))
+		require.True(t, blockSTMCosmosVirtualFeeHasEvent(
+			anteEvents,
+			banktypes.EventTypeTransfer,
+			map[string]string{
+				banktypes.AttributeKeyRecipient: collectorString,
+				banktypes.AttributeKeySender:    payer.address.String(),
+				sdk.AttributeKeyAmount:          expectedFee.String(),
+			},
+		))
+		require.False(t, blockSTMCosmosVirtualFeeHasEvent(
+			anteEvents,
+			banktypes.EventTypeCoinReceived,
+			map[string]string{banktypes.AttributeKeyReceiver: collectorString},
+		))
+
+		endBlockCtx := anteCtx.WithEventManager(sdk.NewEventManager())
+		require.NoError(t, fixture.app.BankKeeper.CreditVirtualAccounts(endBlockCtx))
+		requireIntEqual(t, beforeCollector.AddRaw(150_000), fixture.app.BankKeeper.GetBalance(
+			endBlockCtx,
+			collector,
+			appparams.BaseDenom,
+		).Amount)
+		require.True(t, blockSTMCosmosVirtualFeeHasEvent(
+			endBlockCtx.EventManager().ABCIEvents(),
+			banktypes.EventTypeCoinReceived,
+			map[string]string{
+				banktypes.AttributeKeyReceiver: collectorString,
+				sdk.AttributeKeyAmount:         expectedFee.String(),
+			},
+		))
+	})
+}
+
+func finalizeBlockSTMCosmosVirtualFeeVisibility(
+	t *testing.T,
+	fixture *feePolicyRuntimeFixture,
+	txs ...[]byte,
+) *abci.ResponseFinalizeBlock {
+	t.Helper()
+
+	response, err := fixture.app.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: fixture.nextBlock,
+		Time:   fixture.startTime.Add(time.Duration(fixture.nextBlock) * time.Second),
+		Txs:    txs,
+	})
+	require.NoError(t, err)
+	_, err = fixture.app.Commit()
+	require.NoError(t, err)
+	fixture.nextBlock++
+	return response
+}
+
+func blockSTMCosmosVirtualFeeHasEvent(
+	events []abci.Event,
+	eventType string,
+	expectedAttributes map[string]string,
+) bool {
+	for _, event := range events {
+		if event.Type != eventType {
+			continue
+		}
+
+		attributes := make(map[string]string, len(event.Attributes))
+		for _, attribute := range event.Attributes {
+			attributes[attribute.Key] = attribute.Value
+		}
+		matches := true
+		for key, expectedValue := range expectedAttributes {
+			if attributes[key] != expectedValue {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+
+	return false
+}

--- a/app/blockstm_mixed_cosmos_evm_determinism_test.go
+++ b/app/blockstm_mixed_cosmos_evm_determinism_test.go
@@ -1,0 +1,582 @@
+package app
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log/v2"
+	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	server "github.com/cosmos/cosmos-sdk/server"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/evm/crypto/ethsecp256k1"
+	srvflags "github.com/cosmos/evm/server/flags"
+	evmtesttx "github.com/cosmos/evm/testutil/tx"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	appparams "github.com/gurufinglobal/guru/v3/app/params"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	blockSTMMixedCosmosEVMWorkerEnv = "GURU_BLOCKSTM_MIXED_COSMOS_EVM_WORKER"
+	blockSTMMixedCosmosEVMOutputEnv = "GURU_BLOCKSTM_MIXED_COSMOS_EVM_OUTPUT"
+
+	blockSTMMixedEVMInitialFunds = int64(2_000_000)
+	blockSTMMixedEVMTransfer     = int64(17)
+	blockSTMMixedEVMRevertValue  = int64(11)
+
+	blockSTMMixedEVMDeployGas   = uint64(150_000)
+	blockSTMMixedEVMLogGas      = uint64(100_000)
+	blockSTMMixedEVMRevertGas   = uint64(100_000)
+	blockSTMMixedEVMTransferGas = uint64(21_000)
+)
+
+var (
+	// Empty calldata emits two LOG0 records and succeeds; non-empty calldata
+	// reverts. This keeps both log-index patching and refund/rollback behavior in
+	// one same-block contract dependency chain.
+	blockSTMMixedReverterInitCode = mustBlockSTMMixedHex("6016600c60003960166000f33615600a5760006000fd5b60006000a060006000a000")
+	blockSTMMixedReverterRuntime  = mustBlockSTMMixedHex("3615600a5760006000fd5b60006000a060006000a000")
+)
+
+type blockSTMMixedCosmosEVMFixture struct {
+	*feePolicyRuntimeFixture
+	evmPrivateKey *ethsecp256k1.PrivKey
+	evmAddress    sdk.AccAddress
+	ethAddress    common.Address
+	contract      common.Address
+	evmTxHashes   []string
+}
+
+type blockSTMMixedCosmosEVMState struct {
+	EVMSenderBalance      string `json:"evm_sender_balance"`
+	RecipientBalance      string `json:"recipient_balance"`
+	CollectorBalance      string `json:"collector_balance"`
+	EVMSenderNonce        uint64 `json:"evm_sender_nonce"`
+	ContractBalance       string `json:"contract_balance"`
+	ContractCode          string `json:"contract_code"`
+	CosmosNormalBalance   string `json:"cosmos_normal_balance"`
+	CosmosFailedBalance   string `json:"cosmos_failed_balance"`
+	CosmosGranterBalance  string `json:"cosmos_granter_balance"`
+	CosmosFailedAllowance string `json:"cosmos_failed_allowance"`
+}
+
+type blockSTMMixedCosmosEVMProcessResult struct {
+	GenesisHash []byte                      `json:"genesis_hash"`
+	Txs         [][]byte                    `json:"txs"`
+	Finalize    *abci.ResponseFinalizeBlock `json:"finalize"`
+	CommitHash  []byte                      `json:"commit_hash"`
+	State       blockSTMMixedCosmosEVMState `json:"state"`
+	Empty       *abci.ResponseFinalizeBlock `json:"empty_finalize"`
+	EmptyHash   []byte                      `json:"empty_commit_hash"`
+	EmptyState  blockSTMMixedCosmosEVMState `json:"empty_state"`
+}
+
+// TestBlockSTMMixedCosmosEVMTxDeterminism feeds the same ordered, signed Cosmos
+// and Ethereum transaction bytes to independent sequential and BlockSTM apps.
+// It covers both virtual-fee paths sharing one fee collector, EVM log-index
+// patching, unused-gas refunds, an EVM revert, and same-sender/same-block EVM
+// nonce dependencies.
+func TestBlockSTMMixedCosmosEVMTxDeterminism(t *testing.T) {
+	executors := blockSTMCosmosVirtualFeeExecutors()
+	if rawIndex := os.Getenv(blockSTMMixedCosmosEVMWorkerEnv); rawIndex != "" {
+		index, err := strconv.Atoi(rawIndex)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, index, 0)
+		require.Less(t, index, len(executors))
+		runBlockSTMMixedCosmosEVMWorker(t, executors[index])
+		return
+	}
+
+	results := make([]blockSTMMixedCosmosEVMProcessResult, len(executors))
+	outputDir := t.TempDir()
+	for index, executor := range executors {
+		outputPath := filepath.Join(outputDir, fmt.Sprintf("executor-%d.json", index))
+		cmd := exec.Command(os.Args[0], "-test.run=^"+t.Name()+"$", "-test.count=1")
+		cmd.Env = append(
+			os.Environ(),
+			blockSTMMixedCosmosEVMWorkerEnv+"="+strconv.Itoa(index),
+			blockSTMMixedCosmosEVMOutputEnv+"="+outputPath,
+		)
+		output, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "%s subprocess failed:\n%s", executor.name, output)
+		encoded, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(encoded, &results[index]))
+	}
+
+	reference := results[0]
+	require.NotEmpty(t, reference.GenesisHash)
+	for index := 1; index < len(results); index++ {
+		executor := executors[index]
+		candidate := results[index]
+		require.Equalf(t, reference.GenesisHash, candidate.GenesisHash, "%s genesis AppHash", executor.name)
+		require.Equalf(t, reference.Txs, candidate.Txs, "%s exact ordered signed transaction bytes", executor.name)
+		require.Equalf(t, reference.Finalize, candidate.Finalize, "%s complete FinalizeBlock response (including tx results, EVM response patching, events, validator updates, consensus updates, and AppHash)", executor.name)
+		require.Equalf(t, reference.CommitHash, candidate.CommitHash, "%s committed AppHash", executor.name)
+		require.Equalf(t, reference.State, candidate.State, "%s post-block mixed Cosmos/EVM state", executor.name)
+
+		require.Equalf(t, reference.Empty, candidate.Empty, "%s complete empty FinalizeBlock response", executor.name)
+		require.Equalf(t, reference.EmptyHash, candidate.EmptyHash, "%s empty-block committed AppHash", executor.name)
+		require.Equalf(t, reference.EmptyState, candidate.EmptyState, "%s post-empty-block mixed Cosmos/EVM state", executor.name)
+	}
+}
+
+func runBlockSTMMixedCosmosEVMWorker(t *testing.T, executor blockSTMCosmosVirtualFeeExecutor) {
+	t.Helper()
+	fixture := newBlockSTMMixedCosmosEVMFixture(t, executor)
+	genesisHash := append([]byte(nil), fixture.app.LastCommitID().Hash...)
+	require.NotEmpty(t, genesisHash)
+
+	txs := blockSTMMixedCosmosEVMTransactions(t, fixture)
+	response, err := fixture.app.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: fixture.nextBlock,
+		Time:   fixture.startTime.Add(time.Duration(fixture.nextBlock) * time.Second),
+		Txs:    txs,
+	})
+	require.NoError(t, err)
+	require.Len(t, response.TxResults, len(txs))
+	_, err = fixture.app.Commit()
+	require.NoError(t, err)
+	fixture.nextBlock++
+	commitHash := append([]byte(nil), fixture.app.LastCommitID().Hash...)
+	require.Equal(t, response.AppHash, commitHash)
+	state := blockSTMMixedCosmosEVMCommittedState(t, fixture)
+	requireBlockSTMMixedCosmosEVMSemantics(t, fixture, response, state)
+
+	emptyResponse, err := fixture.app.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: fixture.nextBlock,
+		Time:   fixture.startTime.Add(time.Duration(fixture.nextBlock) * time.Second),
+	})
+	require.NoError(t, err)
+	require.Empty(t, emptyResponse.TxResults)
+	_, err = fixture.app.Commit()
+	require.NoError(t, err)
+	fixture.nextBlock++
+	emptyCommitHash := append([]byte(nil), fixture.app.LastCommitID().Hash...)
+	require.Equal(t, emptyResponse.AppHash, emptyCommitHash)
+	emptyState := blockSTMMixedCosmosEVMCommittedState(t, fixture)
+	requireBlockSTMMixedCosmosEVMEmptyBlockSemantics(t, state, emptyState)
+
+	result := blockSTMMixedCosmosEVMProcessResult{
+		GenesisHash: genesisHash,
+		Txs:         txs,
+		Finalize:    response,
+		CommitHash:  commitHash,
+		State:       state,
+		Empty:       emptyResponse,
+		EmptyHash:   emptyCommitHash,
+		EmptyState:  emptyState,
+	}
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	outputPath := os.Getenv(blockSTMMixedCosmosEVMOutputEnv)
+	require.NotEmpty(t, outputPath)
+	require.NoError(t, os.WriteFile(outputPath, encoded, 0o600))
+}
+
+func newBlockSTMMixedCosmosEVMFixture(
+	t *testing.T,
+	executor blockSTMCosmosVirtualFeeExecutor,
+) *blockSTMMixedCosmosEVMFixture {
+	t.Helper()
+	configureFeePolicyTestBech32Prefixes(t, false)
+
+	appOptions := feePolicyTestAppOptions()
+	appOptions[srvflags.EVMChainID] = appparams.EVMChainID
+	appOptions[server.FlagBlockExecutor] = executor.executor
+	appOptions[server.FlagBlockSTMWorkers] = executor.workers
+	appOptions[server.FlagBlockSTMPreEstimate] = executor.preEstimate
+	testApp := NewApp(
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		true,
+		appOptions,
+		baseapp.SetChainID(feePolicyRuntimeChainID),
+	)
+	t.Cleanup(func() { require.NoError(t, testApp.Close()) })
+
+	baseFixture := &feePolicyRuntimeFixture{
+		app:       testApp,
+		actors:    make(map[string]feePolicyRuntimeSigner, len(feePolicyRuntimeActorNames)),
+		nextBlock: 2,
+		startTime: time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC),
+	}
+	for accountNumber, name := range feePolicyRuntimeActorNames {
+		baseFixture.actors[name] = newFeePolicyRuntimeSigner(t, testApp, name, uint64(accountNumber))
+	}
+
+	privateKeyBytes := make([]byte, ethsecp256k1.PrivKeySize)
+	privateKeyBytes[len(privateKeyBytes)-1] = 1
+	evmPrivateKey := &ethsecp256k1.PrivKey{Key: privateKeyBytes}
+	ethAddress := common.BytesToAddress(evmPrivateKey.PubKey().Address().Bytes())
+	evmAddress := sdk.AccAddress(ethAddress.Bytes())
+	fixture := &blockSTMMixedCosmosEVMFixture{
+		feePolicyRuntimeFixture: baseFixture,
+		evmPrivateKey:           evmPrivateKey,
+		evmAddress:              evmAddress,
+		ethAddress:              ethAddress,
+		contract:                crypto.CreateAddress(ethAddress, 0),
+		evmTxHashes:             make([]string, 0, 5),
+	}
+
+	genesis := testApp.BuildChainDefaultGenesis()
+	setFeePolicyRuntimeConstitutionGenesis(t, baseFixture, genesis)
+	setFeePolicyRuntimeAuthGenesis(t, baseFixture, genesis)
+	setFeePolicyRuntimeStakingGenesis(t, baseFixture, genesis)
+	setFeePolicyRuntimeBankGenesis(t, baseFixture, genesis)
+	setFeePolicyRuntimeFeeMarketGenesis(t, baseFixture, genesis)
+	setFeePolicyRuntimeMintGenesis(t, baseFixture, genesis)
+	setFeePolicyRuntimePolicyGenesis(t, baseFixture, genesis)
+	setFeePolicyRuntimeFeeGrantGenesis(t, baseFixture, genesis)
+	addBlockSTMMixedEVMGenesisAccount(t, fixture, genesis)
+	require.NoError(t, testApp.ValidateChainGenesis(genesis))
+
+	appState, err := json.Marshal(genesis)
+	require.NoError(t, err)
+	_, err = testApp.InitChain(&abci.RequestInitChain{
+		ChainId:         feePolicyRuntimeChainID,
+		InitialHeight:   1,
+		Time:            fixture.startTime,
+		AppStateBytes:   appState,
+		ConsensusParams: simtestutil.DefaultConsensusParams,
+	})
+	require.NoError(t, err)
+	initialBlock, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: 1,
+		Time:   fixture.startTime.Add(time.Second),
+	})
+	require.NoError(t, err)
+	require.Empty(t, initialBlock.TxResults)
+	_, err = testApp.Commit()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), testApp.LastBlockHeight())
+	require.Equal(t, sdkmath.NewInt(blockSTMMixedEVMInitialFunds), fixture.balance(evmAddress))
+	return fixture
+}
+
+func addBlockSTMMixedEVMGenesisAccount(
+	t *testing.T,
+	fixture *blockSTMMixedCosmosEVMFixture,
+	genesis map[string]json.RawMessage,
+) {
+	t.Helper()
+
+	authGenesis := authtypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[authtypes.ModuleName], authGenesis)
+	accounts, err := authtypes.UnpackAccounts(authGenesis.Accounts)
+	require.NoError(t, err)
+	accounts = append(accounts, authtypes.NewBaseAccount(
+		fixture.evmAddress,
+		fixture.evmPrivateKey.PubKey(),
+		uint64(len(feePolicyRuntimeActorNames)),
+		0,
+	))
+	authGenesis = authtypes.NewGenesisState(authGenesis.Params, accounts)
+	genesis[authtypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(authGenesis)
+
+	bankGenesis := banktypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[banktypes.ModuleName], bankGenesis)
+	evmAddressString, err := fixture.app.AccountKeeper.AddressCodec().BytesToString(fixture.evmAddress)
+	require.NoError(t, err)
+	bankGenesis.Balances = append(bankGenesis.Balances, banktypes.Balance{
+		Address: evmAddressString,
+		Coins:   feePolicyRuntimeCoins(blockSTMMixedEVMInitialFunds),
+	})
+	bankGenesis.Supply = nil
+	genesis[banktypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(bankGenesis)
+}
+
+func blockSTMMixedCosmosEVMTransactions(
+	t *testing.T,
+	fixture *blockSTMMixedCosmosEVMFixture,
+) [][]byte {
+	t.Helper()
+	normal := fixture.actor(feePolicyActorNormal)
+	recipient := fixture.actor(feePolicyActorRecipient)
+	messageFailurePayer := fixture.actor(feePolicyActorGrantMsgPayer)
+	messageFailureGranter := fixture.actor(feePolicyActorGrantMsgGranter)
+
+	return [][]byte{
+		fixture.signTx(t, normal, []sdk.Msg{
+			banktypes.NewMsgSend(normal.address, recipient.address, feePolicyRuntimeCoins(7)),
+		}, feePolicyRuntimeTxOptions{}),
+		fixture.signEVMTransaction(t, 0, nil, 0, blockSTMMixedEVMDeployGas, blockSTMMixedReverterInitCode),
+		fixture.signEVMTransaction(t, 1, &fixture.contract, 0, blockSTMMixedEVMLogGas, nil),
+		fixture.signTx(t, messageFailurePayer, []sdk.Msg{
+			banktypes.NewMsgSend(
+				messageFailurePayer.address,
+				recipient.address,
+				feePolicyRuntimeCoins(feePolicyRuntimeInitialFunds+1),
+			),
+		}, feePolicyRuntimeTxOptions{feeGranter: messageFailureGranter.address}),
+		fixture.signEVMTransaction(t, 2, &fixture.contract, 0, blockSTMMixedEVMLogGas, nil),
+		fixture.signEVMTransaction(t, 3, &fixture.contract, blockSTMMixedEVMRevertValue, blockSTMMixedEVMRevertGas, []byte{0x01}),
+		fixture.signEVMTransaction(
+			t,
+			4,
+			blockSTMMixedCommonAddress(recipient.address),
+			blockSTMMixedEVMTransfer,
+			blockSTMMixedEVMTransferGas,
+			nil,
+		),
+	}
+}
+
+func (fixture *blockSTMMixedCosmosEVMFixture) signEVMTransaction(
+	t *testing.T,
+	nonce uint64,
+	to *common.Address,
+	amount int64,
+	gasLimit uint64,
+	input []byte,
+) []byte {
+	t.Helper()
+
+	msg := evmtypes.NewTx(&evmtypes.EvmTxArgs{
+		ChainID:  new(big.Int).SetUint64(appparams.EVMChainID),
+		Nonce:    nonce,
+		To:       to,
+		Amount:   big.NewInt(amount),
+		GasLimit: gasLimit,
+		GasPrice: big.NewInt(1),
+		Input:    append([]byte(nil), input...),
+	})
+	msg.From = fixture.ethAddress.Bytes()
+	signer := gethtypes.LatestSignerForChainID(new(big.Int).SetUint64(appparams.EVMChainID))
+	require.NoError(t, msg.Sign(signer, evmtesttx.NewSigner(fixture.evmPrivateKey)))
+	require.NoError(t, msg.ValidateBasic())
+
+	tx, err := msg.BuildTxWithEvmParams(fixture.app.TxConfig().NewTxBuilder(), evmtypes.Params{
+		EvmDenom: appparams.BaseDenom,
+		ExtendedDenomOptions: &evmtypes.ExtendedDenomOptions{
+			ExtendedDenom: appparams.BaseDenom,
+		},
+	})
+	require.NoError(t, err)
+	txBytes, err := fixture.app.TxConfig().TxEncoder()(tx)
+	require.NoError(t, err)
+	fixture.evmTxHashes = append(fixture.evmTxHashes, msg.Hash().Hex())
+	return txBytes
+}
+
+func blockSTMMixedCosmosEVMCommittedState(
+	t *testing.T,
+	fixture *blockSTMMixedCosmosEVMFixture,
+) blockSTMMixedCosmosEVMState {
+	t.Helper()
+	ctx := fixture.committedContext()
+	codeHash := fixture.app.EVMKeeper.GetCodeHash(ctx, fixture.contract)
+	normal := fixture.actor(feePolicyActorNormal)
+	messageFailurePayer := fixture.actor(feePolicyActorGrantMsgPayer)
+	messageFailureGranter := fixture.actor(feePolicyActorGrantMsgGranter)
+	return blockSTMMixedCosmosEVMState{
+		EVMSenderBalance:      fixture.balance(fixture.evmAddress).String(),
+		RecipientBalance:      fixture.balance(fixture.actor(feePolicyActorRecipient).address).String(),
+		CollectorBalance:      fixture.collectorBalance().String(),
+		EVMSenderNonce:        fixture.app.EVMKeeper.GetNonce(ctx, fixture.ethAddress),
+		ContractBalance:       fixture.app.EVMKeeper.GetBalance(ctx, fixture.contract).String(),
+		ContractCode:          hex.EncodeToString(fixture.app.EVMKeeper.GetCode(ctx, codeHash)),
+		CosmosNormalBalance:   fixture.balance(normal.address).String(),
+		CosmosFailedBalance:   fixture.balance(messageFailurePayer.address).String(),
+		CosmosGranterBalance:  fixture.balance(messageFailureGranter.address).String(),
+		CosmosFailedAllowance: fixture.allowance(t, messageFailureGranter, messageFailurePayer).String(),
+	}
+}
+
+func requireBlockSTMMixedCosmosEVMSemantics(
+	t *testing.T,
+	fixture *blockSTMMixedCosmosEVMFixture,
+	response *abci.ResponseFinalizeBlock,
+	state blockSTMMixedCosmosEVMState,
+) {
+	t.Helper()
+	require.Len(t, response.TxResults, 7)
+	require.Equal(t, abci.CodeTypeOK, response.TxResults[0].Code, response.TxResults[0].Log)
+	require.Equal(t, abci.CodeTypeOK, response.TxResults[1].Code, response.TxResults[1].Log)
+	require.Equal(t, abci.CodeTypeOK, response.TxResults[2].Code, response.TxResults[2].Log)
+	require.NotEqual(t, abci.CodeTypeOK, response.TxResults[3].Code)
+	require.Contains(t, response.TxResults[3].Log, "insufficient funds")
+	require.Equal(t, abci.CodeTypeOK, response.TxResults[4].Code, response.TxResults[4].Log)
+	require.Equal(t, abci.CodeTypeOK, response.TxResults[5].Code, response.TxResults[5].Log)
+	require.Equal(t, abci.CodeTypeOK, response.TxResults[6].Code, response.TxResults[6].Log)
+
+	deployResponse := blockSTMMixedEVMResponse(t, response.TxResults[1])
+	firstLogResponse := blockSTMMixedEVMResponse(t, response.TxResults[2])
+	secondLogResponse := blockSTMMixedEVMResponse(t, response.TxResults[4])
+	revertResponse := blockSTMMixedEVMResponse(t, response.TxResults[5])
+	transferResponse := blockSTMMixedEVMResponse(t, response.TxResults[6])
+	require.Len(t, fixture.evmTxHashes, 5)
+	require.Equal(t, fixture.evmTxHashes[0], deployResponse.Hash, "deployment response hash must identify the actual signed Ethereum transaction")
+	require.Equal(t, fixture.evmTxHashes[1], firstLogResponse.Hash, "first log-call response hash must identify the actual signed Ethereum transaction")
+	require.Equal(t, fixture.evmTxHashes[2], secondLogResponse.Hash, "second log-call response hash must identify the actual signed Ethereum transaction")
+	require.Equal(t, fixture.evmTxHashes[3], revertResponse.Hash, "revert response hash must identify the actual signed Ethereum transaction")
+	require.Equal(t, fixture.evmTxHashes[4], transferResponse.Hash, "transfer response hash must identify the actual signed Ethereum transaction")
+	require.Empty(t, deployResponse.VmError)
+	require.Empty(t, firstLogResponse.VmError)
+	require.Empty(t, secondLogResponse.VmError)
+	require.Equal(t, vm.ErrExecutionReverted.Error(), revertResponse.VmError)
+	require.Empty(t, transferResponse.VmError)
+	require.Positive(t, deployResponse.GasUsed)
+	require.Positive(t, firstLogResponse.GasUsed)
+	require.Positive(t, secondLogResponse.GasUsed)
+	require.Positive(t, revertResponse.GasUsed)
+	require.Positive(t, transferResponse.GasUsed)
+	require.Less(t, deployResponse.GasUsed, blockSTMMixedEVMDeployGas)
+	require.Less(t, firstLogResponse.GasUsed, blockSTMMixedEVMLogGas)
+	require.Less(t, secondLogResponse.GasUsed, blockSTMMixedEVMLogGas)
+	require.Less(t, revertResponse.GasUsed, blockSTMMixedEVMRevertGas)
+	require.Equal(t, blockSTMMixedEVMTransferGas, transferResponse.GasUsed)
+	require.Empty(t, deployResponse.Logs)
+	require.Len(t, firstLogResponse.Logs, 2)
+	require.Len(t, secondLogResponse.Logs, 2)
+	require.Empty(t, revertResponse.Logs)
+	require.Empty(t, transferResponse.Logs)
+	for index, log := range firstLogResponse.Logs {
+		require.Equal(t, fixture.contract.Hex(), log.Address)
+		require.Equal(t, uint64(1), log.TxIndex, "the Cosmos transaction before this call must not consume an Ethereum transaction index")
+		require.Equal(t, uint64(index), log.Index, "log indices must be cumulative and deterministic after block-level patching")
+	}
+	for index, log := range secondLogResponse.Logs {
+		require.Equal(t, fixture.contract.Hex(), log.Address)
+		require.Equal(t, uint64(2), log.TxIndex, "the intervening Cosmos transaction must not consume an Ethereum transaction index")
+		require.Equal(t, uint64(index+2), log.Index, "log indices must remain cumulative across different Ethereum transactions")
+	}
+
+	totalEVMGas := deployResponse.GasUsed + firstLogResponse.GasUsed + secondLogResponse.GasUsed + revertResponse.GasUsed + transferResponse.GasUsed
+	expectedEVMBalance := sdkmath.NewInt(blockSTMMixedEVMInitialFunds).
+		SubRaw(int64(totalEVMGas)).
+		SubRaw(blockSTMMixedEVMTransfer)
+	require.Equal(t, expectedEVMBalance.String(), state.EVMSenderBalance, "unused EVM gas and reverted value must be refunded")
+	require.Equal(t, sdkmath.NewInt(7+blockSTMMixedEVMTransfer).String(), state.RecipientBalance)
+	require.Equal(t, uint64(5), state.EVMSenderNonce)
+	require.Equal(t, "0", state.ContractBalance, "reverted EVM value transfer must roll back")
+	require.Equal(t, hex.EncodeToString(blockSTMMixedReverterRuntime), state.ContractCode)
+	require.Equal(t, sdkmath.NewInt(feePolicyRuntimeInitialFunds-150_000-7).String(), state.CosmosNormalBalance)
+	require.Equal(t, sdkmath.NewInt(feePolicyRuntimeInitialFunds).String(), state.CosmosFailedBalance, "message failure must roll back the attempted bank transfer")
+	require.Equal(t, sdkmath.NewInt(feePolicyRuntimeInitialFunds-150_000).String(), state.CosmosGranterBalance)
+	require.Equal(t, sdkmath.NewInt(400_000-150_000).String(), state.CosmosFailedAllowance)
+	totalFeeAmount := sdkmath.NewInt(300_000 + int64(totalEVMGas))
+	totalFee := totalFeeAmount.String()
+	totalFeeCoins := sdk.NewCoins(sdk.NewCoin(appparams.BaseDenom, totalFeeAmount)).String()
+	require.Equal(
+		t,
+		totalFee,
+		state.CollectorBalance,
+		"Cosmos and EVM virtual fees must settle exactly once into the shared collector",
+	)
+	collectorAddress := fixture.app.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+	collectorAddressString, err := fixture.app.AccountKeeper.AddressCodec().BytesToString(collectorAddress)
+	require.NoError(t, err)
+	collectorAttributes := map[string]string{banktypes.AttributeKeyReceiver: collectorAddressString}
+	for index, result := range response.TxResults {
+		require.Zero(
+			t,
+			countBlockSTMMixedABCIEvents(result.Events, banktypes.EventTypeCoinReceived, collectorAttributes),
+			"tx result %d must not expose an immediate fee-collector receipt while virtual collection is active",
+			index,
+		)
+	}
+	require.Equal(
+		t,
+		1,
+		countBlockSTMMixedABCIEvents(response.Events, banktypes.EventTypeCoinReceived, map[string]string{
+			banktypes.AttributeKeyReceiver: collectorAddressString,
+			"mode":                         "EndBlock",
+		}),
+		"Cosmos and EVM virtual fees must produce one aggregate fee-collector receipt in EndBlock",
+	)
+	require.Equal(
+		t,
+		1,
+		countBlockSTMMixedABCIEvents(response.Events, banktypes.EventTypeCoinReceived, map[string]string{
+			banktypes.AttributeKeyReceiver: collectorAddressString,
+			sdk.AttributeKeyAmount:         totalFeeCoins,
+			"mode":                         "EndBlock",
+		}),
+		"the single EndBlock receipt must equal the combined Cosmos and EVM actual fees",
+	)
+
+	fixture.requireFeeEvent(t, response.TxResults[0], 150_000, fixture.actor(feePolicyActorNormal).addressString)
+	fixture.requireFeeEvent(t, response.TxResults[3], 150_000, fixture.actor(feePolicyActorGrantMsgGranter).addressString)
+}
+
+func requireBlockSTMMixedCosmosEVMEmptyBlockSemantics(
+	t *testing.T,
+	state blockSTMMixedCosmosEVMState,
+	emptyState blockSTMMixedCosmosEVMState,
+) {
+	t.Helper()
+	expected := state
+	expected.CollectorBalance = "0"
+	require.Equal(t, expected, emptyState, "the next block may drain distribution funds but must not settle stale Cosmos or EVM virtual fees or mutate actor state")
+}
+
+func blockSTMMixedEVMResponse(t *testing.T, result *abci.ExecTxResult) *evmtypes.MsgEthereumTxResponse {
+	t.Helper()
+	response, err := evmtypes.DecodeTxResponse(result.Data)
+	require.NoError(t, err)
+	require.NotEmpty(t, response.Hash)
+	return response
+}
+
+func countBlockSTMMixedABCIEvents(
+	events []abci.Event,
+	eventType string,
+	attributes map[string]string,
+) int {
+	count := 0
+	for _, event := range events {
+		if event.Type != eventType {
+			continue
+		}
+		matched := true
+		for key, expected := range attributes {
+			found := false
+			for _, attribute := range event.Attributes {
+				if attribute.Key == key && attribute.Value == expected {
+					found = true
+					break
+				}
+			}
+			if !found {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			count++
+		}
+	}
+	return count
+}
+
+func blockSTMMixedCommonAddress(address sdk.AccAddress) *common.Address {
+	value := common.BytesToAddress(address)
+	return &value
+}
+
+func mustBlockSTMMixedHex(value string) []byte {
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		panic(err)
+	}
+	return decoded
+}

--- a/app/keepers/appkeepers.go
+++ b/app/keepers/appkeepers.go
@@ -60,6 +60,8 @@ type AppKeepers struct {
 	tKeys   map[string]*storetypes.TransientStoreKey
 	objKeys map[string]*storetypes.ObjectStoreKey
 
+	cosmosVirtualFeeCollection bool
+
 	// cosmos sdk keepers
 	AccountKeeper         authkeeper.AccountKeeper
 	BankKeeper            bankkeeper.Keeper
@@ -144,6 +146,7 @@ func NewAppKeepers(cfg appparams.KeepersInitConfig) *AppKeepers {
 		cfg.Logger,
 	)
 	appKeepers.BankKeeper = appKeepers.BankKeeper.WithObjStoreKey(appKeepers.objKeys[banktypes.ObjectStoreKey])
+	appKeepers.EnableCosmosVirtualFeeCollection()
 
 	appKeepers.StakingKeeper = stakingkeeper.NewKeeper(
 		cfg.AppCodec,
@@ -367,4 +370,21 @@ func NewAppKeepers(cfg appparams.KeepersInitConfig) *AppKeepers {
 	)
 
 	return appKeepers
+}
+
+// EnableCosmosVirtualFeeCollection switches only the Cosmos ante fee path to
+// virtual bank collection. EVM fee collection is configured independently on
+// the EVM keeper. Call this only during single-threaded application assembly;
+// the ante handler snapshots the value before transaction execution starts.
+func (appKeepers *AppKeepers) EnableCosmosVirtualFeeCollection() {
+	if appKeepers.BankKeeper == nil {
+		panic("bank keeper must be initialized before enabling Cosmos virtual fee collection")
+	}
+	appKeepers.cosmosVirtualFeeCollection = true
+}
+
+// CosmosVirtualFeeCollectionEnabled reports the binary-selected Cosmos fee
+// policy used when the application constructs its ante handler.
+func (appKeepers *AppKeepers) CosmosVirtualFeeCollectionEnabled() bool {
+	return appKeepers.cosmosVirtualFeeCollection
 }


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

This PR virtualizes Cosmos SDK transaction fee collection to remove the shared `fee_collector` balance write from each transaction during BlockSTM execution.

Fee payer debits remain real state writes. Fee collector credits are recorded through the Bank object store and reconciled during EndBlock. Cosmos and EVM virtual fee collection are configured independently.

The collector implementation is selected once when constructing the ante handler. This avoids validator-local runtime configuration and preserves deterministic execution across nodes running the same binary.

## What changed

- Added a Cosmos-specific fee collector abstraction to the ante handler.
- Added normal and virtual Cosmos fee collection implementations.
- Snapshotted the selected collector method during ante-handler construction.
- Added fail-closed validation when virtual collection is enabled without the required Bank keeper capability.
- Wired the Bank keeper object store into the application.
- Enabled Cosmos virtual fee collection independently from EVM virtual fee collection.
- Preserved fee payer, fee granter, discount, base-fee, tip, priority, zero-fee, and insufficient-funds behavior.
- Added deterministic execution, same-block visibility, mixed Cosmos/EVM, routing, and fee deduction tests.
- Added paired BlockSTM benchmarks for independent-payer and same-account workloads.

## Critical files to review

- `app/ante/ante.go`
  - Defines and selects the Cosmos fee collector implementation.
  - Keeps the Cosmos and EVM ante paths independent.
- `app/ante/cosmos.go`
  - Injects the selected collector into the Cosmos ante chain.
- `app/ante/cosmos_fees.go`
  - Applies Cosmos fee deductions through the selected collector.
- `app/ante_handler.go`
  - Supplies the Cosmos Bank keeper and virtual collection setting.
- `app/keepers/appkeepers.go`
  - Configures the Bank object store and independently enables Cosmos virtual fee collection.
- `app/blockstm_cosmos_virtual_fee_determinism_test.go`
  - Compares sequential and BlockSTM execution results.
- `app/blockstm_cosmos_virtual_fee_visibility_test.go`
  - Verifies same-block fee balance visibility and EndBlock settlement.
- `app/blockstm_mixed_cosmos_evm_determinism_test.go`
  - Verifies deterministic mixed Cosmos/EVM execution.
- `app/blockstm_cosmos_virtual_fee_benchmark_test.go`
  - Measures virtual fee collection performance and allocation changes.

## Consensus and compatibility notes

- The setting is determined during application construction, not through validator-local `app.toml` configuration.
- All validators must activate this change at the same coordinated upgrade height.
- Mixed execution between binaries with and without this change is not supported.
- The fee collector's real balance is credited during EndBlock instead of after every transaction.
- Transaction-local `fee_collector` balance visibility and collector-side receive-event timing therefore change intentionally.
- The committed application state after EndBlock remains equivalent.
- EVM fee handling continues to use its existing independent configuration and upstream ante path.

## Review instructions

1. Verify that only the Cosmos ante path uses `CosmosFeeCollector`.
2. Verify that EVM routing and EVM virtual fee configuration remain unchanged.
3. Verify that virtual collection cannot silently fall back to normal collection when the required capability is missing.
4. Verify sequential-versus-BlockSTM equality for application hash, transaction results, events, balances, and account sequences.
5. Verify that the fee collector's final balance is reconciled correctly during EndBlock.
6. Run the application test suite:
   - `go test -mod=readonly ./app/... -count=1`
   - `go test -mod=readonly -race ./app/ante -count=10`
7. Run the paired benchmark:
   - `GOMAXPROCS=10 GURU_BLOCKSTM_BENCH_TXS=1000 GURU_BLOCKSTM_BENCH_WORKERS=10 go test -mod=readonly ./app -run '^$' -bench 'BenchmarkBlockSTMCosmosFeeCollection' -benchmem`

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member — GCV-195
- [x] left instructions on how to review the changes
- [ ] targeted the `main` branch — N/A: this PR targets `dev-v3`

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code — N/A: this PR changes production ante and keeper wiring
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed