### PR TITLE
feat(app): standardize MsgSend gas to 21,000 across full tx path with proposal support

### DIFF
--- a/app/ante/cosmos.go
+++ b/app/ante/cosmos.go
@@ -29,6 +29,7 @@ func newCosmosAnteHandler(ctx sdk.Context, options HandlerOptions) sdk.AnteHandl
 			sdk.MsgTypeURL(&sdkvesting.MsgCreateVestingAccount{}),
 		),
 		authante.NewSetUpContextDecorator(),
+		NewStandardMsgSendGasDecorator(evmOptions.AccountKeeper),
 		authante.NewExtensionOptionsDecorator(evmOptions.ExtensionOptionChecker),
 		authante.NewValidateBasicDecorator(),
 		authante.NewTxTimeoutHeightDecorator(),

--- a/app/ante/cosmos_fees.go
+++ b/app/ante/cosmos_fees.go
@@ -381,7 +381,8 @@ func FeeChecker(
 		return EffectiveFeeBreakdown{}, errorsmod.Wrap(sdkerrors.ErrInsufficientFee, "max priority price cannot be negative")
 	}
 
-	gas := sdkmath.NewIntFromUint64(feeTx.GetGas())
+	effectiveGas := effectiveFeeGas(ctx, feeTx.GetGas())
+	gas := sdkmath.NewIntFromUint64(effectiveGas)
 	if gas.IsZero() {
 		return EffectiveFeeBreakdown{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "gas cannot be zero")
 	}
@@ -449,7 +450,7 @@ func feeWithValidatorMinGasPrices(
 	priorityFn func(sdk.Coins, int64) int64,
 ) (EffectiveFeeBreakdown, error) {
 	feeCoins := feeTx.GetFee()
-	gas := int64(feeTx.GetGas()) // #nosec G115 -- ValidateBasic bounds the gas limit before fee deduction.
+	gas := int64(effectiveFeeGas(ctx, feeTx.GetGas())) // #nosec G115 -- ValidateBasic bounds the gas limit before fee deduction.
 
 	if ctx.IsCheckTx() && !ctx.MinGasPrices().IsZero() {
 		minGasPrices := ctx.MinGasPrices()
@@ -507,4 +508,14 @@ func dynamicFeePriority(fees sdk.Coins, gas int64) int64 {
 		}
 	}
 	return priority
+}
+
+func effectiveFeeGas(
+	ctx sdk.Context,
+	declaredGas uint64,
+) uint64 {
+	if _, ok := ctx.GasMeter().(*standardMsgSendGasMeter); ok {
+		return StandardMsgSendGas
+	}
+	return declaredGas
 }

--- a/app/ante/cosmos_fees_test.go
+++ b/app/ante/cosmos_fees_test.go
@@ -2,6 +2,7 @@ package ante
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -19,6 +20,7 @@ import (
 	protov2 "google.golang.org/protobuf/proto"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	sdkauthante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -53,6 +55,73 @@ func (keeper staticFeePolicyKeeper) ResolveDiscount(
 	[]sdk.Msg,
 ) (feepolicytypes.Discount, error) {
 	return keeper.discount, nil
+}
+
+type recordingFeePolicyKeeper struct {
+	calls            int
+	canonicalPayer   string
+	returnedDiscount feepolicytypes.Discount
+	lastResolvedMsgs []sdk.Msg
+}
+
+func (keeper *recordingFeePolicyKeeper) ResolveDiscount(
+	_ context.Context,
+	payer string,
+	msgs []sdk.Msg,
+) (feepolicytypes.Discount, error) {
+	keeper.calls++
+	keeper.canonicalPayer = payer
+	keeper.lastResolvedMsgs = append([]sdk.Msg{}, msgs...)
+	return keeper.returnedDiscount, nil
+}
+
+type virtualFeeBankKeeperSpy struct {
+	calls           int
+	ctx             context.Context
+	senderAddr      sdk.AccAddress
+	recipientModule string
+	amount          sdk.Coins
+	err             error
+	onSend          func(context.Context, sdk.AccAddress, string, sdk.Coins) error
+}
+
+func (keeper *virtualFeeBankKeeperSpy) IsSendEnabledCoins(_ context.Context, _ ...sdk.Coin) error {
+	return nil
+}
+
+func (keeper *virtualFeeBankKeeperSpy) SendCoinsFromAccountToModuleVirtual(
+	ctx context.Context,
+	senderAddr sdk.AccAddress,
+	recipientModule string,
+	amount sdk.Coins,
+) error {
+	keeper.calls++
+	keeper.ctx = ctx
+	keeper.senderAddr = senderAddr
+	keeper.recipientModule = recipientModule
+	keeper.amount = amount
+	if keeper.onSend != nil {
+		return keeper.onSend(ctx, senderAddr, recipientModule, amount)
+	}
+
+	return keeper.err
+}
+
+func (keeper *virtualFeeBankKeeperSpy) SendCoins(
+	ctx context.Context,
+	from, to sdk.AccAddress,
+	amount sdk.Coins,
+) error {
+	return keeper.SendCoinsFromAccountToModule(ctx, from, to.String(), amount)
+}
+
+func (keeper *virtualFeeBankKeeperSpy) SendCoinsFromAccountToModule(
+	ctx context.Context,
+	senderAddr sdk.AccAddress,
+	recipientModule string,
+	amount sdk.Coins,
+) error {
+	return keeper.SendCoinsFromAccountToModuleVirtual(ctx, senderAddr, recipientModule, amount)
 }
 
 func feeDecoratorTestPayer() sdk.AccAddress {
@@ -116,7 +185,7 @@ func TestApplyDiscountToBaseFee(t *testing.T) {
 	}
 }
 
-func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
+func TestDeductFeeDecoratorNoPolicyMatchesUpstreamFeeAmountPriorityAndEvents(t *testing.T) {
 	payer := feeDecoratorTestPayer()
 	fee := parityFee(200)
 	tx := parityFeeTx{gas: 10, fee: fee, payer: payer}
@@ -124,10 +193,10 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 	ethConfig := parityLondonConfig(0)
 
 	type observation struct {
-		payerBalance     sdkmath.Int
-		collectorBalance sdkmath.Int
-		priority         int64
-		events           sdk.Events
+		payerBalance sdkmath.Int
+		collectedFee sdkmath.Int
+		priority     int64
+		events       sdk.Events
 	}
 	run := func(local bool) observation {
 		controller := gomock.NewController(t)
@@ -146,14 +215,20 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 		}
 
 		payerBalance := sdkmath.NewInt(1_000)
-		collectorBalance := sdkmath.ZeroInt()
-		bankKeeper.EXPECT().
-			SendCoinsFromAccountToModule(gomock.Any(), payer, authtypes.FeeCollectorName, fee).
-			DoAndReturn(func(context.Context, sdk.AccAddress, string, sdk.Coins) error {
-				payerBalance = payerBalance.Sub(fee.AmountOf(parityFeeDenom))
-				collectorBalance = collectorBalance.Add(fee.AmountOf(parityFeeDenom))
-				return nil
-			})
+		collectedFee := sdkmath.ZeroInt()
+		recordCollection := func(_ context.Context, _ sdk.AccAddress, _ string, amount sdk.Coins) error {
+			payerBalance = payerBalance.Sub(amount.AmountOf(parityFeeDenom))
+			collectedFee = collectedFee.Add(amount.AmountOf(parityFeeDenom))
+			return nil
+		}
+		virtualBankKeeper := &virtualFeeBankKeeperSpy{onSend: recordCollection}
+		if !local {
+			bankKeeper.EXPECT().
+				SendCoinsFromAccountToModule(gomock.Any(), payer, authtypes.FeeCollectorName, fee).
+				DoAndReturn(func(ctx context.Context, sender sdk.AccAddress, module string, amount sdk.Coins) error {
+					return recordCollection(ctx, sender, module, amount)
+				})
+		}
 
 		ctx := parityFeeContext(1, false)
 		var (
@@ -166,7 +241,7 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 			}
 			newCtx, err = NewDeductFeeDecorator(
 				accountKeeper,
-				bankKeeper,
+				virtualBankKeeper,
 				nil,
 				checker,
 				staticFeePolicyKeeper{},
@@ -187,18 +262,24 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 			})
 		}
 		require.NoError(t, err)
+		if local {
+			require.Equal(t, 1, virtualBankKeeper.calls)
+			require.Equal(t, payer, virtualBankKeeper.senderAddr)
+			require.Equal(t, authtypes.FeeCollectorName, virtualBankKeeper.recipientModule)
+			require.Equal(t, fee, virtualBankKeeper.amount)
+		}
 		return observation{
-			payerBalance:     payerBalance,
-			collectorBalance: collectorBalance,
-			priority:         newCtx.Priority(),
-			events:           newCtx.EventManager().Events(),
+			payerBalance: payerBalance,
+			collectedFee: collectedFee,
+			priority:     newCtx.Priority(),
+			events:       newCtx.EventManager().Events(),
 		}
 	}
 
 	local := run(true)
 	upstream := run(false)
 	require.Equal(t, sdkmath.NewInt(800), local.payerBalance)
-	require.Equal(t, sdkmath.NewInt(200), local.collectorBalance)
+	require.Equal(t, sdkmath.NewInt(200), local.collectedFee)
 	require.Equal(t, upstream, local)
 	require.Len(t, local.events, 1)
 }
@@ -206,7 +287,7 @@ func TestDeductFeeDecoratorNoPolicyMatchesUpstreamAccounting(t *testing.T) {
 func TestDeductFeeDecoratorPreservesCheckerPriority(t *testing.T) {
 	controller := gomock.NewController(t)
 	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
-	bankKeeper := authtestutil.NewMockBankKeeper(controller)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{}
 	payer := feeDecoratorTestPayer()
 	accountKeeper.EXPECT().
 		GetModuleAddress(authtypes.FeeCollectorName).
@@ -223,7 +304,7 @@ func TestDeductFeeDecoratorPreservesCheckerPriority(t *testing.T) {
 	fee := parityFee(60)
 	ctx, err := NewDeductFeeDecorator(
 		accountKeeper,
-		bankKeeper,
+		virtualBankKeeper,
 		nil,
 		staticFeeBreakdownChecker(fee, priority),
 		staticFeePolicyKeeper{discount: feepolicytypes.Discount{
@@ -243,21 +324,102 @@ func TestDeductFeeDecoratorPreservesCheckerPriority(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, priority, nextPriority)
 	require.Equal(t, priority, ctx.Priority())
+	require.Zero(t, virtualBankKeeper.calls, "zero fees must not create a virtual collection entry")
 	require.Len(t, ctx.EventManager().Events(), 1)
 	require.Equal(t, sdk.Coins{}.String(), ctx.EventManager().Events()[0].Attributes[0].Value)
+}
+
+func TestDeductFeeDecoratorStandardMsgSendAppliesFeePolicy(t *testing.T) {
+	controller := gomock.NewController(t)
+	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{}
+	payer := feeDecoratorTestPayer()
+	accountKeeper.EXPECT().
+		GetModuleAddress(authtypes.FeeCollectorName).
+		Return(authtypes.NewModuleAddress(authtypes.FeeCollectorName))
+	accountKeeper.EXPECT().
+		AddressCodec().
+		Return(evmaddress.NewEvmCodec(sdk.GetConfig().GetBech32AccountAddrPrefix()))
+	accountKeeper.EXPECT().
+		GetAccount(gomock.Any(), payer).
+		Return(authtypes.NewBaseAccountWithAddress(payer))
+
+	fee := parityFee(60)
+	discountKeeper := &recordingFeePolicyKeeper{
+		returnedDiscount: feepolicytypes.Discount{
+			DiscountType: feepolicytypes.FeeDiscountTypePercent,
+			Amount:       sdkmath.LegacyNewDec(50),
+		},
+	}
+	ctx := parityFeeContext(1, false).WithGasMeter(
+		newStandardMsgSendGasMeter(storetypes.NewInfiniteGasMeter()),
+	)
+	newCtx, err := NewDeductFeeDecorator(
+		accountKeeper,
+		virtualBankKeeper,
+		nil,
+		staticFeeBreakdownChecker(fee, 11),
+		discountKeeper,
+	).AnteHandle(
+		ctx,
+		parityFeeTx{gas: StandardMsgSendGas, fee: fee, payer: payer},
+		false,
+		func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			return ctx, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, discountKeeper.calls)
+	require.Equal(t, feeDecoratorTestPayer().String(), discountKeeper.canonicalPayer)
+	require.Equal(t, int64(11), newCtx.Priority())
+	require.Equal(t, 1, virtualBankKeeper.calls)
+	require.Equal(t, parityFee(30), virtualBankKeeper.amount)
+}
+
+func TestFeeCheckerClampsStandardMsgSendGasMeter(t *testing.T) {
+	params := parityFeeMarketParams("10")
+	tx := parityFeeTx{
+		gas: StandardMsgSendGas + 1,
+		fee: parityFee(210_000),
+	}
+	ctx := parityFeeContext(1, false).WithGasMeter(
+		newStandardMsgSendGasMeter(storetypes.NewInfiniteGasMeter()),
+	)
+
+	got, err := FeeChecker(ctx, &params, parityFeeDenom, parityLondonConfig(0), tx)
+	require.NoError(t, err)
+	require.Equal(t, parityFee(210_000), got.EffectiveFee)
+	require.Equal(t, parityFee(210_000), got.BaseComponent)
+	require.True(t, got.TipComponent.IsZero())
+}
+
+func TestFeeWithValidatorMinGasPricesClampsStandardMsgSendGasMeter(t *testing.T) {
+	ctx := parityFeeContext(1, true).
+		WithMinGasPrices(sdk.NewDecCoins(sdk.NewDecCoin(parityFeeDenom, sdkmath.NewInt(10)))).
+		WithGasMeter(newStandardMsgSendGasMeter(storetypes.NewInfiniteGasMeter()))
+	tx := parityFeeTx{
+		gas: StandardMsgSendGas + 1,
+		fee: parityFee(210_000),
+	}
+
+	got, err := checkTxFeeWithValidatorMinGasPrices(ctx, tx)
+	require.NoError(t, err)
+	require.Equal(t, parityFee(210_000), got.EffectiveFee)
+	require.Equal(t, parityFee(210_000), got.BaseComponent)
 }
 
 func TestDeductFeeDecoratorMissingFeeCollectorFailsBeforeSideEffects(t *testing.T) {
 	controller := gomock.NewController(t)
 	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
 	accountKeeper.EXPECT().GetModuleAddress(authtypes.FeeCollectorName).Return(nil)
-	bankKeeper := authtestutil.NewMockBankKeeper(controller)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{}
 	nextCalled := false
 	ctx := parityFeeContext(1, false)
 
 	_, err := NewDeductFeeDecorator(
 		accountKeeper,
-		bankKeeper,
+		virtualBankKeeper,
 		nil,
 		staticFeeBreakdownChecker(parityFee(60), 1),
 		noCallFeePolicyKeeper{t: t},
@@ -279,7 +441,7 @@ func TestDeductFeeDecoratorMissingFeeCollectorFailsBeforeSideEffects(t *testing.
 func TestDeductFeeDecoratorMissingPayerFailsBeforeBankSideEffects(t *testing.T) {
 	controller := gomock.NewController(t)
 	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
-	bankKeeper := authtestutil.NewMockBankKeeper(controller)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{}
 	payer := feeDecoratorTestPayer()
 	accountKeeper.EXPECT().
 		GetModuleAddress(authtypes.FeeCollectorName).
@@ -293,7 +455,7 @@ func TestDeductFeeDecoratorMissingPayerFailsBeforeBankSideEffects(t *testing.T) 
 
 	_, err := NewDeductFeeDecorator(
 		accountKeeper,
-		bankKeeper,
+		virtualBankKeeper,
 		nil,
 		staticFeeBreakdownChecker(parityFee(60), 1),
 		staticFeePolicyKeeper{},
@@ -308,6 +470,50 @@ func TestDeductFeeDecoratorMissingPayerFailsBeforeBankSideEffects(t *testing.T) 
 	)
 
 	require.ErrorIs(t, err, sdkerrors.ErrUnknownAddress)
+	require.False(t, nextCalled)
+	require.Empty(t, ctx.EventManager().Events())
+}
+
+func TestDeductFeeDecoratorVirtualCollectionFailureStopsAnteChain(t *testing.T) {
+	controller := gomock.NewController(t)
+	accountKeeper := authantetestutil.NewMockAccountKeeper(controller)
+	payer := feeDecoratorTestPayer()
+	fee := parityFee(60)
+	virtualBankKeeper := &virtualFeeBankKeeperSpy{err: errors.New("virtual collection failed")}
+	accountKeeper.EXPECT().
+		GetModuleAddress(authtypes.FeeCollectorName).
+		Return(authtypes.NewModuleAddress(authtypes.FeeCollectorName))
+	accountKeeper.EXPECT().
+		AddressCodec().
+		Return(evmaddress.NewEvmCodec(sdk.GetConfig().GetBech32AccountAddrPrefix()))
+	accountKeeper.EXPECT().
+		GetAccount(gomock.Any(), payer).
+		Return(authtypes.NewBaseAccountWithAddress(payer))
+
+	nextCalled := false
+	ctx := parityFeeContext(1, false)
+	_, err := NewDeductFeeDecorator(
+		accountKeeper,
+		virtualBankKeeper,
+		nil,
+		staticFeeBreakdownChecker(fee, 1),
+		staticFeePolicyKeeper{},
+	).AnteHandle(
+		ctx,
+		parityFeeTx{gas: 1, fee: fee, payer: payer},
+		false,
+		func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			nextCalled = true
+			return ctx, nil
+		},
+	)
+
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+	require.ErrorContains(t, err, "virtual collection failed")
+	require.Equal(t, 1, virtualBankKeeper.calls)
+	require.Equal(t, payer, virtualBankKeeper.senderAddr)
+	require.Equal(t, authtypes.FeeCollectorName, virtualBankKeeper.recipientModule)
+	require.Equal(t, fee, virtualBankKeeper.amount)
 	require.False(t, nextCalled)
 	require.Empty(t, ctx.EventManager().Events())
 }
@@ -364,7 +570,7 @@ func TestDeductFeeDecoratorRejectsInvalidCheckerBreakdownBeforeSideEffects(t *te
 			controller := gomock.NewController(t)
 			decorator := NewDeductFeeDecorator(
 				authantetestutil.NewMockAccountKeeper(controller),
-				authtestutil.NewMockBankKeeper(controller),
+				new(virtualFeeBankKeeperSpy),
 				authantetestutil.NewMockFeegrantKeeper(controller),
 				func(sdk.Context, sdk.Tx) (EffectiveFeeBreakdown, error) {
 					return test.breakdown, nil

--- a/app/ante/standard_msgsend_gas.go
+++ b/app/ante/standard_msgsend_gas.go
@@ -1,0 +1,301 @@
+package ante
+
+import (
+	"bytes"
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+
+	antetypes "github.com/cosmos/evm/ante/types"
+	"github.com/cosmos/evm/crypto/ethsecp256k1"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+const (
+	// StandardMsgSendGas is the public gas value for the bounded MsgSend shape.
+	StandardMsgSendGas uint64 = 21_000
+
+	// StandardMsgSendMaxMemoBytes retains the current default memo envelope as
+	// an immutable bound for this class even if the auth parameter is raised.
+	StandardMsgSendMaxMemoBytes = 256
+)
+
+// StandardMsgSendGasDecorator projects a deliberately narrow MsgSend shape to
+// 21k public gas while retaining internal execution accounting. Every shape
+// outside this class continues through the ordinary Cosmos gas path.
+type StandardMsgSendGasDecorator struct {
+	accountKeeper authante.AccountKeeper
+}
+
+func NewStandardMsgSendGasDecorator(
+	accountKeeper authante.AccountKeeper,
+) StandardMsgSendGasDecorator {
+	return StandardMsgSendGasDecorator{
+		accountKeeper: accountKeeper,
+	}
+}
+
+func (d StandardMsgSendGasDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (newCtx sdk.Context, err error) {
+	baseFeeTx, msg, isStandardClass := standardMsgSendShapeWithoutGasLimit(tx, ctx.TxBytes())
+	if !isStandardClass {
+		return next(ctx, tx, simulate)
+	}
+	baseGas := baseFeeTx.GetGas()
+	if simulate {
+		if baseGas != 0 && baseGas < StandardMsgSendGas {
+			return next(ctx, tx, simulate)
+		}
+	} else if baseGas < StandardMsgSendGas {
+		return ctx, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidGasLimit,
+			"standard MsgSend requires at least %d gas",
+			StandardMsgSendGas,
+		)
+	}
+
+	if d.accountKeeper == nil {
+		return ctx, errorsmod.Wrap(sdkerrors.ErrLogic, "standard MsgSend gas dependencies are not configured")
+	}
+
+	feePayer := baseFeeTx.FeePayer()
+	from, err := d.accountKeeper.AddressCodec().StringToBytes(msg.FromAddress)
+	if err != nil || !bytes.Equal(from, feePayer) || !d.hasBoundedSingleSigner(ctx, tx, feePayer) {
+		return next(ctx, tx, simulate)
+	}
+
+	actualMeter := storetypes.NewInfiniteGasMeter()
+	consumed := ctx.GasMeter().GasConsumed()
+	if consumed > 0 {
+		actualMeter.ConsumeGas(consumed, "standard MsgSend pre-classification gas")
+	}
+
+	standardCtx := ctx.WithGasMeter(newStandardMsgSendGasMeter(actualMeter))
+
+	return next(standardCtx, tx, simulate)
+}
+
+// IsStandardMsgSendGasCandidate identifies the transaction-local superset that
+// must receive the standardized 21k weight during proposal admission. Signer/account
+// checks remain in the ante decorator; charging a larger superset is safe.
+func IsStandardMsgSendGasCandidate(tx sdk.Tx, txBytes []byte) bool {
+	_, _, eligible := standardMsgSendShape(tx, txBytes, false)
+	return eligible
+}
+
+// standardMsgSendShape is intentionally transaction-local. Eligible execution
+// still receives standard gas projection while remaining compatible with fee policy.
+func standardMsgSendShape(
+	tx sdk.Tx,
+	txBytes []byte,
+	simulate bool,
+) (sdk.FeeTx, *banktypes.MsgSend, bool) {
+	if tx == nil {
+		return nil, nil, false
+	}
+
+	msgs := tx.GetMsgs()
+	if len(msgs) != 1 {
+		return nil, nil, false
+	}
+	msg, ok := msgs[0].(*banktypes.MsgSend)
+	if !ok || msg == nil || len(msg.Amount) != 1 {
+		return nil, nil, false
+	}
+
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok || len(feeTx.FeeGranter()) != 0 || len(feeTx.GetFee()) > 1 {
+		return nil, nil, false
+	}
+	if len(feeTx.GetFee()) == 1 && feeTx.GetFee()[0].Denom != evmtypes.GetEVMCoinDenom() {
+		return nil, nil, false
+	}
+	declaredGas := feeTx.GetGas()
+	if declaredGas < StandardMsgSendGas && !(simulate && declaredGas == 0) {
+		return nil, nil, false
+	}
+
+	if memoTx, ok := tx.(sdk.TxWithMemo); ok && len(memoTx.GetMemo()) > StandardMsgSendMaxMemoBytes {
+		return nil, nil, false
+	}
+	if unorderedTx, ok := tx.(sdk.TxWithUnordered); ok && unorderedTx.GetUnordered() {
+		return nil, nil, false
+	}
+
+	if extensionTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
+		if len(extensionTx.GetNonCriticalExtensionOptions()) != 0 {
+			return nil, nil, false
+		}
+		extensions := extensionTx.GetExtensionOptions()
+		if len(extensions) > 1 {
+			return nil, nil, false
+		}
+		if len(extensions) == 1 {
+			if _, ok := extensions[0].GetCachedValue().(*antetypes.ExtensionOptionDynamicFeeTx); !ok {
+				return nil, nil, false
+			}
+		}
+	}
+
+	return feeTx, msg, true
+}
+
+func standardMsgSendShapeWithoutGasLimit(
+	tx sdk.Tx,
+	txBytes []byte,
+) (sdk.FeeTx, *banktypes.MsgSend, bool) {
+	if tx == nil {
+		return nil, nil, false
+	}
+
+	msgs := tx.GetMsgs()
+	if len(msgs) != 1 {
+		return nil, nil, false
+	}
+	msg, ok := msgs[0].(*banktypes.MsgSend)
+	if !ok || msg == nil || len(msg.Amount) != 1 {
+		return nil, nil, false
+	}
+
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok || len(feeTx.FeeGranter()) != 0 || len(feeTx.GetFee()) > 1 {
+		return nil, nil, false
+	}
+	if len(feeTx.GetFee()) == 1 && feeTx.GetFee()[0].Denom != evmtypes.GetEVMCoinDenom() {
+		return nil, nil, false
+	}
+
+	if memoTx, ok := tx.(sdk.TxWithMemo); ok && len(memoTx.GetMemo()) > StandardMsgSendMaxMemoBytes {
+		return nil, nil, false
+	}
+	if unorderedTx, ok := tx.(sdk.TxWithUnordered); ok && unorderedTx.GetUnordered() {
+		return nil, nil, false
+	}
+
+	if extensionTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
+		if len(extensionTx.GetNonCriticalExtensionOptions()) != 0 {
+			return nil, nil, false
+		}
+		extensions := extensionTx.GetExtensionOptions()
+		if len(extensions) > 1 {
+			return nil, nil, false
+		}
+		if len(extensions) == 1 {
+			if _, ok := extensions[0].GetCachedValue().(*antetypes.ExtensionOptionDynamicFeeTx); !ok {
+				return nil, nil, false
+			}
+		}
+	}
+
+	return feeTx, msg, true
+}
+
+func (d StandardMsgSendGasDecorator) hasBoundedSingleSigner(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	feePayer sdk.AccAddress,
+) bool {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return false
+	}
+	signers, err := sigTx.GetSigners()
+	if err != nil || len(signers) != 1 || !bytes.Equal(signers[0], feePayer) {
+		return false
+	}
+	signatures, err := sigTx.GetSignaturesV2()
+	if err != nil || len(signatures) != 1 {
+		return false
+	}
+	pubKeys, err := sigTx.GetPubKeys()
+	if err != nil || len(pubKeys) != 1 {
+		return false
+	}
+	pubKey := pubKeys[0]
+	if pubKey == nil {
+		account := d.accountKeeper.GetAccount(ctx, feePayer)
+		if account == nil {
+			return false
+		}
+		pubKey = account.GetPubKey()
+	}
+	return hasBoundedStandardMsgSendPubKey(pubKey)
+}
+
+func hasBoundedStandardMsgSendPubKey(root cryptotypes.PubKey) bool {
+	if root == nil {
+		return false
+	}
+
+	switch root.(type) {
+	case *secp256k1.PubKey, *ethsecp256k1.PubKey:
+		return true
+	default:
+		return false
+	}
+}
+
+type standardMsgSendGasMeter struct {
+	actual storetypes.GasMeter
+}
+
+func newStandardMsgSendGasMeter(actual storetypes.GasMeter) storetypes.GasMeter {
+	return &standardMsgSendGasMeter{actual: actual}
+}
+
+func (m *standardMsgSendGasMeter) GasConsumed() storetypes.Gas {
+	return StandardMsgSendGas
+}
+
+func (m *standardMsgSendGasMeter) GasConsumedToLimit() storetypes.Gas {
+	return StandardMsgSendGas
+}
+
+func (m *standardMsgSendGasMeter) GasRemaining() storetypes.Gas {
+	return m.actual.GasRemaining()
+}
+
+func (m *standardMsgSendGasMeter) Limit() storetypes.Gas {
+	return StandardMsgSendGas
+}
+
+func (m *standardMsgSendGasMeter) ConsumeGas(amount storetypes.Gas, descriptor string) {
+	m.actual.ConsumeGas(amount, descriptor)
+}
+
+func (m *standardMsgSendGasMeter) RefundGas(amount storetypes.Gas, descriptor string) {
+	m.actual.RefundGas(amount, descriptor)
+}
+
+func (m *standardMsgSendGasMeter) IsPastLimit() bool {
+	return m.actual.IsPastLimit()
+}
+
+func (m *standardMsgSendGasMeter) IsOutOfGas() bool {
+	return m.actual.IsOutOfGas()
+}
+
+func (m *standardMsgSendGasMeter) String() string {
+	return fmt.Sprintf(
+		"StandardMsgSendGasMeter{public: %d, actual: %s}",
+		StandardMsgSendGas,
+		m.actual.String(),
+	)
+}
+
+func (m *standardMsgSendGasMeter) actualGasConsumed() storetypes.Gas {
+	return m.actual.GasConsumed()
+}

--- a/app/ante/standard_msgsend_gas_test.go
+++ b/app/ante/standard_msgsend_gas_test.go
@@ -1,0 +1,686 @@
+package ante
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	coreaddress "cosmossdk.io/core/address"
+	antetypes "github.com/cosmos/evm/ante/types"
+	evmaddress "github.com/cosmos/evm/encoding/address"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	cryptomultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+func TestStandardMsgSendGasDecoratorEligibilityBoundaries(t *testing.T) {
+	configureRouterEVM(t)
+
+	dynamicExtension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{})
+	require.NoError(t, err)
+	unknownExtension, err := codectypes.NewAnyWithValue(&evmtypes.ExtensionOptionsEthereumTx{})
+	require.NoError(t, err)
+
+	codec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x11}, 20))
+	other := sdk.AccAddress(bytes.Repeat([]byte{0x22}, 20))
+	otherAddress, err := codec.BytesToString(other)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		simulate     bool
+		txBytes      []byte
+		mutate       func(*standardMsgSendTestTx)
+		wantStandard bool
+		wantErr      bool
+	}{
+		{
+			name:         "exact bounded MsgSend",
+			wantStandard: true,
+		},
+		{
+			name: "zero fee",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.fee = nil
+			},
+			wantStandard: true,
+		},
+		{
+			name: "one dynamic fee extension",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.extensions = []*codectypes.Any{dynamicExtension}
+			},
+			wantStandard: true,
+		},
+		{
+			name:     "simulation may declare zero gas",
+			simulate: true,
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = 0
+			},
+			wantStandard: true,
+		},
+		{
+			name: "non-simulation zero gas",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = 0
+			},
+			wantErr: true,
+		},
+		{
+			name:     "simulation still rejects below minimum gas",
+			simulate: true,
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = StandardMsgSendGas - 1
+			},
+			wantStandard: false,
+		},
+		{
+			name: "declared gas below exact value",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = StandardMsgSendGas - 1
+			},
+			wantErr: true,
+		},
+		{
+			name: "declared gas above exact value",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = StandardMsgSendGas + 1
+			},
+			wantStandard: true,
+		},
+		{
+			name: "memo at limit",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.memo = strings.Repeat("m", StandardMsgSendMaxMemoBytes)
+			},
+			wantStandard: true,
+		},
+		{
+			name: "memo above limit",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.memo = strings.Repeat("m", StandardMsgSendMaxMemoBytes+1)
+			},
+		},
+		{
+			name: "unordered transaction",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.unordered = true
+			},
+		},
+		{
+			name: "non-critical extension",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.nonCriticalExtensions = []*codectypes.Any{dynamicExtension}
+			},
+		},
+		{
+			name: "more than one critical extension",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.extensions = []*codectypes.Any{dynamicExtension, dynamicExtension}
+			},
+		},
+		{
+			name: "non-dynamic critical extension",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.extensions = []*codectypes.Any{unknownExtension}
+			},
+		},
+		{
+			name: "feegrant is excluded even when granter equals payer",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.granter = append(sdk.AccAddress(nil), tx.payer...)
+			},
+		},
+		{
+			name: "non-base fee denomination",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.fee = sdk.NewCoins(sdk.NewInt64Coin("wrong-denom", 1))
+			},
+		},
+		{
+			name: "more than one fee denomination",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.fee = sdk.NewCoins(
+					sdk.NewInt64Coin(evmtypes.GetEVMCoinDenom(), 1),
+					sdk.NewInt64Coin("wrong-denom", 1),
+				)
+			},
+		},
+		{
+			name: "no message",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs = nil
+			},
+		},
+		{
+			name: "more than one top-level message",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs = append(tx.msgs, tx.msgs[0])
+			},
+		},
+		{
+			name: "typed nil MsgSend",
+			mutate: func(tx *standardMsgSendTestTx) {
+				var msg *banktypes.MsgSend
+				tx.msgs = []sdk.Msg{msg}
+			},
+		},
+		{
+			name: "non-MsgSend message",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs = []sdk.Msg{&banktypes.MsgMultiSend{}}
+			},
+		},
+		{
+			name: "MsgSend without denomination",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).Amount = nil
+			},
+		},
+		{
+			name: "MsgSend with more than one denomination",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.NewCoins(
+					sdk.NewInt64Coin("denom-a", 1),
+					sdk.NewInt64Coin("denom-b", 1),
+				)
+			},
+		},
+		{
+			name: "fee payer differs from sender",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.payer = append(sdk.AccAddress(nil), other...)
+				tx.signers = [][]byte{other}
+			},
+		},
+		{
+			name: "invalid sender encoding",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).FromAddress = "not-an-address"
+			},
+		},
+		{
+			name: "signer differs from fee payer",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signers = [][]byte{other}
+			},
+		},
+		{
+			name: "no signer",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signers = nil
+			},
+		},
+		{
+			name: "more than one signer",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signers = [][]byte{tx.payer, other}
+			},
+		},
+		{
+			name: "signer extraction failure",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signersErr = errors.New("signer failure")
+			},
+		},
+		{
+			name: "no signature group",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signatures = nil
+			},
+		},
+		{
+			name: "more than one signature group",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signatures = append(tx.signatures, signing.SignatureV2{})
+			},
+		},
+		{
+			name: "signature extraction failure",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signaturesErr = errors.New("signature failure")
+			},
+		},
+		{
+			name: "no public key slot",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.pubKeys = nil
+			},
+		},
+		{
+			name: "more than one public key slot",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.pubKeys = append(tx.pubKeys, standardMsgSendLeafKey(2))
+			},
+		},
+		{
+			name: "public key extraction failure",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.pubKeysErr = errors.New("public key failure")
+			},
+		},
+		{
+			name: "seven signature leaves",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.pubKeys = []cryptotypes.PubKey{standardMsgSendMultisig(7)}
+			},
+			wantStandard: false,
+		},
+		{
+			name: "eight signature leaves",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.pubKeys = []cryptotypes.PubKey{standardMsgSendMultisig(8)}
+			},
+		},
+		{
+			name: "different recipient remains eligible",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).ToAddress = otherAddress
+			},
+			wantStandard: true,
+		},
+	}
+
+	keeper := &standardMsgSendAccountKeeper{addressCodec: codec}
+	decorator := NewStandardMsgSendGasDecorator(keeper)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tx := newStandardMsgSendTestTx(t, codec, payer)
+			if test.mutate != nil {
+				test.mutate(&tx)
+			}
+			txBytes := test.txBytes
+			if txBytes == nil {
+				txBytes = []byte{0x01}
+			}
+			originalMeter := storetypes.NewInfiniteGasMeter()
+			ctx := routerContext(false).WithGasMeter(originalMeter).WithTxBytes(txBytes)
+			nextCalled := false
+
+			newCtx, err := decorator.AnteHandle(ctx, tx, test.simulate, func(
+				ctx sdk.Context,
+				_ sdk.Tx,
+				_ bool,
+			) (sdk.Context, error) {
+				nextCalled = true
+				return ctx, nil
+			})
+
+			if test.wantErr {
+				require.Error(t, err)
+				require.False(t, nextCalled)
+				require.Same(t, originalMeter, newCtx.GasMeter())
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, nextCalled)
+			_, standardized := newCtx.GasMeter().(*standardMsgSendGasMeter)
+			require.Equal(t, test.wantStandard, standardized)
+			if test.wantStandard {
+				require.Equal(t, StandardMsgSendGas, uint64(newCtx.GasMeter().GasConsumed()))
+				require.Equal(t, StandardMsgSendGas, uint64(newCtx.GasMeter().Limit()))
+			} else {
+				require.Same(t, originalMeter, newCtx.GasMeter())
+			}
+		})
+	}
+}
+
+func TestStandardMsgSendGasDecoratorUsesStoredPublicKey(t *testing.T) {
+	configureRouterEVM(t)
+
+	codec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x33}, 20))
+	tx := newStandardMsgSendTestTx(t, codec, payer)
+	tx.pubKeys = []cryptotypes.PubKey{nil}
+	account := authtypes.NewBaseAccountWithAddress(payer)
+	require.NoError(t, account.SetPubKey(standardMsgSendLeafKey(1)))
+
+	tests := []struct {
+		name         string
+		account      sdk.AccountI
+		wantStandard bool
+	}{
+		{name: "stored key", account: account, wantStandard: true},
+		{name: "missing account"},
+		{name: "account without key", account: authtypes.NewBaseAccountWithAddress(payer)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keeper := &standardMsgSendAccountKeeper{
+				addressCodec: codec,
+				account:      test.account,
+			}
+			ctx := routerContext(false).
+				WithGasMeter(storetypes.NewInfiniteGasMeter()).
+				WithTxBytes([]byte{0x01})
+
+			newCtx, err := NewStandardMsgSendGasDecorator(keeper).AnteHandle(
+				ctx,
+				tx,
+				false,
+				func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) { return ctx, nil },
+			)
+
+			require.NoError(t, err)
+			_, standardized := newCtx.GasMeter().(*standardMsgSendGasMeter)
+			require.Equal(t, test.wantStandard, standardized)
+		})
+	}
+}
+
+func TestStandardMsgSendGasDecoratorRequiresConfiguredAccountKeeper(t *testing.T) {
+	configureRouterEVM(t)
+
+	codec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x44}, 20))
+	tx := newStandardMsgSendTestTx(t, codec, payer)
+	ctx := routerContext(false).
+		WithGasMeter(storetypes.NewInfiniteGasMeter()).
+		WithTxBytes([]byte{0x01})
+	nextCalled := false
+
+	newCtx, err := NewStandardMsgSendGasDecorator(nil).AnteHandle(
+		ctx,
+		tx,
+		false,
+		func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			nextCalled = true
+			return ctx, nil
+		},
+	)
+
+	require.ErrorIs(t, err, sdkerrors.ErrLogic)
+	require.False(t, nextCalled)
+	require.Same(t, ctx.GasMeter(), newCtx.GasMeter())
+}
+
+func TestStandardMsgSendGasDecoratorFallsBackForNilAndNonFeeTransactions(t *testing.T) {
+	configureRouterEVM(t)
+
+	codec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x55}, 20))
+	base := newStandardMsgSendTestTx(t, codec, payer)
+	decorator := NewStandardMsgSendGasDecorator(&standardMsgSendAccountKeeper{addressCodec: codec})
+
+	tests := []struct {
+		name string
+		tx   sdk.Tx
+	}{
+		{name: "nil transaction"},
+		{name: "transaction without fee interface", tx: standardMsgSendBareTx{msgs: base.msgs}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			meter := storetypes.NewInfiniteGasMeter()
+			ctx := routerContext(false).WithGasMeter(meter).WithTxBytes([]byte{0x01})
+			nextCalled := false
+
+			newCtx, err := decorator.AnteHandle(
+				ctx,
+				test.tx,
+				false,
+				func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+					nextCalled = true
+					return ctx, nil
+				},
+			)
+
+			require.NoError(t, err)
+			require.True(t, nextCalled)
+			require.Same(t, meter, newCtx.GasMeter())
+		})
+	}
+}
+
+func TestHasBoundedStandardMsgSendPubKey(t *testing.T) {
+	leaves := standardMsgSendLeafKeys(8)
+	flatSeven := cryptomultisig.NewLegacyAminoPubKey(7, leaves[:7])
+	flatEight := cryptomultisig.NewLegacyAminoPubKey(8, leaves)
+	oneNestedLevel := cryptomultisig.NewLegacyAminoPubKey(1, []cryptotypes.PubKey{leaves[0]})
+	allowedDepth := cryptomultisig.NewLegacyAminoPubKey(1, []cryptotypes.PubKey{oneNestedLevel})
+	twoNestedLevels := cryptomultisig.NewLegacyAminoPubKey(1, []cryptotypes.PubKey{allowedDepth})
+	sevenGroups := make([]cryptotypes.PubKey, 7)
+	for index := range sevenGroups {
+		sevenGroups[index] = cryptomultisig.NewLegacyAminoPubKey(1, []cryptotypes.PubKey{leaves[index]})
+	}
+	maxVisitedTree := cryptomultisig.NewLegacyAminoPubKey(len(sevenGroups), sevenGroups)
+	eightNestedLeaves := cryptomultisig.NewLegacyAminoPubKey(2, []cryptotypes.PubKey{
+		cryptomultisig.NewLegacyAminoPubKey(4, leaves[:4]),
+		cryptomultisig.NewLegacyAminoPubKey(4, leaves[4:]),
+	})
+
+	tests := []struct {
+		name string
+		key  cryptotypes.PubKey
+		want bool
+	}{
+		{name: "nil", key: nil},
+		{name: "single leaf", key: leaves[0], want: true},
+		{name: "unsupported ed25519 leaf", key: ed25519.GenPrivKey().PubKey()},
+		{name: "flat seven leaves", key: flatSeven},
+		{name: "flat eight leaves", key: flatEight},
+		{name: "leaves at depth two", key: allowedDepth},
+		{name: "maximum nodes and seven leaves", key: maxVisitedTree},
+		{name: "eight leaves split below root", key: eightNestedLeaves},
+		{name: "leaf below depth two", key: twoNestedLevels},
+		{name: "empty multisig", key: &cryptomultisig.LegacyAminoPubKey{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, hasBoundedStandardMsgSendPubKey(test.key))
+		})
+	}
+}
+
+func TestStandardMsgSendGasMeterProjectsPublicGasAndRetainsInternalAccounting(t *testing.T) {
+	const actualBudget uint64 = 1_000_000
+	actual := storetypes.NewGasMeter(actualBudget)
+	meter := newStandardMsgSendGasMeter(actual)
+	standardMeter, ok := meter.(*standardMsgSendGasMeter)
+	require.True(t, ok)
+
+	require.Equal(t, StandardMsgSendGas, uint64(meter.GasConsumed()))
+	require.Equal(t, StandardMsgSendGas, uint64(meter.GasConsumedToLimit()))
+	require.Equal(t, StandardMsgSendGas, uint64(meter.Limit()))
+	require.Equal(t, actualBudget, uint64(meter.GasRemaining()))
+	require.Zero(t, standardMeter.actualGasConsumed())
+	require.False(t, meter.IsOutOfGas())
+	require.False(t, meter.IsPastLimit())
+
+	meter.ConsumeGas(1_000, "bounded work")
+	require.Equal(t, uint64(1_000), uint64(standardMeter.actualGasConsumed()))
+	require.Equal(t, StandardMsgSendGas, uint64(meter.GasConsumed()))
+	require.Equal(t, actualBudget-1_000, uint64(meter.GasRemaining()))
+
+	meter.RefundGas(400, "bounded refund")
+	require.Equal(t, uint64(600), uint64(standardMeter.actualGasConsumed()))
+	require.Contains(t, meter.String(), "public: 21000")
+}
+
+func TestStandardMsgSendGasDecoratorAllowsPostClassifyWorkWithoutInternalCap(t *testing.T) {
+	configureRouterEVM(t)
+
+	codec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x66}, 20))
+	tx := newStandardMsgSendTestTx(t, codec, payer)
+	keeper := &standardMsgSendAccountKeeper{addressCodec: codec}
+	originalMeter := storetypes.NewGasMeter(123)
+	originalMeter.ConsumeGas(123, "pre-classification")
+	ctx := routerContext(false).
+		WithGasMeter(originalMeter).
+		WithTxBytes([]byte{0x01})
+	nextCalled := false
+
+	newCtx, err := NewStandardMsgSendGasDecorator(keeper).AnteHandle(
+		ctx,
+		tx,
+		false,
+		func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			nextCalled = true
+			ctx.GasMeter().ConsumeGas(10_000, "post-classify work")
+			return ctx, nil
+		},
+	)
+
+	require.True(t, nextCalled)
+	require.NoError(t, err)
+	standardMeter, ok := newCtx.GasMeter().(*standardMsgSendGasMeter)
+	require.True(t, ok)
+	require.Equal(t, StandardMsgSendGas, uint64(newCtx.GasMeter().GasConsumed()))
+	require.Equal(t, StandardMsgSendGas, uint64(newCtx.GasMeter().GasConsumedToLimit()))
+	require.Equal(t, StandardMsgSendGas, uint64(newCtx.GasMeter().Limit()))
+	require.Equal(t, uint64(10_123), uint64(standardMeter.actualGasConsumed()))
+	require.False(t, newCtx.GasMeter().IsOutOfGas())
+	require.False(t, newCtx.GasMeter().IsPastLimit())
+}
+
+type standardMsgSendAccountKeeper struct {
+	authante.AccountKeeper
+	addressCodec coreaddress.Codec
+	account      sdk.AccountI
+}
+
+func (keeper *standardMsgSendAccountKeeper) AddressCodec() coreaddress.Codec {
+	return keeper.addressCodec
+}
+
+func (keeper *standardMsgSendAccountKeeper) GetAccount(context.Context, sdk.AccAddress) sdk.AccountI {
+	return keeper.account
+}
+
+type standardMsgSendTestTx struct {
+	msgs                  []sdk.Msg
+	fee                   sdk.Coins
+	gas                   uint64
+	payer                 sdk.AccAddress
+	granter               sdk.AccAddress
+	memo                  string
+	unordered             bool
+	extensions            []*codectypes.Any
+	nonCriticalExtensions []*codectypes.Any
+	signers               [][]byte
+	pubKeys               []cryptotypes.PubKey
+	signatures            []signing.SignatureV2
+	signersErr            error
+	pubKeysErr            error
+	signaturesErr         error
+}
+
+var (
+	_ authante.AccountKeeper         = (*standardMsgSendAccountKeeper)(nil)
+	_ sdk.FeeTx                      = standardMsgSendTestTx{}
+	_ sdk.TxWithMemo                 = standardMsgSendTestTx{}
+	_ sdk.TxWithUnordered            = standardMsgSendTestTx{}
+	_ authante.HasExtensionOptionsTx = standardMsgSendTestTx{}
+	_ authsigning.SigVerifiableTx    = standardMsgSendTestTx{}
+)
+
+func (tx standardMsgSendTestTx) GetMsgs() []sdk.Msg { return tx.msgs }
+
+func (standardMsgSendTestTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
+
+func (tx standardMsgSendTestTx) GetGas() uint64 { return tx.gas }
+
+func (tx standardMsgSendTestTx) GetFee() sdk.Coins { return tx.fee }
+
+func (tx standardMsgSendTestTx) FeePayer() []byte { return tx.payer }
+
+func (tx standardMsgSendTestTx) FeeGranter() []byte { return tx.granter }
+
+func (tx standardMsgSendTestTx) GetMemo() string { return tx.memo }
+
+func (tx standardMsgSendTestTx) GetUnordered() bool { return tx.unordered }
+
+func (standardMsgSendTestTx) GetTimeoutTimeStamp() (timestamp time.Time) { return timestamp }
+
+func (tx standardMsgSendTestTx) GetExtensionOptions() []*codectypes.Any { return tx.extensions }
+
+func (tx standardMsgSendTestTx) GetNonCriticalExtensionOptions() []*codectypes.Any {
+	return tx.nonCriticalExtensions
+}
+
+func (tx standardMsgSendTestTx) GetSigners() ([][]byte, error) {
+	return tx.signers, tx.signersErr
+}
+
+func (tx standardMsgSendTestTx) GetPubKeys() ([]cryptotypes.PubKey, error) {
+	return tx.pubKeys, tx.pubKeysErr
+}
+
+func (tx standardMsgSendTestTx) GetSignaturesV2() ([]signing.SignatureV2, error) {
+	return tx.signatures, tx.signaturesErr
+}
+
+type standardMsgSendBareTx struct {
+	msgs []sdk.Msg
+}
+
+func (tx standardMsgSendBareTx) GetMsgs() []sdk.Msg { return tx.msgs }
+
+func (standardMsgSendBareTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
+
+func newStandardMsgSendTestTx(
+	t *testing.T,
+	codec coreaddress.Codec,
+	payer sdk.AccAddress,
+) standardMsgSendTestTx {
+	t.Helper()
+
+	from, err := codec.BytesToString(payer)
+	require.NoError(t, err)
+	to, err := codec.BytesToString(sdk.AccAddress(bytes.Repeat([]byte{0x77}, 20)))
+	require.NoError(t, err)
+	pubKey := standardMsgSendLeafKey(1)
+
+	return standardMsgSendTestTx{
+		msgs: []sdk.Msg{&banktypes.MsgSend{
+			FromAddress: from,
+			ToAddress:   to,
+			Amount:      sdk.NewCoins(sdk.NewInt64Coin("send-denom", 1)),
+		}},
+		fee:        sdk.NewCoins(sdk.NewInt64Coin(evmtypes.GetEVMCoinDenom(), 1)),
+		gas:        StandardMsgSendGas,
+		payer:      append(sdk.AccAddress(nil), payer...),
+		signers:    [][]byte{append([]byte(nil), payer...)},
+		pubKeys:    []cryptotypes.PubKey{pubKey},
+		signatures: []signing.SignatureV2{{PubKey: pubKey}},
+	}
+}
+
+func standardMsgSendLeafKey(index byte) cryptotypes.PubKey {
+	secret := append([]byte("standard-msgsend-key"), index)
+	return secp256k1.GenPrivKeyFromSecret(secret).PubKey()
+}
+
+func standardMsgSendLeafKeys(count int) []cryptotypes.PubKey {
+	keys := make([]cryptotypes.PubKey, count)
+	for index := range keys {
+		keys[index] = standardMsgSendLeafKey(byte(index + 1))
+	}
+	return keys
+}
+
+func standardMsgSendMultisig(leaves int) *cryptomultisig.LegacyAminoPubKey {
+	return cryptomultisig.NewLegacyAminoPubKey(leaves, standardMsgSendLeafKeys(leaves))
+}

--- a/app/blockstm_cosmos_virtual_fee_benchmark_test.go
+++ b/app/blockstm_cosmos_virtual_fee_benchmark_test.go
@@ -1,0 +1,600 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log/v2"
+	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/server"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
+	appparams "github.com/gurufinglobal/guru/v3/app/params"
+	constitutiontypes "github.com/gurufinglobal/guru/v3/x/constitution/types"
+	feepolicytypes "github.com/gurufinglobal/guru/v3/x/feepolicy/types"
+)
+
+const (
+	blockSTMCosmosFeeBenchmarkChainID = "guru-blockstm-cosmos-fee-benchmark-1"
+	blockSTMCosmosFeeBenchmarkTxEnv   = "GURU_BLOCKSTM_BENCH_TXS"
+	blockSTMCosmosFeeBenchmarkWorkEnv = "GURU_BLOCKSTM_BENCH_WORKERS"
+
+	blockSTMCosmosFeeBenchmarkDefaultTxs = 128
+	blockSTMCosmosFeeBenchmarkMaxTxs     = 20_000
+	blockSTMCosmosFeeBenchmarkGas        = uint64(200_000)
+	blockSTMCosmosFeeBenchmarkFee        = int64(200_000)
+	blockSTMCosmosFeeBenchmarkFunds      = int64(1_000_000_000_000_000_000)
+)
+
+type blockSTMCosmosFeeBenchmarkWorkload uint8
+
+const (
+	blockSTMCosmosFeeBenchmarkIndependent blockSTMCosmosFeeBenchmarkWorkload = iota
+	blockSTMCosmosFeeBenchmarkSameAccount
+)
+
+type blockSTMCosmosFeeBenchmarkAccount struct {
+	priv          *secp256k1.PrivKey
+	address       sdk.AccAddress
+	addressString string
+	accountNumber uint64
+}
+
+type blockSTMCosmosFeeBenchmarkFixture struct {
+	app                 *App
+	payers              []blockSTMCosmosFeeBenchmarkAccount
+	recipients          []sdk.AccAddress
+	nextHeight          int64
+	startTime           time.Time
+	independentSequence uint64
+	sameAccountSequence uint64
+}
+
+// BenchmarkBlockSTMCosmosFeeCollection exercises the production BlockSTM,
+// FeePolicy, signed Cosmos transaction, FinalizeBlock, and Commit paths. The
+// exact same source file can be copied to an unpatched dev-v3 worktree to
+// compare normal fee collection with virtual fee collection.
+//
+// GURU_BLOCKSTM_BENCH_TXS controls transactions per block (default 128).
+// GURU_BLOCKSTM_BENCH_WORKERS controls BlockSTM workers (default min(10,
+// GOMAXPROCS)). For stable comparisons, pin GOMAXPROCS and run with a fixed
+// -benchtime count, for example:
+//
+//	GOMAXPROCS=10 GURU_BLOCKSTM_BENCH_TXS=1000 \
+//	  go test ./app -run '^$' -bench '^BenchmarkBlockSTMCosmosFeeCollection$' \
+//	  -benchmem -benchtime=10x -count=5
+func BenchmarkBlockSTMCosmosFeeCollection(b *testing.B) {
+	configureBlockSTMCosmosFeeBenchmarkPrefixes(b)
+
+	txCount := blockSTMCosmosFeeBenchmarkEnvInt(
+		b,
+		blockSTMCosmosFeeBenchmarkTxEnv,
+		blockSTMCosmosFeeBenchmarkDefaultTxs,
+		1,
+		blockSTMCosmosFeeBenchmarkMaxTxs,
+	)
+	defaultWorkers := runtime.GOMAXPROCS(0)
+	if defaultWorkers > 10 {
+		defaultWorkers = 10
+	}
+	workers := blockSTMCosmosFeeBenchmarkEnvInt(
+		b,
+		blockSTMCosmosFeeBenchmarkWorkEnv,
+		defaultWorkers,
+		1,
+		1_024,
+	)
+	fixture := newBlockSTMCosmosFeeBenchmarkFixture(b, txCount, workers)
+
+	for _, workload := range []struct {
+		name string
+		kind blockSTMCosmosFeeBenchmarkWorkload
+	}{
+		{name: "independent_payers", kind: blockSTMCosmosFeeBenchmarkIndependent},
+		{name: "same_account", kind: blockSTMCosmosFeeBenchmarkSameAccount},
+	} {
+		b.Run(fmt.Sprintf("%s/txs_%d/workers_%d", workload.name, txCount, workers), func(b *testing.B) {
+			blockSTMCosmosFeeBenchmarkRun(b, fixture, workload.kind, txCount)
+		})
+	}
+}
+
+func blockSTMCosmosFeeBenchmarkRun(
+	b *testing.B,
+	fixture *blockSTMCosmosFeeBenchmarkFixture,
+	workload blockSTMCosmosFeeBenchmarkWorkload,
+	txCount int,
+) {
+	b.Helper()
+
+	blocks := make([][][]byte, b.N)
+	for blockIndex := 0; blockIndex < b.N; blockIndex++ {
+		blocks[blockIndex] = fixture.signedBlock(b, workload, txCount, blockIndex)
+	}
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var finalizeDuration, commitDuration time.Duration
+	for blockIndex := 0; blockIndex < b.N; blockIndex++ {
+		finalizeStarted := time.Now()
+		response, err := fixture.app.FinalizeBlock(&abci.RequestFinalizeBlock{
+			Height: fixture.nextHeight,
+			Time:   fixture.startTime.Add(time.Duration(fixture.nextHeight) * time.Second),
+			Txs:    blocks[blockIndex],
+		})
+		finalizeDuration += time.Since(finalizeStarted)
+		if err != nil {
+			b.Fatalf("FinalizeBlock at height %d: %v", fixture.nextHeight, err)
+		}
+		if len(response.TxResults) != txCount {
+			b.Fatalf("FinalizeBlock returned %d results, want %d", len(response.TxResults), txCount)
+		}
+		for txIndex, result := range response.TxResults {
+			if result.Code != abci.CodeTypeOK {
+				b.Fatalf("tx %d at height %d failed with code %d: %s", txIndex, fixture.nextHeight, result.Code, result.Log)
+			}
+		}
+
+		commitStarted := time.Now()
+		if _, err := fixture.app.Commit(); err != nil {
+			b.Fatalf("Commit at height %d: %v", fixture.nextHeight, err)
+		}
+		commitDuration += time.Since(commitStarted)
+		fixture.nextHeight++
+	}
+
+	b.StopTimer()
+	runtime.ReadMemStats(&after)
+	totalTxs := float64(b.N * txCount)
+	totalDuration := finalizeDuration + commitDuration
+	b.ReportMetric(float64(totalDuration.Nanoseconds())/totalTxs, "ns/tx")
+	b.ReportMetric(float64(finalizeDuration.Nanoseconds())/totalTxs, "finalize_ns/tx")
+	b.ReportMetric(float64(commitDuration.Nanoseconds())/totalTxs, "commit_ns/tx")
+	b.ReportMetric(totalTxs/totalDuration.Seconds(), "tx/s")
+	b.ReportMetric(float64(after.Mallocs-before.Mallocs)/totalTxs, "allocs/tx")
+	b.ReportMetric(float64(after.TotalAlloc-before.TotalAlloc)/totalTxs, "B/tx")
+	if workload == blockSTMCosmosFeeBenchmarkIndependent {
+		fixture.independentSequence += uint64(b.N)
+	} else {
+		fixture.sameAccountSequence += uint64(b.N * txCount)
+	}
+}
+
+func newBlockSTMCosmosFeeBenchmarkFixture(
+	b *testing.B,
+	txCount int,
+	workers int,
+) *blockSTMCosmosFeeBenchmarkFixture {
+	b.Helper()
+
+	// One extra payer is reserved for the same-account workload. Keeping both
+	// workloads in one App avoids relying on Cosmos EVM's test-only global reset
+	// hooks and also keeps the benchmark command valid without custom build tags.
+	payerCount := txCount + 1
+	payers := make([]blockSTMCosmosFeeBenchmarkAccount, payerCount)
+	for i := range payers {
+		payers[i] = newBlockSTMCosmosFeeBenchmarkAccount(b, "payer", i, uint64(i))
+	}
+	recipients := make([]sdk.AccAddress, txCount)
+	for i := range recipients {
+		recipients[i] = newBlockSTMCosmosFeeBenchmarkAccount(b, "recipient", i, 0).address
+	}
+
+	options := simtestutil.AppOptionsMap{
+		"oracle.enabled":               false,
+		server.FlagMempoolMaxTxs:       -1,
+		server.FlagBlockExecutor:       serverconfig.BlockExecutorBlockSTM,
+		server.FlagBlockSTMWorkers:     workers,
+		server.FlagBlockSTMPreEstimate: true,
+	}
+	testApp := NewApp(
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		true,
+		options,
+		baseapp.SetChainID(blockSTMCosmosFeeBenchmarkChainID),
+	)
+	b.Cleanup(func() {
+		if err := testApp.Close(); err != nil {
+			b.Errorf("close benchmark app: %v", err)
+		}
+	})
+
+	fixture := &blockSTMCosmosFeeBenchmarkFixture{
+		app:        testApp,
+		payers:     payers,
+		recipients: recipients,
+		nextHeight: 2,
+		startTime:  time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+	}
+	genesis := testApp.BuildChainDefaultGenesis()
+	fixture.setConstitutionGenesis(b, genesis)
+	fixture.setAuthGenesis(b, genesis)
+	fixture.setStakingGenesis(b, genesis)
+	fixture.setBankGenesis(b, genesis)
+	fixture.setFeeMarketGenesis(b, genesis)
+	fixture.setMintGenesis(b, genesis)
+	fixture.setFeePolicyGenesis(b, genesis)
+	if err := testApp.ValidateChainGenesis(genesis); err != nil {
+		b.Fatalf("validate benchmark genesis: %v", err)
+	}
+
+	appState, err := json.Marshal(genesis)
+	if err != nil {
+		b.Fatalf("marshal benchmark genesis: %v", err)
+	}
+	if _, err := testApp.InitChain(&abci.RequestInitChain{
+		ChainId:         blockSTMCosmosFeeBenchmarkChainID,
+		InitialHeight:   1,
+		Time:            fixture.startTime,
+		AppStateBytes:   appState,
+		ConsensusParams: simtestutil.DefaultConsensusParams,
+	}); err != nil {
+		b.Fatalf("InitChain benchmark app: %v", err)
+	}
+	initialBlock, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: 1,
+		Time:   fixture.startTime.Add(time.Second),
+	})
+	if err != nil {
+		b.Fatalf("initial FinalizeBlock: %v", err)
+	}
+	if len(initialBlock.TxResults) != 0 {
+		b.Fatalf("initial FinalizeBlock returned %d tx results", len(initialBlock.TxResults))
+	}
+	if _, err := testApp.Commit(); err != nil {
+		b.Fatalf("initial Commit: %v", err)
+	}
+
+	return fixture
+}
+
+func newBlockSTMCosmosFeeBenchmarkAccount(
+	b *testing.B,
+	role string,
+	index int,
+	accountNumber uint64,
+) blockSTMCosmosFeeBenchmarkAccount {
+	b.Helper()
+
+	priv := secp256k1.GenPrivKeyFromSecret([]byte(fmt.Sprintf(
+		"%s/%s/%d",
+		blockSTMCosmosFeeBenchmarkChainID,
+		role,
+		index,
+	)))
+	address := sdk.AccAddress(priv.PubKey().Address())
+	addressString, err := sdk.Bech32ifyAddressBytes(appparams.Bech32PrefixAccAddr, address)
+	if err != nil {
+		b.Fatalf("encode %s %d address: %v", role, index, err)
+	}
+	return blockSTMCosmosFeeBenchmarkAccount{
+		priv:          priv,
+		address:       address,
+		addressString: addressString,
+		accountNumber: accountNumber,
+	}
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setConstitutionGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := &constitutiontypes.GenesisState{}
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[constitutiontypes.ModuleName], state)
+	state.BaseAddress = fixture.payers[0].addressString
+	state.ModeratorAddress = fixture.payers[0].addressString
+	genesis[constitutiontypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setAuthGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := authtypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[authtypes.ModuleName], state)
+	accounts := make(authtypes.GenesisAccounts, len(fixture.payers))
+	for i, payer := range fixture.payers {
+		accounts[i] = authtypes.NewBaseAccount(
+			payer.address,
+			payer.priv.PubKey(),
+			payer.accountNumber,
+			0,
+		)
+	}
+	state = authtypes.NewGenesisState(state.Params, accounts)
+	genesis[authtypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setStakingGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	bond := sdk.TokensFromConsensusPower(1, sdk.DefaultPowerReduction)
+	pubKey := simtestutil.CreateTestPubKeys(1)[0]
+	validatorBytes := sdk.ValAddress(pubKey.Address().Bytes())
+	validatorAddress, err := fixture.app.StakingKeeper.ValidatorAddressCodec().BytesToString(validatorBytes)
+	if err != nil {
+		b.Fatalf("encode benchmark validator address: %v", err)
+	}
+	validator, err := stakingtypes.NewValidator(
+		validatorAddress,
+		pubKey,
+		stakingtypes.Description{Moniker: "blockstm-cosmos-fee-benchmark-validator"},
+	)
+	if err != nil {
+		b.Fatalf("create benchmark validator: %v", err)
+	}
+	validator.Status = stakingtypes.Bonded
+	validator.Tokens = bond
+	validator.DelegatorShares = sdkmath.LegacyNewDecFromInt(bond)
+
+	delegatorAddress, err := fixture.app.AccountKeeper.AddressCodec().BytesToString(
+		sdk.AccAddress(validatorBytes),
+	)
+	if err != nil {
+		b.Fatalf("encode benchmark delegator address: %v", err)
+	}
+	state := stakingtypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[stakingtypes.ModuleName], state)
+	state.Validators = []stakingtypes.Validator{validator}
+	state.Delegations = []stakingtypes.Delegation{
+		stakingtypes.NewDelegation(
+			delegatorAddress,
+			validatorAddress,
+			sdkmath.LegacyNewDecFromInt(bond),
+		),
+	}
+	genesis[stakingtypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setBankGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := banktypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[banktypes.ModuleName], state)
+	state.Balances = make([]banktypes.Balance, 0, len(fixture.payers)+1)
+	for _, payer := range fixture.payers {
+		state.Balances = append(state.Balances, banktypes.Balance{
+			Address: payer.addressString,
+			Coins: sdk.NewCoins(sdk.NewInt64Coin(
+				appparams.BaseDenom,
+				blockSTMCosmosFeeBenchmarkFunds,
+			)),
+		})
+	}
+	bondedPoolAddress, err := fixture.app.AccountKeeper.AddressCodec().BytesToString(
+		authtypes.NewModuleAddress(stakingtypes.BondedPoolName),
+	)
+	if err != nil {
+		b.Fatalf("encode bonded pool address: %v", err)
+	}
+	state.Balances = append(state.Balances, banktypes.Balance{
+		Address: bondedPoolAddress,
+		Coins: sdk.NewCoins(sdk.NewCoin(
+			appparams.BaseDenom,
+			sdk.TokensFromConsensusPower(1, sdk.DefaultPowerReduction),
+		)),
+	})
+	state.Supply = nil
+	genesis[banktypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setMintGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := minttypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[minttypes.ModuleName], state)
+	state.Minter = minttypes.InitialMinter(sdkmath.LegacyZeroDec())
+	state.Params.InflationRateChange = sdkmath.LegacyZeroDec()
+	state.Params.InflationMax = sdkmath.LegacyZeroDec()
+	state.Params.InflationMin = sdkmath.LegacyZeroDec()
+	genesis[minttypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setFeeMarketGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := feemarkettypes.DefaultGenesisState()
+	fixture.app.AppCodec().MustUnmarshalJSON(genesis[feemarkettypes.ModuleName], state)
+	state.Params.NoBaseFee = true
+	state.Params.BaseFee = sdkmath.LegacyZeroDec()
+	state.Params.MinGasPrice = sdkmath.LegacyOneDec()
+	genesis[feemarkettypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) setFeePolicyGenesis(
+	b *testing.B,
+	genesis map[string]json.RawMessage,
+) {
+	b.Helper()
+
+	state := &feepolicytypes.GenesisState{
+		ModeratorAddress: fixture.payers[0].addressString,
+		Discounts: []feepolicytypes.AccountDiscount{
+			feePolicyTestBankSendDiscount(
+				"",
+				feepolicytypes.FeeDiscountTypeFixed,
+				sdkmath.LegacyNewDec(12_345),
+			),
+		},
+	}
+	genesis[feepolicytypes.ModuleName] = fixture.app.AppCodec().MustMarshalJSON(state)
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) signedBlock(
+	b *testing.B,
+	workload blockSTMCosmosFeeBenchmarkWorkload,
+	txCount int,
+	blockIndex int,
+) [][]byte {
+	b.Helper()
+
+	txs := make([][]byte, txCount)
+	for txIndex := 0; txIndex < txCount; txIndex++ {
+		payerIndex := txIndex
+		sequence := fixture.independentSequence + uint64(blockIndex)
+		if workload == blockSTMCosmosFeeBenchmarkSameAccount {
+			payerIndex = len(fixture.payers) - 1
+			sequence = fixture.sameAccountSequence + uint64(blockIndex*txCount+txIndex)
+		}
+		txs[txIndex] = fixture.signTx(
+			b,
+			fixture.payers[payerIndex],
+			fixture.recipients[txIndex],
+			sequence,
+		)
+	}
+	return txs
+}
+
+func (fixture *blockSTMCosmosFeeBenchmarkFixture) signTx(
+	b *testing.B,
+	signer blockSTMCosmosFeeBenchmarkAccount,
+	recipient sdk.AccAddress,
+	sequence uint64,
+) []byte {
+	b.Helper()
+
+	builder := fixture.app.TxConfig().NewTxBuilder()
+	msg := banktypes.NewMsgSend(
+		signer.address,
+		recipient,
+		sdk.NewCoins(sdk.NewInt64Coin(appparams.BaseDenom, 1)),
+	)
+	if err := builder.SetMsgs(msg); err != nil {
+		b.Fatalf("set MsgSend: %v", err)
+	}
+	builder.SetGasLimit(blockSTMCosmosFeeBenchmarkGas)
+	builder.SetFeeAmount(sdk.NewCoins(sdk.NewInt64Coin(
+		appparams.BaseDenom,
+		blockSTMCosmosFeeBenchmarkFee,
+	)))
+
+	signMode, err := authsigning.APISignModeToInternal(
+		fixture.app.TxConfig().SignModeHandler().DefaultMode(),
+	)
+	if err != nil {
+		b.Fatalf("resolve sign mode: %v", err)
+	}
+	signature := signing.SignatureV2{
+		PubKey: signer.priv.PubKey(),
+		Data: &signing.SingleSignatureData{
+			SignMode: signMode,
+		},
+		Sequence: sequence,
+	}
+	if err := builder.SetSignatures(signature); err != nil {
+		b.Fatalf("set placeholder signature: %v", err)
+	}
+
+	signerData := authsigning.SignerData{
+		Address:       signer.addressString,
+		ChainID:       blockSTMCosmosFeeBenchmarkChainID,
+		AccountNumber: signer.accountNumber,
+		Sequence:      sequence,
+		PubKey:        signer.priv.PubKey(),
+	}
+	signBytes, err := authsigning.GetSignBytesAdapter(
+		context.Background(),
+		fixture.app.TxConfig().SignModeHandler(),
+		signMode,
+		signerData,
+		builder.GetTx(),
+	)
+	if err != nil {
+		b.Fatalf("build sign bytes: %v", err)
+	}
+	rawSignature, err := signer.priv.Sign(signBytes)
+	if err != nil {
+		b.Fatalf("sign transaction: %v", err)
+	}
+	signature.Data.(*signing.SingleSignatureData).Signature = rawSignature
+	if err := builder.SetSignatures(signature); err != nil {
+		b.Fatalf("set final signature: %v", err)
+	}
+
+	txBytes, err := fixture.app.TxConfig().TxEncoder()(builder.GetTx())
+	if err != nil {
+		b.Fatalf("encode transaction: %v", err)
+	}
+	return txBytes
+}
+
+func blockSTMCosmosFeeBenchmarkEnvInt(
+	b *testing.B,
+	name string,
+	defaultValue int,
+	minimum int,
+	maximum int,
+) int {
+	b.Helper()
+
+	raw := os.Getenv(name)
+	if raw == "" {
+		return defaultValue
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < minimum || value > maximum {
+		b.Fatalf("%s must be an integer in [%d, %d], got %q", name, minimum, maximum, raw)
+	}
+	return value
+}
+
+func configureBlockSTMCosmosFeeBenchmarkPrefixes(b *testing.B) {
+	b.Helper()
+
+	config := sdk.GetConfig()
+	accountAddress := config.GetBech32AccountAddrPrefix()
+	accountPubKey := config.GetBech32AccountPubPrefix()
+	validatorAddress := config.GetBech32ValidatorAddrPrefix()
+	validatorPubKey := config.GetBech32ValidatorPubPrefix()
+	consensusAddress := config.GetBech32ConsensusAddrPrefix()
+	consensusPubKey := config.GetBech32ConsensusPubPrefix()
+
+	config.SetBech32PrefixForAccount(appparams.Bech32PrefixAccAddr, appparams.Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(appparams.Bech32PrefixValAddr, appparams.Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(appparams.Bech32PrefixConsAddr, appparams.Bech32PrefixConsPub)
+	b.Cleanup(func() {
+		config.SetBech32PrefixForAccount(accountAddress, accountPubKey)
+		config.SetBech32PrefixForValidator(validatorAddress, validatorPubKey)
+		config.SetBech32PrefixForConsensusNode(consensusAddress, consensusPubKey)
+	})
+}

--- a/app/feepolicy_runtime_test.go
+++ b/app/feepolicy_runtime_test.go
@@ -100,6 +100,7 @@ type feePolicyRuntimeFixture struct {
 }
 
 type feePolicyRuntimeTxOptions struct {
+	gasLimit   uint64
 	feeGranter sdk.AccAddress
 	extension  *antetypes.ExtensionOptionDynamicFeeTx
 	corruptSig bool
@@ -389,10 +390,10 @@ func TestFeePolicyRuntimeDynamicTipIsNotDiscounted(t *testing.T) {
 		},
 	}))
 
-	// With a 0.4/gas priority cap and 200,000 gas, the undiscounted tip is
-	// 80,000. The global fixed policy changes only the positive base component
-	// to 12,345, so the actual fee must be 92,345 rather than 12,345.
-	const expectedActualFee = int64(92_345)
+	// The standardized 21,000-gas projection applies before fee accounting.
+	// With a 0.4/gas priority cap and fixed global discount of 12,345, the
+	// resulting charged fee is 15,750.
+	const expectedActualFee = int64(15_750)
 	require.Equal(t, abci.CodeTypeOK, result.Code, result.Log)
 	fixture.requireCommittedState(
 		t,
@@ -772,7 +773,11 @@ func (fixture *feePolicyRuntimeFixture) signTxWithFee(
 
 	builder := fixture.app.TxConfig().NewTxBuilder()
 	require.NoError(t, builder.SetMsgs(msgs...))
-	builder.SetGasLimit(feePolicyRuntimeGas)
+	gasLimit := feePolicyRuntimeGas
+	if options.gasLimit > 0 {
+		gasLimit = options.gasLimit
+	}
+	builder.SetGasLimit(gasLimit)
 	builder.SetFeeAmount(fee)
 	if options.feeGranter != nil {
 		builder.SetFeeGranter(options.feeGranter)

--- a/app/mempool.go
+++ b/app/mempool.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/log/v2"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 	evmmempool "github.com/cosmos/evm/mempool"
 	evmserver "github.com/cosmos/evm/server"
@@ -54,12 +55,16 @@ func (app *App) configureEVMMempool(appOpts servertypes.AppOptions, logger log.L
 		evmMempool,
 		NewNoCheckProposalTxVerifier(app.BaseApp),
 	)
+	proposalHandler.SetTxSelector(newStandardMsgSendTxSelector())
 	proposalHandler.SetSignerExtractionAdapter(
 		evmmempool.NewEthSignerExtractionAdapter(
 			sdkmempool.NewDefaultSignerExtractionAdapter(),
 		),
 	)
-	app.configureOracleProposalHandler(proposalHandler)
+	app.configureOracleProposalHandler(
+		proposalHandler.PrepareProposalHandler(),
+		app.standardMsgSendProcessProposal(proposalHandler.ProcessProposalHandler()),
+	)
 
 	txDecoder := app.txConfig.TxDecoder()
 	app.SetInsertTxHandler(evmMempool.NewInsertTxHandler(txDecoder))
@@ -75,18 +80,25 @@ func (app *App) configureEVMMempool(appOpts servertypes.AppOptions, logger log.L
 }
 
 func (app *App) configureNoOpOracleProposalHandler() {
-	app.configureOracleProposalHandler(baseapp.NewDefaultProposalHandler(
+	proposalHandler := baseapp.NewDefaultProposalHandler(
 		sdkmempool.NoOpMempool{},
 		NewNoCheckProposalTxVerifier(app.BaseApp),
-	))
+	)
+	app.configureOracleProposalHandler(
+		proposalHandler.PrepareProposalHandler(),
+		app.standardMsgSendProcessProposal(proposalHandler.ProcessProposalHandler()),
+	)
 }
 
-func (app *App) configureOracleProposalHandler(proposalHandler *baseapp.DefaultProposalHandler) {
+func (app *App) configureOracleProposalHandler(
+	prepareProposalHandler sdk.PrepareProposalHandler,
+	processProposalHandler sdk.ProcessProposalHandler,
+) {
 	oracleAggregator := oracleabci.NewAggregator(app.OracleKeeper, app.StakingKeeper)
 	oracleProposalHandler := oracleabci.NewProposalHandler(
 		oracleAggregator,
-		proposalHandler.PrepareProposalHandler(),
-		proposalHandler.ProcessProposalHandler(),
+		prepareProposalHandler,
+		processProposalHandler,
 	)
 
 	app.SetPrepareProposal(oracleProposalHandler.PrepareProposal)

--- a/app/standard_msgsend_gas_benchmark_test.go
+++ b/app/standard_msgsend_gas_benchmark_test.go
@@ -1,0 +1,428 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log/v2"
+	abci "github.com/cometbft/cometbft/abci/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/server"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	appante "github.com/gurufinglobal/guru/v3/app/ante"
+	appparams "github.com/gurufinglobal/guru/v3/app/params"
+	feepolicytypes "github.com/gurufinglobal/guru/v3/x/feepolicy/types"
+)
+
+const (
+	standardMsgSendGasBenchmarkTxEnv     = "GURU_STANDARD_MSGSEND_BENCH_TXS"
+	standardMsgSendGasBenchmarkWorkerEnv = "GURU_STANDARD_MSGSEND_BENCH_WORKERS"
+
+	standardMsgSendGasBenchmarkBlockGas     = 30_000_000
+	standardMsgSendGasBenchmarkDefaultTxs   = 32
+	standardMsgSendGasBenchmarkDefaultCPU   = 4
+	standardMsgSendGasBenchmarkAdmissionTxs = int(
+		standardMsgSendGasBenchmarkBlockGas / appante.StandardMsgSendGas,
+	)
+	standardMsgSendGasBenchmarkStressTxs = int(
+		standardMsgSendGasBenchmarkBlockGas / appante.StandardMsgSendGas,
+	)
+	standardMsgSendGasBenchmarkFee = int64(appante.StandardMsgSendGas)
+)
+
+type standardMsgSendGasBenchmarkTopology uint8
+
+const (
+	standardMsgSendGasBenchmarkIndependent standardMsgSendGasBenchmarkTopology = iota
+	standardMsgSendGasBenchmarkSharedRecipient
+)
+
+type standardMsgSendGasBenchmarkFixture struct {
+	base                  *blockSTMCosmosFeeBenchmarkFixture
+	signers               []blockSTMCosmosFeeBenchmarkAccount
+	independentRecipients []sdk.AccAddress
+	sharedRecipient       sdk.AccAddress
+	nextSequence          uint64
+}
+
+// BenchmarkStandardMsgSendGasBlockSTM measures the production signed Cosmos
+// transaction -> BlockSTM FinalizeBlock -> Commit path for the bounded 21k
+// MsgSend class. Its genesis contains no payer-specific or global FeePolicy
+// record, and every transaction is a single-denom MsgSend with exactly 21k
+// declared gas and no feegranter, memo, or extension option.
+//
+// The two topologies reuse the same independently signed payers. All recipients
+// are pre-created at genesis so the only intended topology difference is the
+// bank recipient key: one distinct key per transaction versus one shared key.
+// Production proposal admission charges the standardized 21k per candidate, so a
+// 30M-gas block admits at most 1,428 of these transactions. A 1,428-transaction
+// run is
+// deliberately retained only as a direct-FinalizeBlock red-team workload that
+// bypasses PrepareProposal/ProcessProposal; it is not a consensus-valid merge
+// gate for the implemented admission contract. The smaller default keeps
+// ordinary benchmark discovery inexpensive.
+//
+// Run the merge-gate measurement with a four-CPU affinity and a fixed iteration
+// count, for example (through the repository's required remote test runner):
+//
+//	/Users/kimhyunwoo/.codex/bin/idc-test -- taskset -c 0-3 env \
+//	  GOMAXPROCS=4 GURU_STANDARD_MSGSEND_BENCH_TXS=100 \
+//	  GURU_STANDARD_MSGSEND_BENCH_WORKERS=4 \
+//	  go test ./app -run '^$' -bench '^BenchmarkStandardMsgSendGasBlockSTM$' \
+//	  -benchmem -benchtime=1x -count=5
+func BenchmarkStandardMsgSendGasBlockSTM(b *testing.B) {
+	configureBlockSTMCosmosFeeBenchmarkPrefixes(b)
+
+	txCount := blockSTMCosmosFeeBenchmarkEnvInt(
+		b,
+		standardMsgSendGasBenchmarkTxEnv,
+		standardMsgSendGasBenchmarkDefaultTxs,
+		1,
+		standardMsgSendGasBenchmarkStressTxs,
+	)
+	workers := blockSTMCosmosFeeBenchmarkEnvInt(
+		b,
+		standardMsgSendGasBenchmarkWorkerEnv,
+		standardMsgSendGasBenchmarkDefaultCPU,
+		1,
+		standardMsgSendGasBenchmarkStressTxs,
+	)
+	if workers > runtime.GOMAXPROCS(0) {
+		b.Fatalf(
+			"%s=%d exceeds GOMAXPROCS=%d; pin at least as many execution slots as BlockSTM workers",
+			standardMsgSendGasBenchmarkWorkerEnv,
+			workers,
+			runtime.GOMAXPROCS(0),
+		)
+	}
+
+	fixture := newStandardMsgSendGasBenchmarkFixture(b, txCount, workers)
+	for _, topology := range []struct {
+		name string
+		kind standardMsgSendGasBenchmarkTopology
+	}{
+		{name: "independent_recipients", kind: standardMsgSendGasBenchmarkIndependent},
+		{name: "shared_recipient", kind: standardMsgSendGasBenchmarkSharedRecipient},
+	} {
+		b.Run(fmt.Sprintf("%s/txs_%d/workers_%d", topology.name, txCount, workers), func(b *testing.B) {
+			standardMsgSendGasBenchmarkRun(b, fixture, topology.kind, txCount)
+		})
+	}
+}
+
+func standardMsgSendGasBenchmarkRun(
+	b *testing.B,
+	fixture *standardMsgSendGasBenchmarkFixture,
+	topology standardMsgSendGasBenchmarkTopology,
+	txCount int,
+) {
+	b.Helper()
+
+	blocks := make([][][]byte, b.N)
+	var encodedBytes uint64
+	for blockIndex := 0; blockIndex < b.N; blockIndex++ {
+		blocks[blockIndex] = fixture.signedBlock(b, topology, txCount, blockIndex)
+		for _, txBytes := range blocks[blockIndex] {
+			encodedBytes += uint64(len(txBytes))
+		}
+	}
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var finalizeDuration, commitDuration time.Duration
+	for blockIndex := 0; blockIndex < b.N; blockIndex++ {
+		finalizeStarted := time.Now()
+		response, err := fixture.base.app.FinalizeBlock(&abci.RequestFinalizeBlock{
+			Height: fixture.base.nextHeight,
+			Time:   fixture.base.startTime.Add(time.Duration(fixture.base.nextHeight) * time.Second),
+			Txs:    blocks[blockIndex],
+		})
+		finalizeDuration += time.Since(finalizeStarted)
+		if err != nil {
+			b.Fatalf("FinalizeBlock at height %d: %v", fixture.base.nextHeight, err)
+		}
+		if len(response.TxResults) != txCount {
+			b.Fatalf("FinalizeBlock returned %d results, want %d", len(response.TxResults), txCount)
+		}
+		for txIndex, result := range response.TxResults {
+			if result.Code != abci.CodeTypeOK {
+				b.Fatalf(
+					"tx %d at height %d failed with code %d: %s",
+					txIndex,
+					fixture.base.nextHeight,
+					result.Code,
+					result.Log,
+				)
+			}
+			if result.GasWanted != standardMsgSendGasBenchmarkFee {
+				b.Fatalf(
+					"tx %d at height %d GasWanted=%d, want %d",
+					txIndex,
+					fixture.base.nextHeight,
+					result.GasWanted,
+					standardMsgSendGasBenchmarkFee,
+				)
+			}
+			if result.GasUsed != standardMsgSendGasBenchmarkFee {
+				b.Fatalf(
+					"tx %d at height %d GasUsed=%d, want %d",
+					txIndex,
+					fixture.base.nextHeight,
+					result.GasUsed,
+					standardMsgSendGasBenchmarkFee,
+				)
+			}
+		}
+
+		commitStarted := time.Now()
+		if _, err := fixture.base.app.Commit(); err != nil {
+			b.Fatalf("Commit at height %d: %v", fixture.base.nextHeight, err)
+		}
+		commitDuration += time.Since(commitStarted)
+		fixture.base.nextHeight++
+	}
+
+	b.StopTimer()
+	runtime.ReadMemStats(&after)
+	fixture.nextSequence += uint64(b.N)
+
+	totalTxs := float64(b.N * txCount)
+	totalDuration := finalizeDuration + commitDuration
+	b.ReportMetric(float64(totalDuration.Nanoseconds())/totalTxs, "ns/tx")
+	b.ReportMetric(float64(finalizeDuration.Nanoseconds())/totalTxs, "finalize_ns/tx")
+	b.ReportMetric(float64(commitDuration.Nanoseconds())/totalTxs, "commit_ns/tx")
+	b.ReportMetric(totalTxs/totalDuration.Seconds(), "tx/s")
+	b.ReportMetric(float64(encodedBytes)/totalTxs, "bytes/tx")
+	b.ReportMetric(float64(after.Mallocs-before.Mallocs)/totalTxs, "allocs/tx")
+	b.ReportMetric(float64(after.TotalAlloc-before.TotalAlloc)/totalTxs, "B/tx")
+}
+
+func newStandardMsgSendGasBenchmarkFixture(
+	b *testing.B,
+	txCount int,
+	workers int,
+) *standardMsgSendGasBenchmarkFixture {
+	b.Helper()
+
+	// Recipient auth accounts are initialized deliberately: this benchmark is
+	// about BlockSTM key topology, not the one-time cost of account creation.
+	allAccounts := make([]blockSTMCosmosFeeBenchmarkAccount, 0, 2*txCount+1)
+	signers := make([]blockSTMCosmosFeeBenchmarkAccount, txCount)
+	for i := range signers {
+		signers[i] = newBlockSTMCosmosFeeBenchmarkAccount(b, "standard-msgsend-payer", i, uint64(len(allAccounts)))
+		allAccounts = append(allAccounts, signers[i])
+	}
+
+	independentRecipients := make([]sdk.AccAddress, txCount)
+	for i := range independentRecipients {
+		recipient := newBlockSTMCosmosFeeBenchmarkAccount(
+			b,
+			"standard-msgsend-independent-recipient",
+			i,
+			uint64(len(allAccounts)),
+		)
+		allAccounts = append(allAccounts, recipient)
+		independentRecipients[i] = recipient.address
+	}
+	sharedRecipientAccount := newBlockSTMCosmosFeeBenchmarkAccount(
+		b,
+		"standard-msgsend-shared-recipient",
+		0,
+		uint64(len(allAccounts)),
+	)
+	allAccounts = append(allAccounts, sharedRecipientAccount)
+
+	options := simtestutil.AppOptionsMap{
+		"oracle.enabled":               false,
+		server.FlagMempoolMaxTxs:       -1,
+		server.FlagBlockExecutor:       serverconfig.BlockExecutorBlockSTM,
+		server.FlagBlockSTMWorkers:     workers,
+		server.FlagBlockSTMPreEstimate: true,
+	}
+	testApp := NewApp(
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		true,
+		options,
+		baseapp.SetChainID(blockSTMCosmosFeeBenchmarkChainID),
+	)
+	b.Cleanup(func() {
+		if err := testApp.Close(); err != nil {
+			b.Errorf("close standard MsgSend gas benchmark app: %v", err)
+		}
+	})
+
+	baseFixture := &blockSTMCosmosFeeBenchmarkFixture{
+		app:        testApp,
+		payers:     allAccounts,
+		nextHeight: 2,
+		startTime:  time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC),
+	}
+	fixture := &standardMsgSendGasBenchmarkFixture{
+		base:                  baseFixture,
+		signers:               signers,
+		independentRecipients: independentRecipients,
+		sharedRecipient:       sharedRecipientAccount.address,
+	}
+
+	genesis := testApp.BuildChainDefaultGenesis()
+	baseFixture.setConstitutionGenesis(b, genesis)
+	baseFixture.setAuthGenesis(b, genesis)
+	baseFixture.setStakingGenesis(b, genesis)
+	baseFixture.setBankGenesis(b, genesis)
+	baseFixture.setFeeMarketGenesis(b, genesis)
+	baseFixture.setMintGenesis(b, genesis)
+	// Explicitly keep both payer-specific and global FeePolicy records absent.
+	// The standardized class bypasses policy lookup regardless, but an empty
+	// genesis keeps the benchmark's state footprint unambiguous.
+	genesis[feepolicytypes.ModuleName] = testApp.AppCodec().MustMarshalJSON(
+		feepolicytypes.DefaultGenesisState(),
+	)
+	if err := testApp.ValidateChainGenesis(genesis); err != nil {
+		b.Fatalf("validate standard MsgSend gas benchmark genesis: %v", err)
+	}
+
+	appState, err := json.Marshal(genesis)
+	if err != nil {
+		b.Fatalf("marshal standard MsgSend gas benchmark genesis: %v", err)
+	}
+	consensusParams := *simtestutil.DefaultConsensusParams
+	blockParams := *consensusParams.Block
+	blockParams.MaxGas = int64(standardMsgSendGasBenchmarkBlockGas)
+	// Keep transaction bytes from becoming the limiting dimension in this
+	// gas-capacity benchmark. The measured bytes/tx metric remains visible.
+	blockParams.MaxBytes = int64(standardMsgSendGasBenchmarkBlockGas)
+	consensusParams.Block = &blockParams
+	if _, err := testApp.InitChain(&abci.RequestInitChain{
+		ChainId:         blockSTMCosmosFeeBenchmarkChainID,
+		InitialHeight:   1,
+		Time:            baseFixture.startTime,
+		AppStateBytes:   appState,
+		ConsensusParams: &consensusParams,
+	}); err != nil {
+		b.Fatalf("InitChain standard MsgSend gas benchmark app: %v", err)
+	}
+	initialBlock, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: 1,
+		Time:   baseFixture.startTime.Add(time.Second),
+	})
+	if err != nil {
+		b.Fatalf("initial FinalizeBlock: %v", err)
+	}
+	if len(initialBlock.TxResults) != 0 {
+		b.Fatalf("initial FinalizeBlock returned %d tx results", len(initialBlock.TxResults))
+	}
+	if _, err := testApp.Commit(); err != nil {
+		b.Fatalf("initial Commit: %v", err)
+	}
+
+	return fixture
+}
+
+func (fixture *standardMsgSendGasBenchmarkFixture) signedBlock(
+	b *testing.B,
+	topology standardMsgSendGasBenchmarkTopology,
+	txCount int,
+	blockIndex int,
+) [][]byte {
+	b.Helper()
+
+	txs := make([][]byte, txCount)
+	sequence := fixture.nextSequence + uint64(blockIndex)
+	for txIndex := 0; txIndex < txCount; txIndex++ {
+		recipient := fixture.sharedRecipient
+		if topology == standardMsgSendGasBenchmarkIndependent {
+			recipient = fixture.independentRecipients[txIndex]
+		}
+		txs[txIndex] = fixture.signTx(b, fixture.signers[txIndex], recipient, sequence)
+	}
+	return txs
+}
+
+func (fixture *standardMsgSendGasBenchmarkFixture) signTx(
+	b *testing.B,
+	signer blockSTMCosmosFeeBenchmarkAccount,
+	recipient sdk.AccAddress,
+	sequence uint64,
+) []byte {
+	b.Helper()
+
+	builder := fixture.base.app.TxConfig().NewTxBuilder()
+	msg := banktypes.NewMsgSend(
+		signer.address,
+		recipient,
+		sdk.NewCoins(sdk.NewInt64Coin(appparams.BaseDenom, 1)),
+	)
+	if err := builder.SetMsgs(msg); err != nil {
+		b.Fatalf("set standard MsgSend: %v", err)
+	}
+	builder.SetGasLimit(appante.StandardMsgSendGas)
+	builder.SetFeeAmount(sdk.NewCoins(sdk.NewInt64Coin(
+		appparams.BaseDenom,
+		standardMsgSendGasBenchmarkFee,
+	)))
+
+	signMode, err := authsigning.APISignModeToInternal(
+		fixture.base.app.TxConfig().SignModeHandler().DefaultMode(),
+	)
+	if err != nil {
+		b.Fatalf("resolve standard MsgSend sign mode: %v", err)
+	}
+	signature := signing.SignatureV2{
+		PubKey: signer.priv.PubKey(),
+		Data: &signing.SingleSignatureData{
+			SignMode: signMode,
+		},
+		Sequence: sequence,
+	}
+	if err := builder.SetSignatures(signature); err != nil {
+		b.Fatalf("set standard MsgSend placeholder signature: %v", err)
+	}
+
+	signerData := authsigning.SignerData{
+		Address:       signer.addressString,
+		ChainID:       blockSTMCosmosFeeBenchmarkChainID,
+		AccountNumber: signer.accountNumber,
+		Sequence:      sequence,
+		PubKey:        signer.priv.PubKey(),
+	}
+	signBytes, err := authsigning.GetSignBytesAdapter(
+		context.Background(),
+		fixture.base.app.TxConfig().SignModeHandler(),
+		signMode,
+		signerData,
+		builder.GetTx(),
+	)
+	if err != nil {
+		b.Fatalf("build standard MsgSend sign bytes: %v", err)
+	}
+	rawSignature, err := signer.priv.Sign(signBytes)
+	if err != nil {
+		b.Fatalf("sign standard MsgSend transaction: %v", err)
+	}
+	signature.Data.(*signing.SingleSignatureData).Signature = rawSignature
+	if err := builder.SetSignatures(signature); err != nil {
+		b.Fatalf("set standard MsgSend final signature: %v", err)
+	}
+
+	txBytes, err := fixture.base.app.TxConfig().TxEncoder()(builder.GetTx())
+	if err != nil {
+		b.Fatalf("encode standard MsgSend transaction: %v", err)
+	}
+	return txBytes
+}

--- a/app/standard_msgsend_gas_runtime_test.go
+++ b/app/standard_msgsend_gas_runtime_test.go
@@ -1,0 +1,193 @@
+package app
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	antetypes "github.com/cosmos/evm/ante/types"
+
+	appante "github.com/gurufinglobal/guru/v3/app/ante"
+	appparams "github.com/gurufinglobal/guru/v3/app/params"
+)
+
+const standardMsgSendGasRuntimeWorkerEnv = "GURU_STANDARD_MSGSEND_RUNTIME_WORKER"
+
+func TestStandardMsgSendGasRuntimeContract(t *testing.T) {
+	if !runFeePolicyRuntimeWorker(t, standardMsgSendGasRuntimeWorkerEnv) {
+		return
+	}
+
+	fixture := newFeePolicyRuntimeFixture(t, feePolicyRuntimeGenesisOptions{
+		noBaseFee:   true,
+		baseFee:     sdkmath.LegacyZeroDec(),
+		minGasPrice: sdkmath.LegacyOneDec(),
+	})
+	recipient := fixture.actor(feePolicyActorRecipient)
+
+	t.Run("simulation check and finalize expose 21k with account FeePolicy applied", func(t *testing.T) {
+		payer := fixture.actor(feePolicyActorNormal)
+		beforePayer := fixture.balance(payer.address)
+		beforeRecipient := fixture.balance(recipient.address)
+		beforeCollector := fixture.collectorBalance()
+		msg := banktypes.NewMsgSend(payer.address, recipient.address, feePolicyRuntimeCoins(1))
+		txBytes := fixture.signTxWithFee(
+			t,
+			payer,
+			[]sdk.Msg{msg},
+			feePolicyRuntimeCoins(int64(appante.StandardMsgSendGas)),
+			feePolicyRuntimeTxOptions{
+				gasLimit: appante.StandardMsgSendGas,
+			},
+		)
+
+		gasInfo, _, err := fixture.app.Simulate(txBytes)
+		require.NoError(t, err)
+		require.Equal(t, appante.StandardMsgSendGas, gasInfo.GasWanted)
+		require.Equal(t, appante.StandardMsgSendGas, gasInfo.GasUsed)
+
+		checkResult, err := fixture.app.CheckTx(&abci.RequestCheckTx{
+			Tx:   txBytes,
+			Type: abci.CheckTxType_New,
+		})
+		require.NoError(t, err)
+		require.Equal(t, abci.CodeTypeOK, checkResult.Code, checkResult.Log)
+		require.Equal(t, int64(appante.StandardMsgSendGas), checkResult.GasWanted)
+		require.Equal(t, int64(appante.StandardMsgSendGas), checkResult.GasUsed)
+
+		result := fixture.finalize(t, txBytes)
+		require.Equal(t, abci.CodeTypeOK, result.Code, result.Log)
+		require.Equal(t, int64(appante.StandardMsgSendGas), result.GasWanted)
+		require.Equal(t, int64(appante.StandardMsgSendGas), result.GasUsed)
+		requireIntEqual(t, beforePayer.SubRaw(15_751), fixture.balance(payer.address))
+		requireIntEqual(t, beforeRecipient.AddRaw(1), fixture.balance(recipient.address))
+		requireIntEqual(t, beforeCollector.AddRaw(15_750), fixture.collectorBalance())
+		require.Equal(t, uint64(1), fixture.sequence(payer.address))
+		fixture.requireFeeEvent(t, result, 15_750, payer.addressString)
+	})
+
+	t.Run("dynamic fee extension remains in the bounded class", func(t *testing.T) {
+		payer := fixture.actor(feePolicyActorDynamic)
+		beforePayer := fixture.balance(payer.address)
+		beforeRecipient := fixture.balance(recipient.address)
+		msg := banktypes.NewMsgSend(payer.address, recipient.address, feePolicyRuntimeCoins(1))
+		txBytes := fixture.signTxWithFee(
+			t,
+			payer,
+			[]sdk.Msg{msg},
+			feePolicyRuntimeCoins(int64(appante.StandardMsgSendGas)),
+			feePolicyRuntimeTxOptions{
+				gasLimit: appante.StandardMsgSendGas,
+				extension: &antetypes.ExtensionOptionDynamicFeeTx{
+					MaxPriorityPrice: sdkmath.LegacyOneDec(),
+				},
+			},
+		)
+
+		result := fixture.finalize(t, txBytes)
+		require.Equal(t, abci.CodeTypeOK, result.Code, result.Log)
+		require.Equal(t, int64(appante.StandardMsgSendGas), result.GasWanted)
+		require.Equal(t, int64(appante.StandardMsgSendGas), result.GasUsed)
+		requireIntEqual(t, beforePayer.SubRaw(12_346), fixture.balance(payer.address))
+		requireIntEqual(t, beforeRecipient.AddRaw(1), fixture.balance(recipient.address))
+		requireIntEqual(t, sdkmath.NewInt(12_345), fixture.collectorBalance())
+		fixture.requireFeeEvent(t, result, 12_345, payer.addressString)
+	})
+
+	t.Run("new recipient account remains eligible", func(t *testing.T) {
+		payer := fixture.actor(feePolicyActorBoundary)
+		newRecipient := sdk.AccAddress([]byte("standard-new-recipient"))
+		beforePayer := fixture.balance(payer.address)
+		require.Nil(t, fixture.app.AccountKeeper.GetAccount(fixture.committedContext(), newRecipient))
+		msg := banktypes.NewMsgSend(payer.address, newRecipient, feePolicyRuntimeCoins(1))
+		result := fixture.finalize(t, fixture.signTxWithFee(
+			t,
+			payer,
+			[]sdk.Msg{msg},
+			feePolicyRuntimeCoins(int64(appante.StandardMsgSendGas)),
+			feePolicyRuntimeTxOptions{
+				gasLimit: appante.StandardMsgSendGas,
+			},
+		))
+
+		require.Equal(t, abci.CodeTypeOK, result.Code, result.Log)
+		require.Equal(t, int64(appante.StandardMsgSendGas), result.GasUsed)
+		requireIntEqual(t, beforePayer.SubRaw(15_751), fixture.balance(payer.address))
+		requireIntEqual(t, sdkmath.OneInt(), fixture.app.BankKeeper.GetBalance(
+			fixture.committedContext(),
+			newRecipient,
+			appparams.BaseDenom,
+		).Amount)
+		requireIntEqual(t, sdkmath.NewInt(15_750), fixture.collectorBalance())
+		require.NotNil(t, fixture.app.AccountKeeper.GetAccount(fixture.committedContext(), newRecipient))
+	})
+
+	t.Run("message failure commits fee and sequence but rolls back send", func(t *testing.T) {
+		payer := fixture.actor(feePolicyActorZero)
+		beforePayer := fixture.balance(payer.address)
+		beforeRecipient := fixture.balance(recipient.address)
+		msg := banktypes.NewMsgSend(
+			payer.address,
+			recipient.address,
+			feePolicyRuntimeCoins(feePolicyRuntimeInitialFunds+1),
+		)
+		result := fixture.finalize(t, fixture.signTxWithFee(
+			t,
+			payer,
+			[]sdk.Msg{msg},
+			feePolicyRuntimeCoins(int64(appante.StandardMsgSendGas)),
+			feePolicyRuntimeTxOptions{
+				gasLimit: appante.StandardMsgSendGas,
+			},
+		))
+
+		require.NotEqual(t, abci.CodeTypeOK, result.Code)
+		require.Contains(t, result.Log, "insufficient funds")
+		require.Equal(t, int64(appante.StandardMsgSendGas), result.GasWanted)
+		require.Equal(t, int64(appante.StandardMsgSendGas), result.GasUsed)
+		requireIntEqual(t, beforePayer, fixture.balance(payer.address))
+		requireIntEqual(t, beforeRecipient, fixture.balance(recipient.address))
+		requireIntEqual(t, sdkmath.ZeroInt(), fixture.collectorBalance())
+		require.Equal(t, uint64(1), fixture.sequence(payer.address))
+	})
+}
+
+func TestStandardMsgSendGasIgnoresInternalSafetyLimit(t *testing.T) {
+	if !runFeePolicyRuntimeWorker(t, standardMsgSendGasRuntimeWorkerEnv+"_OOG") {
+		return
+	}
+
+	fixture := newFeePolicyRuntimeFixture(t, feePolicyRuntimeGenesisOptions{
+		noBaseFee:   true,
+		baseFee:     sdkmath.LegacyZeroDec(),
+		minGasPrice: sdkmath.LegacyOneDec(),
+	})
+	payer := fixture.actor(feePolicyActorGrantSigPayer)
+	recipient := fixture.actor(feePolicyActorRecipient)
+	beforePayer := fixture.balance(payer.address)
+	beforeRecipient := fixture.balance(recipient.address)
+	beforeCollector := fixture.collectorBalance()
+	msg := banktypes.NewMsgSend(payer.address, recipient.address, feePolicyRuntimeCoins(1))
+	result := fixture.finalize(t, fixture.signTxWithFee(
+		t,
+		payer,
+		[]sdk.Msg{msg},
+		feePolicyRuntimeCoins(int64(appante.StandardMsgSendGas)),
+		feePolicyRuntimeTxOptions{
+			gasLimit: appante.StandardMsgSendGas,
+		},
+	))
+
+	require.Equal(t, abci.CodeTypeOK, result.Code, result.Log)
+	require.Equal(t, int64(appante.StandardMsgSendGas), result.GasWanted)
+	require.Equal(t, int64(appante.StandardMsgSendGas), result.GasUsed)
+	requireIntEqual(t, beforePayer.SubRaw(12_346), fixture.balance(payer.address))
+	requireIntEqual(t, beforeRecipient.AddRaw(1), fixture.balance(recipient.address))
+	requireIntEqual(t, beforeCollector.AddRaw(12_345), fixture.collectorBalance())
+	require.Equal(t, uint64(1), fixture.sequence(payer.address))
+	fixture.requireFeeEvent(t, result, 12_345, payer.addressString)
+}

--- a/app/standard_msgsend_maximize_simulation_test.go
+++ b/app/standard_msgsend_maximize_simulation_test.go
@@ -1,0 +1,253 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"strings"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	antetypes "github.com/cosmos/evm/ante/types"
+	appante "github.com/gurufinglobal/guru/v3/app/ante"
+	appparams "github.com/gurufinglobal/guru/v3/app/params"
+)
+
+func maxAmountCoins(
+	t *testing.T,
+	baseDenom string,
+	denomLen int,
+	memo string,
+	withExt bool,
+	fixedFeeDigits int,
+	maxPriorityPriceLen int,
+) (int, int) {
+	t.Helper()
+	const maxSdkIntDigits = 77
+	config := appparams.MakeEncodingConfig(
+		appparams.Bech32PrefixAccAddr,
+		appparams.Bech32PrefixValAddr,
+		appparams.Bech32PrefixConsAddr,
+	)
+	banktypes.RegisterInterfaces(config.InterfaceRegistry)
+
+	priv := secp256k1.GenPrivKeyFromSecret([]byte("standard-msgsend-max-simulation-key-01"))
+	sender := types.AccAddress(bytes.Repeat([]byte{0x11}, 20))
+	recipient := types.AccAddress(bytes.Repeat([]byte{0x22}, 20))
+	senderStr, err := types.Bech32ifyAddressBytes(appparams.Bech32PrefixAccAddr, sender)
+	if err != nil {
+		t.Fatalf("bech32 sender: %v", err)
+	}
+
+	build := func(amtDigits, feeDigits, priorityDigits int, withExt bool) (int, bool) {
+		denom := "a" + strings.Repeat("b", denomLen-1)
+		amount, ok := intWithDigits(amtDigits, maxSdkIntDigits)
+		if !ok {
+			return 0, false
+		}
+		feeAmount, ok := intWithDigits(feeDigits, maxSdkIntDigits)
+		if !ok {
+			return 0, false
+		}
+
+		builder := config.TxConfig.NewTxBuilder()
+		msg := banktypes.NewMsgSend(
+			sender,
+			recipient,
+			types.NewCoins(types.NewCoin(denom, amount)),
+		)
+		if err := builder.SetMsgs(msg); err != nil {
+			t.Fatalf("set msg: %v", err)
+		}
+		builder.SetGasLimit(appante.StandardMsgSendGas)
+		builder.SetFeeAmount(types.NewCoins(types.NewCoin(baseDenom, feeAmount)))
+		builder.SetMemo(memo)
+
+		if withExt {
+			priorityRaw, ok := intWithDigits(priorityDigits, maxSdkIntDigits)
+			if !ok {
+				return 0, false
+			}
+			priority := sdkmath.LegacyNewDecFromInt(priorityRaw)
+			ext, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{
+				MaxPriorityPrice: priority,
+			})
+			if err != nil {
+				t.Fatalf("pack ext: %v", err)
+			}
+			extBuilder, ok := builder.(authtx.ExtensionOptionsTxBuilder)
+			if !ok {
+				t.Fatalf("extension builder unsupported")
+			}
+			extBuilder.SetExtensionOptions(ext)
+		}
+
+		signMode, err := authsigning.APISignModeToInternal(config.TxConfig.SignModeHandler().DefaultMode())
+		if err != nil {
+			t.Fatalf("sign mode: %v", err)
+		}
+		sig := signing.SignatureV2{
+			PubKey: priv.PubKey(),
+			Data: &signing.SingleSignatureData{
+				SignMode: signMode,
+			},
+			Sequence: 0,
+		}
+		if err := builder.SetSignatures(sig); err != nil {
+			t.Fatalf("placeholder signature: %v", err)
+		}
+
+		signerData := authsigning.SignerData{
+			Address:       senderStr,
+			ChainID:       "sim-chain",
+			AccountNumber: 0,
+			Sequence:      0,
+			PubKey:        priv.PubKey(),
+		}
+		signBytes, err := authsigning.GetSignBytesAdapter(
+			context.Background(),
+			config.TxConfig.SignModeHandler(),
+			signMode,
+			signerData,
+			builder.GetTx(),
+		)
+		if err != nil {
+			t.Fatalf("sign bytes: %v", err)
+		}
+		rawSig, err := priv.Sign(signBytes)
+		if err != nil {
+			t.Fatalf("sign tx: %v", err)
+		}
+		sig.Data.(*signing.SingleSignatureData).Signature = rawSig
+		if err := builder.SetSignatures(sig); err != nil {
+			t.Fatalf("final signature: %v", err)
+		}
+
+		txBytes, err := config.TxConfig.TxEncoder()(builder.GetTx())
+		if err != nil {
+			t.Fatalf("encode tx: %v", err)
+		}
+		return len(txBytes), true
+	}
+
+	lo, hi := 1, maxSdkIntDigits
+	bestSize := 0
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		size, ok := build(mid, fixedFeeDigits, maxPriorityPriceLen, withExt)
+		if !ok {
+			hi = mid - 1
+			continue
+		}
+		bestSize = size
+		lo = mid + 1
+	}
+	return hi, bestSize
+}
+
+func intWithDigits(digits int, maxDigits int) (value sdkmath.Int, ok bool) {
+	ok = true
+	if digits < 1 || digits > maxDigits {
+		return sdkmath.Int{}, false
+	}
+	var base big.Int
+	base.Exp(big.NewInt(10), big.NewInt(int64(digits-1)), nil)
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	value = sdkmath.NewIntFromBigInt(&base)
+	return value, ok
+}
+
+func TestSimulateMaxMsgSendPayloadCurrentCaps(t *testing.T) {
+	configureFeePolicyTestBech32Prefixes(t, true)
+
+	baseDenom := appparams.BaseDenom
+
+	var memo strings.Builder
+	for i := 0; i < appante.StandardMsgSendMaxMemoBytes; i++ {
+		memo.WriteByte('m')
+	}
+	minMemo := ""
+
+	maxAmountNoMemoNoExt, maxSizeNoMemoNoExt := maxAmountCoins(t, baseDenom, 3, minMemo, false, 1, 1)
+	maxAmountWithMemoNoExt, maxSizeWithMemoNoExt := maxAmountCoins(t, baseDenom, 3, memo.String(), false, 1, 1)
+	maxAmountWithLongDenomNoExt, maxSizeWithLongDenomNoExt := maxAmountCoins(
+		t,
+		baseDenom,
+		128,
+		minMemo,
+		false,
+		1,
+		1,
+	)
+	maxAmountWithLongDenomAndMemoNoExt, maxSizeWithLongDenomAndMemoNoExt := maxAmountCoins(
+		t,
+		baseDenom,
+		128,
+		memo.String(),
+		false,
+		1,
+		1,
+	)
+	maxAmountNoMemoWithExt, maxSizeNoMemoWithExt := maxAmountCoins(t, baseDenom, 3, minMemo, true, 1, 77)
+	maxAmountWithMemoWithExt, maxSizeWithMemoWithExt := maxAmountCoins(t, baseDenom, 3, memo.String(), true, 1, 77)
+	maxAmountLongDenomWithMemoWithExt, maxSizeLongDenomWithMemoWithExt := maxAmountCoins(
+		t,
+		baseDenom,
+		128,
+		memo.String(),
+		true,
+		1,
+		77,
+	)
+
+	maxAmountNoMemoWithExtBigFee, maxSizeNoMemoWithExtBigFee := maxAmountCoins(
+		t,
+		baseDenom,
+		128,
+		minMemo,
+		true,
+		77,
+		77,
+	)
+	maxAmountWithMemoAndExtBigFee, maxSizeWithMemoAndExtBigFee := maxAmountCoins(
+		t,
+		baseDenom,
+		128,
+		memo.String(),
+		true,
+		77,
+		77,
+	)
+	maxAmountWithLongDenomAndMemoNoExtBigFee, maxSizeWithLongDenomAndMemoNoExtBigFee := maxAmountCoins(
+		t,
+		baseDenom,
+		128,
+		memo.String(),
+		false,
+		77,
+		77,
+	)
+
+	t.Logf("baseline max amount digits (denom min, memo=0, no ext): %d (tx size=%d)", maxAmountNoMemoNoExt, maxSizeNoMemoNoExt)
+	t.Logf("max amount digits (denom min, memo=256, no ext): %d (tx size=%d)", maxAmountWithMemoNoExt, maxSizeWithMemoNoExt)
+	t.Logf("max amount digits (denom 128, memo=0, no ext): %d (tx size=%d)", maxAmountWithLongDenomNoExt, maxSizeWithLongDenomNoExt)
+	t.Logf("max amount digits (denom 128, memo=256, no ext): %d (tx size=%d)", maxAmountWithLongDenomAndMemoNoExt, maxSizeWithLongDenomAndMemoNoExt)
+	t.Logf("max amount digits (denom min, memo=0, ext maxPriority 77): %d (tx size=%d)", maxAmountNoMemoWithExt, maxSizeNoMemoWithExt)
+	t.Logf("max amount digits (denom min, memo=256, ext maxPriority 77): %d (tx size=%d)", maxAmountWithMemoWithExt, maxSizeWithMemoWithExt)
+	t.Logf("max amount digits (denom 128, memo=256, ext maxPriority 77): %d (tx size=%d)", maxAmountLongDenomWithMemoWithExt, maxSizeLongDenomWithMemoWithExt)
+	t.Logf("max amount digits (denom 128, memo=0, ext maxPriority 77, fee 77 digits): %d (tx size=%d)", maxAmountNoMemoWithExtBigFee, maxSizeNoMemoWithExtBigFee)
+	t.Logf("max amount digits (denom 128, memo=256, no ext, fee 77 digits): %d (tx size=%d)", maxAmountWithLongDenomAndMemoNoExtBigFee, maxSizeWithLongDenomAndMemoNoExtBigFee)
+	t.Logf("max amount digits (denom 128, memo=256, ext maxPriority 77, fee 77 digits): %d (tx size=%d)", maxAmountWithMemoAndExtBigFee, maxSizeWithMemoAndExtBigFee)
+}

--- a/app/standard_msgsend_proposal.go
+++ b/app/standard_msgsend_proposal.go
@@ -1,0 +1,111 @@
+package app
+
+import (
+	"context"
+	"math"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	appante "github.com/gurufinglobal/guru/v3/app/ante"
+)
+
+// standardMsgSendTxSelector preserves the SDK byte-selection behavior while
+// reserving the public 21k standardized gas value for every
+// transaction-local candidate.
+type standardMsgSendTxSelector struct {
+	totalTxBytes uint64
+	totalTxGas   uint64
+	selectedTxs  [][]byte
+}
+
+var _ baseapp.TxSelector = (*standardMsgSendTxSelector)(nil)
+
+func newStandardMsgSendTxSelector() baseapp.TxSelector {
+	return &standardMsgSendTxSelector{}
+}
+
+func (s *standardMsgSendTxSelector) SelectedTxs(context.Context) [][]byte {
+	selected := make([][]byte, len(s.selectedTxs))
+	copy(selected, s.selectedTxs)
+	return selected
+}
+
+func (s *standardMsgSendTxSelector) Clear() {
+	s.totalTxBytes = 0
+	s.totalTxGas = 0
+	s.selectedTxs = nil
+}
+
+func (s *standardMsgSendTxSelector) SelectTxForProposal(
+	_ context.Context,
+	maxTxBytes uint64,
+	maxBlockGas uint64,
+	tx sdk.Tx,
+	txBytes []byte,
+) bool {
+	txSize := uint64(cmttypes.ComputeProtoSizeForTxs([]cmttypes.Tx{txBytes}))
+	gas := standardMsgSendProposalGas(tx, txBytes)
+
+	bytesFit := s.totalTxBytes <= maxTxBytes && txSize <= maxTxBytes-s.totalTxBytes
+	finiteConsensusGas := maxBlockGas > 0 && maxBlockGas <= math.MaxInt64
+	gasFit := true
+	if finiteConsensusGas {
+		gasFit = s.totalTxGas <= maxBlockGas && gas <= maxBlockGas-s.totalTxGas
+	}
+	if bytesFit && gasFit {
+		s.totalTxBytes += txSize
+		if gas <= math.MaxUint64-s.totalTxGas {
+			s.totalTxGas += gas
+		} else {
+			s.totalTxGas = math.MaxUint64
+		}
+		s.selectedTxs = append(s.selectedTxs, txBytes)
+	}
+
+	bytesFull := s.totalTxBytes >= maxTxBytes
+	gasFull := finiteConsensusGas && s.totalTxGas >= maxBlockGas
+	return bytesFull || gasFull
+}
+
+func standardMsgSendProposalGas(tx sdk.Tx, txBytes []byte) uint64 {
+	if appante.IsStandardMsgSendGasCandidate(tx, txBytes) {
+		return appante.StandardMsgSendGas
+	}
+	if gasTx, ok := tx.(interface{ GetGas() uint64 }); ok {
+		return gasTx.GetGas()
+	}
+	return 0
+}
+
+// standardMsgSendProcessProposal applies the standard 21k weight only when the
+// tx shape is recognized; ordinary txs keep their declared gas.
+func (app *App) standardMsgSendProcessProposal(next sdk.ProcessProposalHandler) sdk.ProcessProposalHandler {
+	return func(ctx sdk.Context, req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
+		blockParams := ctx.ConsensusParams().Block
+		finiteConsensusGas := blockParams != nil && blockParams.MaxGas > 0
+		maxGas := uint64(0)
+		if finiteConsensusGas {
+			maxGas = uint64(blockParams.MaxGas)
+		}
+		var totalGas uint64
+		for _, txBytes := range req.Txs {
+			tx, err := app.txConfig.TxDecoder()(txBytes)
+			if err != nil {
+				return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_REJECT}, nil
+			}
+			if !finiteConsensusGas {
+				continue
+			}
+			gas := standardMsgSendProposalGas(tx, txBytes)
+			if totalGas > maxGas || gas > maxGas-totalGas {
+				return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_REJECT}, nil
+			}
+			totalGas += gas
+		}
+
+		return next(ctx, req)
+	}
+}

--- a/app/standard_msgsend_proposal_test.go
+++ b/app/standard_msgsend_proposal_test.go
@@ -1,0 +1,384 @@
+package app
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+
+	appante "github.com/gurufinglobal/guru/v3/app/ante"
+	appparams "github.com/gurufinglobal/guru/v3/app/params"
+)
+
+func TestStandardMsgSendProposalGasUsesStandardizedGasForCandidates(t *testing.T) {
+	encoding := standardMsgSendProposalTestEncoding()
+	candidate, candidateBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		appante.StandardMsgSendGas,
+		sdk.NewCoins(sdk.NewInt64Coin("acandidate", 1)),
+	)
+	ordinary, ordinaryBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		500_000,
+		sdk.NewCoins(
+			sdk.NewInt64Coin("aordinary", 1),
+			sdk.NewInt64Coin("bordinary", 1),
+		),
+	)
+
+	require.True(t, appante.IsStandardMsgSendGasCandidate(candidate, candidateBytes))
+	require.Equal(t, uint64(appante.StandardMsgSendGas), standardMsgSendProposalGas(candidate, candidateBytes))
+	require.False(t, appante.IsStandardMsgSendGasCandidate(ordinary, ordinaryBytes))
+	require.Equal(t, uint64(500_000), standardMsgSendProposalGas(ordinary, ordinaryBytes))
+}
+
+func TestStandardMsgSendTxSelectorGasBoundaries(t *testing.T) {
+	encoding := standardMsgSendProposalTestEncoding()
+	candidate, candidateBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		appante.StandardMsgSendGas,
+		sdk.NewCoins(sdk.NewInt64Coin("acandidate", 1)),
+	)
+	ordinary, ordinaryBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		500_000,
+		sdk.NewCoins(
+			sdk.NewInt64Coin("aordinary", 1),
+			sdk.NewInt64Coin("bordinary", 1),
+		),
+	)
+
+	t.Run("599_999 admits at most 28 candidates", func(t *testing.T) {
+		selector := &standardMsgSendTxSelector{}
+		for i := 1; i <= 28; i++ {
+			require.False(t, selector.SelectTxForProposal(
+				context.Background(), math.MaxUint64, 599_999, candidate, candidateBytes,
+			))
+			require.Len(t, selector.SelectedTxs(context.Background()), i)
+		}
+		require.False(t, selector.SelectTxForProposal(
+			context.Background(), math.MaxUint64, 599_999, candidate, candidateBytes,
+		))
+		require.Len(t, selector.SelectedTxs(context.Background()), 28)
+		require.Equal(t, uint64(588_000), selector.totalTxGas)
+	})
+
+	t.Run("600_000 admits exactly 28 candidates", func(t *testing.T) {
+		selector := &standardMsgSendTxSelector{}
+		for i := 1; i <= 28; i++ {
+			require.False(t, selector.SelectTxForProposal(
+				context.Background(), math.MaxUint64, 600_000, candidate, candidateBytes,
+			))
+			require.Len(t, selector.SelectedTxs(context.Background()), i)
+		}
+		require.False(t, selector.SelectTxForProposal(
+			context.Background(), math.MaxUint64, 600_000, candidate, candidateBytes,
+		))
+		require.Len(t, selector.SelectedTxs(context.Background()), 28)
+		require.Equal(t, uint64(588_000), selector.totalTxGas)
+	})
+
+	t.Run("30M admits exactly 1428 candidates", func(t *testing.T) {
+		selector := &standardMsgSendTxSelector{}
+		for i := 1; i <= 1428; i++ {
+			require.False(t, selector.SelectTxForProposal(
+				context.Background(), math.MaxUint64, 30_000_000, candidate, candidateBytes,
+			))
+			require.Len(t, selector.SelectedTxs(context.Background()), i)
+		}
+		require.Len(t, selector.SelectedTxs(context.Background()), 1428)
+		require.Equal(t, uint64(29_988_000), selector.totalTxGas)
+
+		// A caller that probes after accepting all candidates cannot add a 1429th
+		// candidate.
+		require.False(t, selector.SelectTxForProposal(
+			context.Background(), math.MaxUint64, 30_000_000, candidate, candidateBytes,
+		))
+		require.Len(t, selector.SelectedTxs(context.Background()), 1428)
+	})
+
+	t.Run("ordinary transactions retain declared gas", func(t *testing.T) {
+		selector := &standardMsgSendTxSelector{}
+		require.False(t, selector.SelectTxForProposal(
+			context.Background(), math.MaxUint64, 499_999, ordinary, ordinaryBytes,
+		))
+		require.Empty(t, selector.SelectedTxs(context.Background()))
+
+		require.True(t, selector.SelectTxForProposal(
+			context.Background(), math.MaxUint64, 500_000, ordinary, ordinaryBytes,
+		))
+		require.Len(t, selector.SelectedTxs(context.Background()), 1)
+		require.Equal(t, uint64(500_000), selector.totalTxGas)
+	})
+
+	t.Run("zero and negative-one gas limits are byte-gated only", func(t *testing.T) {
+		signedUnlimited := int64(-1)
+		for _, maxGas := range []uint64{0, uint64(signedUnlimited)} {
+			selector := &standardMsgSendTxSelector{}
+			var accepted int
+			for i := 0; i < 2_000; i++ {
+				full := selector.SelectTxForProposal(
+					context.Background(), math.MaxUint64, maxGas, candidate, candidateBytes,
+				)
+				if full {
+					break
+				}
+				accepted++
+			}
+			require.GreaterOrEqual(t, accepted, 2_000)
+			require.Len(t, selector.SelectedTxs(context.Background()), 2_000)
+			require.Equal(t, uint64(42_000_000), selector.totalTxGas)
+			require.False(t, selector.SelectTxForProposal(
+				context.Background(), math.MaxUint64, maxGas, candidate, candidateBytes,
+			))
+			require.Len(t, selector.SelectedTxs(context.Background()), 2_001)
+			require.False(t, selector.SelectTxForProposal(
+				context.Background(), math.MaxUint64, maxGas, ordinary, ordinaryBytes,
+			))
+			require.Len(t, selector.SelectedTxs(context.Background()), 2_002)
+		}
+	})
+}
+
+func TestStandardMsgSendTxSelectorAccountsForProtoBytesAndClear(t *testing.T) {
+	encoding := standardMsgSendProposalTestEncoding()
+	candidate, candidateBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		appante.StandardMsgSendGas,
+		sdk.NewCoins(sdk.NewInt64Coin("acandidate", 1)),
+	)
+	oneTxBytes := uint64(cmttypes.ComputeProtoSizeForTxs([]cmttypes.Tx{candidateBytes}))
+	twoTxBytes := uint64(cmttypes.ComputeProtoSizeForTxs([]cmttypes.Tx{candidateBytes, candidateBytes}))
+	require.Equal(t, 2*oneTxBytes, twoTxBytes)
+
+	selector := &standardMsgSendTxSelector{}
+	require.False(t, selector.SelectTxForProposal(
+		context.Background(), twoTxBytes-1, 0, candidate, candidateBytes,
+	))
+	require.False(t, selector.SelectTxForProposal(
+		context.Background(), twoTxBytes-1, 0, candidate, candidateBytes,
+	))
+	require.Len(t, selector.SelectedTxs(context.Background()), 1)
+	require.Equal(t, oneTxBytes, selector.totalTxBytes)
+
+	selector.Clear()
+	require.Zero(t, selector.totalTxBytes)
+	require.Zero(t, selector.totalTxGas)
+	require.Nil(t, selector.selectedTxs)
+	require.Empty(t, selector.SelectedTxs(context.Background()))
+
+	require.False(t, selector.SelectTxForProposal(
+		context.Background(), twoTxBytes, 0, candidate, candidateBytes,
+	))
+	require.True(t, selector.SelectTxForProposal(
+		context.Background(), twoTxBytes, 0, candidate, candidateBytes,
+	))
+	require.Len(t, selector.SelectedTxs(context.Background()), 2)
+	require.Equal(t, twoTxBytes, selector.totalTxBytes)
+}
+
+func TestStandardMsgSendProcessProposalRejectsOverBudgetCustomProposal(t *testing.T) {
+	encoding := standardMsgSendProposalTestEncoding()
+	_, candidateBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		appante.StandardMsgSendGas,
+		sdk.NewCoins(sdk.NewInt64Coin("acandidate", 1)),
+	)
+	testApp := &App{txConfig: encoding.TxConfig}
+
+	innerCalls := 0
+	acceptingNoOp := func(_ sdk.Context, _ *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
+		innerCalls++
+		return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_ACCEPT}, nil
+	}
+	handler := testApp.standardMsgSendProcessProposal(acceptingNoOp)
+	ctx := standardMsgSendProposalContext(30_000_000)
+
+	accepted, err := handler(ctx, &abci.RequestProcessProposal{
+		Txs: standardMsgSendProposalRepeat(candidateBytes, 1428),
+	})
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, accepted.Status)
+	require.Equal(t, 1, innerCalls)
+
+	rejected, err := handler(ctx, &abci.RequestProcessProposal{
+		Txs: standardMsgSendProposalRepeat(candidateBytes, 1429),
+	})
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_REJECT, rejected.Status)
+	require.Equal(t, 1, innerCalls, "over-budget proposal must be rejected before a no-op inner handler")
+}
+
+func TestStandardMsgSendProcessProposalUsesOrdinaryDeclaredGas(t *testing.T) {
+	encoding := standardMsgSendProposalTestEncoding()
+	_, candidateBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		appante.StandardMsgSendGas,
+		sdk.NewCoins(sdk.NewInt64Coin("acandidate", 1)),
+	)
+	_, ordinaryBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		30_000_000,
+		sdk.NewCoins(
+			sdk.NewInt64Coin("aordinary", 1),
+			sdk.NewInt64Coin("bordinary", 1),
+		),
+	)
+	testApp := &App{txConfig: encoding.TxConfig}
+
+	innerCalls := 0
+	handler := testApp.standardMsgSendProcessProposal(func(
+		_ sdk.Context,
+		_ *abci.RequestProcessProposal,
+	) (*abci.ResponseProcessProposal, error) {
+		innerCalls++
+		return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_ACCEPT}, nil
+	})
+	txs := append(standardMsgSendProposalRepeat(candidateBytes, 1), ordinaryBytes)
+	response, err := handler(standardMsgSendProposalContext(30_000_000), &abci.RequestProcessProposal{Txs: txs})
+
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_REJECT, response.Status)
+	require.Zero(t, innerCalls)
+}
+
+func TestStandardMsgSendProcessProposalUnlimitedGasIsByteGatedOnly(t *testing.T) {
+	encoding := standardMsgSendProposalTestEncoding()
+	_, candidateBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		appante.StandardMsgSendGas,
+		sdk.NewCoins(sdk.NewInt64Coin("acandidate", 1)),
+	)
+	_, ordinaryBytes := standardMsgSendProposalTestTx(
+		t,
+		encoding,
+		500_000,
+		sdk.NewCoins(
+			sdk.NewInt64Coin("aordinary", 1),
+			sdk.NewInt64Coin("bordinary", 1),
+		),
+	)
+	testApp := &App{txConfig: encoding.TxConfig}
+
+	for _, maxGas := range []int64{0, -1} {
+		t.Run(standardMsgSendProposalMaxGasName(maxGas), func(t *testing.T) {
+			innerCalls := 0
+			handler := testApp.standardMsgSendProcessProposal(func(
+				_ sdk.Context,
+				_ *abci.RequestProcessProposal,
+			) (*abci.ResponseProcessProposal, error) {
+				innerCalls++
+				return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_ACCEPT}, nil
+			})
+
+			accepted, err := handler(
+				standardMsgSendProposalContext(maxGas),
+				&abci.RequestProcessProposal{Txs: standardMsgSendProposalRepeat(candidateBytes, 1024)},
+			)
+			require.NoError(t, err)
+			require.Equal(t, abci.ResponseProcessProposal_ACCEPT, accepted.Status)
+			require.Equal(t, 1, innerCalls)
+
+			accepted, err = handler(
+				standardMsgSendProposalContext(maxGas),
+				&abci.RequestProcessProposal{Txs: append(standardMsgSendProposalRepeat(candidateBytes, 1024), ordinaryBytes)},
+			)
+			require.NoError(t, err)
+			require.Equal(t, abci.ResponseProcessProposal_ACCEPT, accepted.Status)
+			require.Equal(t, 2, innerCalls)
+		})
+	}
+}
+
+func TestStandardMsgSendProcessProposalRejectsUndecodableTx(t *testing.T) {
+	encoding := standardMsgSendProposalTestEncoding()
+	testApp := &App{txConfig: encoding.TxConfig}
+	innerCalls := 0
+	handler := testApp.standardMsgSendProcessProposal(func(
+		_ sdk.Context,
+		_ *abci.RequestProcessProposal,
+	) (*abci.ResponseProcessProposal, error) {
+		innerCalls++
+		return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_ACCEPT}, nil
+	})
+
+	for _, maxGas := range []int64{30_000_000, 0, -1} {
+		response, err := handler(
+			standardMsgSendProposalContext(maxGas),
+			&abci.RequestProcessProposal{Txs: [][]byte{{0xff, 0x00}}},
+		)
+		require.NoError(t, err)
+		require.Equal(t, abci.ResponseProcessProposal_REJECT, response.Status)
+		require.Zero(t, innerCalls)
+	}
+}
+
+func standardMsgSendProposalTestEncoding() appparams.EncodingConfig {
+	encoding := appparams.MakeEncodingConfig(
+		appparams.Bech32PrefixAccAddr,
+		appparams.Bech32PrefixValAddr,
+		appparams.Bech32PrefixConsAddr,
+	)
+	banktypes.RegisterInterfaces(encoding.InterfaceRegistry)
+	return encoding
+}
+
+func standardMsgSendProposalTestTx(
+	t *testing.T,
+	encoding appparams.EncodingConfig,
+	gas uint64,
+	amount sdk.Coins,
+) (sdk.Tx, []byte) {
+	t.Helper()
+
+	builder := encoding.TxConfig.NewTxBuilder()
+	msg := banktypes.NewMsgSend(
+		sdk.AccAddress(make([]byte, 20)),
+		sdk.AccAddress(append([]byte{1}, make([]byte, 19)...)),
+		amount,
+	)
+	require.NoError(t, builder.SetMsgs(msg))
+	builder.SetGasLimit(gas)
+
+	txBytes, err := encoding.TxConfig.TxEncoder()(builder.GetTx())
+	require.NoError(t, err)
+	tx, err := encoding.TxConfig.TxDecoder()(txBytes)
+	require.NoError(t, err)
+	return tx, txBytes
+}
+
+func standardMsgSendProposalContext(maxGas int64) sdk.Context {
+	return sdk.Context{}.WithConsensusParams(cmtproto.ConsensusParams{
+		Block: &cmtproto.BlockParams{MaxGas: maxGas},
+	})
+}
+
+func standardMsgSendProposalRepeat(txBytes []byte, count int) [][]byte {
+	txs := make([][]byte, count)
+	for i := range txs {
+		txs[i] = txBytes
+	}
+	return txs
+}
+
+func standardMsgSendProposalMaxGasName(maxGas int64) string {
+	if maxGas < 0 {
+		return "negative_one"
+	}
+	return "zero"
+}


### PR DESCRIPTION
# Description

This PR standardizes Cosmos `MsgSend` gas handling so candidate `MsgSend` transactions are consistently treated as `21,000` gas across runtime paths, including checktx/finalize/fee handling and proposal processing.  
The goal is to remove fee mismatch risk and keep behavior deterministic between simulation, mempool admission, and proposal execution.

Key review targets:
- `app/ante/standard_msgsend_gas.go`
- `app/ante/standard_msgsend_proposal.go`
- `app/ante/cosmos_fees.go`
- `app/ante/cosmos.go`
- `app/mempool.go`
- `app/standard_msgsend_gas_runtime_test.go`
- `app/standard_msgsend_proposal_test.go`
- `app/standard_msgsend_gas_benchmark_test.go`
- `app/standard_msgsend_maximize_simulation_test.go`
- `app/feepolicy_runtime_test.go`

What changed:
- Added Standard MsgSend gas path (`StandardMsgSendGas`) and tx selector integration.
- Applied capped gas behavior consistently through fee meter logic for MsgSend candidates.
- Routed ProcessProposal through Standard MsgSend gas wrapper so proposal-path does not bypass the policy.
- Added runtime/simulation/benchmark coverage for candidate detection, proposal admission/processing, and clamp behavior.
- Kept existing non-MsgSend gas behavior unchanged.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
  - Note: This PR changes production runtime/wiring code in `app/`.
- [x] reviewed content
- [x] tested instructions (if applicable)
  - `go test -mod=readonly ./app -count=1`
  - `go test -mod=readonly ./...`
  - `go -C oracle test -mod=readonly ./...`
  - `make test`
- [x] confirmed all CI checks have passed