### PR TITLE
feat(bootstrap): align standard MsgSend gas accounting with EVM transfers

### DIFF
--- a/app/ante/handler.go
+++ b/app/ante/handler.go
@@ -1,0 +1,98 @@
+package ante
+
+import (
+	evmante "github.com/cosmos/evm/ante"
+	cosmosante "github.com/cosmos/evm/ante/cosmos"
+	evmanteevm "github.com/cosmos/evm/ante/evm"
+	antetypes "github.com/cosmos/evm/ante/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	ibcante "github.com/cosmos/ibc-go/v10/modules/core/ante"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+)
+
+var (
+	ethereumExtensionTypeURL = sdk.MsgTypeURL(&evmtypes.ExtensionOptionsEthereumTx{})
+	dynamicFeeExtensionURL   = sdk.MsgTypeURL(&antetypes.ExtensionOptionDynamicFeeTx{})
+)
+
+// NewAnteHandler preserves the upstream Cosmos EVM v0.6.1 Ethereum path and
+// routes Cosmos transactions through the application-local standard MsgSend
+// gas extension.
+func NewAnteHandler(options evmante.HandlerOptions) sdk.AnteHandler {
+	upstreamHandler := evmante.NewAnteHandler(options)
+
+	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		if tx == nil {
+			return upstreamHandler(ctx, tx, simulate)
+		}
+
+		if extensionTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
+			extensions := extensionTx.GetExtensionOptions()
+			if len(extensions) > 0 {
+				switch extensions[0].GetTypeUrl() {
+				case ethereumExtensionTypeURL:
+					return upstreamHandler(ctx, tx, simulate)
+				case dynamicFeeExtensionURL:
+					return newCosmosAnteHandler(ctx, options)(ctx, tx, simulate)
+				default:
+					return upstreamHandler(ctx, tx, simulate)
+				}
+			}
+		}
+
+		return newCosmosAnteHandler(ctx, options)(ctx, tx, simulate)
+	}
+}
+
+// newCosmosAnteHandler mirrors the Cosmos EVM v0.6.1 Cosmos ante chain. Fee
+// market parameters are read from the transaction context on every invocation.
+func newCosmosAnteHandler(ctx sdk.Context, options evmante.HandlerOptions) sdk.AnteHandler {
+	feemarketParams := options.FeeMarketKeeper.GetParams(ctx)
+
+	var txFeeChecker authante.TxFeeChecker
+	if options.DynamicFeeChecker {
+		txFeeChecker = newStandardMsgSendDynamicFeeChecker(&feemarketParams)
+	} else {
+		txFeeChecker = newStandardMsgSendValidatorFeeChecker()
+	}
+
+	return sdk.ChainAnteDecorators(
+		cosmosante.NewRejectMessagesDecorator(),
+		cosmosante.NewAuthzLimiterDecorator(
+			sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
+			sdk.MsgTypeURL(&sdkvesting.MsgCreateVestingAccount{}),
+		),
+		authante.NewSetUpContextDecorator(),
+		NewStandardMsgSendGasDecorator(
+			options.AccountKeeper,
+			feemarketParams.MinGasMultiplier,
+			options.MaxTxGasWanted,
+		),
+		authante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
+		authante.NewValidateBasicDecorator(),
+		authante.NewTxTimeoutHeightDecorator(),
+		authante.NewValidateMemoDecorator(options.AccountKeeper),
+		newStandardMsgSendMinGasPriceDecorator(&feemarketParams),
+		authante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		authante.NewDeductFeeDecorator(
+			options.AccountKeeper,
+			options.BankKeeper,
+			options.FeegrantKeeper,
+			txFeeChecker,
+		),
+		authante.NewSetPubKeyDecorator(options.AccountKeeper),
+		authante.NewValidateSigCountDecorator(options.AccountKeeper),
+		authante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
+		authante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		authante.NewIncrementSequenceDecorator(options.AccountKeeper),
+		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
+		evmanteevm.NewGasWantedDecorator(
+			options.EvmKeeper,
+			options.FeeMarketKeeper,
+			&feemarketParams,
+		),
+	)
+}

--- a/app/ante/standard_msgsend_fee.go
+++ b/app/ante/standard_msgsend_fee.go
@@ -1,0 +1,405 @@
+package ante
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"slices"
+
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+
+	cosmosante "github.com/cosmos/evm/ante/cosmos"
+	evmanteevm "github.com/cosmos/evm/ante/evm"
+	antetypes "github.com/cosmos/evm/ante/types"
+	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+)
+
+// newStandardMsgSendDynamicFeeChecker leaves ordinary transactions on the
+// upstream Cosmos EVM v0.6.1 checker. Eligible MsgSend transactions use the
+// Ethereum transaction price model against declared gas D, then settle that
+// price against execution gas E.
+//
+// This application's native EVM denom has 18 decimals. Consequently, the EVM
+// path's ConvertAmountTo18DecimalsLegacy step is a no-op, while converting the
+// LegacyDec base fee to *big.Int still truncates its fractional component.
+func newStandardMsgSendDynamicFeeChecker(
+	feemarketParams *feemarkettypes.Params,
+) authante.TxFeeChecker {
+	upstream := evmanteevm.NewDynamicFeeChecker(feemarketParams)
+
+	return func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+		if !isStandardMsgSendGasContext(ctx) {
+			return upstream(ctx, tx)
+		}
+
+		feeTx, ok := tx.(sdk.FeeTx)
+		if !ok {
+			return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+		}
+		settlementGas, ok := standardMsgSendSettlementGas(ctx)
+		if !ok {
+			return nil, 0, errorsmod.Wrap(sdkerrors.ErrLogic, "standard MsgSend execution gas is unavailable")
+		}
+		if ctx.BlockHeight() == 0 ||
+			!evmtypes.IsLondon(evmtypes.GetEthChainConfig(), ctx.BlockHeight()) {
+			fees, priority, err := upstream(ctx, tx)
+			if err != nil || isStandardMsgSendAdmissionContext(ctx) {
+				return fees, priority, err
+			}
+			settled, settleErr := settleStandardMsgSendFees(
+				fees,
+				feeTx.GetGas(),
+				settlementGas,
+			)
+			return settled, priority, settleErr
+		}
+
+		if isStandardMsgSendAdmissionContext(ctx) {
+			return checkAndSettleStandardMsgSendFee(
+				ctx,
+				feeTx,
+				feemarketParams,
+				feeTx.GetGas(),
+			)
+		}
+		return checkAndSettleStandardMsgSendFee(
+			ctx,
+			feeTx,
+			feemarketParams,
+			settlementGas,
+		)
+	}
+}
+
+// newStandardMsgSendValidatorFeeChecker mirrors the Cosmos SDK v0.53
+// validator-min-gas-price checker. Admission and priority use the declared gas;
+// eligible MsgSend settlement alone uses execution gas.
+func newStandardMsgSendValidatorFeeChecker() authante.TxFeeChecker {
+	return func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+		fees, priority, err := checkStandardMsgSendValidatorFee(ctx, tx)
+		if err != nil || !isStandardMsgSendGasContext(ctx) {
+			return fees, priority, err
+		}
+		if isStandardMsgSendAdmissionContext(ctx) {
+			return fees, priority, nil
+		}
+
+		feeTx, ok := tx.(sdk.FeeTx)
+		if !ok {
+			return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+		}
+
+		settlementGas, ok := standardMsgSendSettlementGas(ctx)
+		if !ok {
+			return fees, priority, nil
+		}
+
+		settled, settleErr := settleStandardMsgSendFees(
+			fees,
+			feeTx.GetGas(),
+			settlementGas,
+		)
+		return settled, priority, settleErr
+	}
+}
+
+func isStandardMsgSendAdmissionContext(ctx sdk.Context) bool {
+	return ctx.IsCheckTx() || ctx.IsReCheckTx()
+}
+
+func isStandardMsgSendGasContext(ctx sdk.Context) bool {
+	_, ok := ctx.GasMeter().(*standardMsgSendGasMeter)
+	return ok
+}
+
+func standardMsgSendSettlementGas(ctx sdk.Context) (uint64, bool) {
+	meter, ok := ctx.GasMeter().(*standardMsgSendGasMeter)
+	if !ok {
+		return 0, false
+	}
+	return uint64(meter.executionGas), true
+}
+
+// checkAndSettleStandardMsgSendFee applies the successful Ethereum plain
+// transfer price semantics:
+//
+//   - legacy/no extension: P = F = submittedFee / D
+//   - dynamic extension: P = min(B + tip, F)
+//   - admission and priority use D; deduction is ceil(P * E)
+//
+// B is the integer EVM base fee. NoBaseFee and pre-enable heights produce B=0.
+func checkAndSettleStandardMsgSendFee(
+	ctx sdk.Context,
+	feeTx sdk.FeeTx,
+	feemarketParams *feemarkettypes.Params,
+	executionGas uint64,
+) (sdk.Coins, int64, error) {
+	declaredGas := feeTx.GetGas()
+	if declaredGas == 0 {
+		return nil, 0, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "gas cannot be zero")
+	}
+
+	denom := evmtypes.GetEVMCoinDenom()
+	declaredGasInt := sdkmath.NewIntFromUint64(declaredGas)
+	feeAmount := feeTx.GetFee().AmountOfNoDenomValidation(denom) //nolint:staticcheck // matches Cosmos EVM v0.6.1
+	feeCap := sdkmath.LegacyNewDecFromInt(feeAmount).QuoInt(declaredGasInt)
+	baseFee := standardMsgSendEthereumBaseFee(ctx, feemarketParams)
+
+	dynamicFee, hasDynamicFee := standardMsgSendDynamicFee(feeTx)
+	effectivePrice := feeCap
+	priorityPrice := feeCap.Sub(baseFee)
+	if hasDynamicFee {
+		tipCap := dynamicFee.MaxPriorityPrice
+		if tipCap.IsNil() {
+			tipCap = sdkmath.LegacyZeroDec()
+		}
+		if tipCap.IsNegative() {
+			return nil, 0, errorsmod.Wrap(sdkerrors.ErrInsufficientFee, "max priority price cannot be negative")
+		}
+		if tipCap.GT(feeCap) {
+			return nil, 0, errorsmod.Wrapf(
+				sdkerrors.ErrInsufficientFee,
+				"max priority price %s exceeds fee cap %s",
+				tipCap,
+				feeCap,
+			)
+		}
+		if feeCap.LT(baseFee) {
+			return nil, 0, errorsmod.Wrapf(
+				sdkerrors.ErrInsufficientFee,
+				"gas prices too low, got: %s%s required: %s%s. Please retry using a higher gas price or a higher fee",
+				feeCap,
+				denom,
+				baseFee,
+				denom,
+			)
+		}
+
+		effectivePrice = sdkmath.LegacyMinDec(baseFee.Add(tipCap), feeCap)
+		priorityPrice = effectivePrice.Sub(baseFee)
+	} else if feeCap.LT(baseFee) {
+		// Ethereum legacy transactions must cover the current base fee.
+		return nil, 0, errorsmod.Wrapf(
+			sdkerrors.ErrInsufficientFee,
+			"gas prices too low, got: %s%s required: %s%s. Please retry using a higher gas price or a higher fee",
+			feeCap,
+			denom,
+			baseFee,
+			denom,
+		)
+	}
+
+	priorityInt := priorityPrice.QuoInt(evmtypes.DefaultPriorityReduction).TruncateInt()
+	priority := int64(math.MaxInt64)
+	if priorityInt.IsInt64() {
+		priority = priorityInt.Int64()
+	}
+
+	settledAmount := effectivePrice.
+		MulInt(sdkmath.NewIntFromUint64(executionGas)).
+		Ceil().
+		RoundInt()
+	return sdk.Coins{{Denom: denom, Amount: settledAmount}}, priority, nil
+}
+
+func standardMsgSendEthereumBaseFee(
+	ctx sdk.Context,
+	feemarketParams *feemarkettypes.Params,
+) sdkmath.LegacyDec {
+	if feemarketParams == nil || !feemarketParams.IsBaseFeeEnabled(ctx.BlockHeight()) {
+		return sdkmath.LegacyZeroDec()
+	}
+
+	baseFee := feemarketParams.BaseFee
+	if baseFee.IsNil() || baseFee.IsZero() {
+		return sdkmath.LegacyZeroDec()
+	}
+
+	// The application config fixes the native EVM denom exponent to 18, so
+	// ConvertAmountTo18DecimalsLegacy is intentionally not needed here.
+	return sdkmath.LegacyNewDecFromInt(baseFee.TruncateInt())
+}
+
+func standardMsgSendDynamicFee(feeTx sdk.FeeTx) (*antetypes.ExtensionOptionDynamicFeeTx, bool) {
+	extensionTx, ok := feeTx.(authante.HasExtensionOptionsTx)
+	if !ok {
+		return nil, false
+	}
+	for _, option := range extensionTx.GetExtensionOptions() {
+		if dynamicFee, ok := option.GetCachedValue().(*antetypes.ExtensionOptionDynamicFeeTx); ok {
+			return dynamicFee, true
+		}
+	}
+	return nil, false
+}
+
+// standardMsgSendMinGasPriceDecorator preserves the upstream Cosmos decorator
+// for ordinary transactions. For an eligible MsgSend it checks the Ethereum
+// effective price P against the global minimum price, both multiplied by D.
+type standardMsgSendMinGasPriceDecorator struct {
+	upstream        cosmosante.MinGasPriceDecorator
+	feemarketParams *feemarkettypes.Params
+}
+
+func newStandardMsgSendMinGasPriceDecorator(
+	feemarketParams *feemarkettypes.Params,
+) standardMsgSendMinGasPriceDecorator {
+	return standardMsgSendMinGasPriceDecorator{
+		upstream:        cosmosante.NewMinGasPriceDecorator(feemarketParams),
+		feemarketParams: feemarketParams,
+	}
+}
+
+func (d standardMsgSendMinGasPriceDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (sdk.Context, error) {
+	if !isStandardMsgSendGasContext(ctx) {
+		return d.upstream.AnteHandle(ctx, tx, simulate, next)
+	}
+
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return ctx, errorsmod.Wrapf(sdkerrors.ErrInvalidType, "invalid transaction type %T, expected sdk.FeeTx", tx)
+	}
+
+	feeCoins := feeTx.GetFee()
+	denom := evmtypes.GetEVMCoinDenom()
+	validFees := len(feeCoins) == 0 ||
+		(len(feeCoins) == 1 && slices.Contains([]string{denom, sdk.DefaultBondDenom}, feeCoins.GetDenomByIndex(0)))
+	if !validFees && !simulate {
+		return ctx, fmt.Errorf("expected only native token %s for fee, but got %s", denom, feeCoins.String())
+	}
+	if d.feemarketParams.MinGasPrice.IsZero() || simulate {
+		return next(ctx, tx, simulate)
+	}
+	if feeTx.GetGas() == 0 {
+		return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "gas cannot be zero")
+	}
+
+	feeCap := sdkmath.LegacyNewDecFromInt(feeCoins.AmountOfNoDenomValidation(denom)). //nolint:staticcheck // matches v0.6.1 native-denom handling
+												QuoInt(sdkmath.NewIntFromUint64(feeTx.GetGas()))
+	effectivePrice := feeCap
+	if dynamicFee, ok := standardMsgSendDynamicFee(feeTx); ok {
+		tipCap := dynamicFee.MaxPriorityPrice
+		if tipCap.IsNil() {
+			tipCap = sdkmath.LegacyZeroDec()
+		}
+		if tipCap.IsNegative() {
+			return ctx, errorsmod.Wrap(sdkerrors.ErrInsufficientFee, "max priority price cannot be negative")
+		}
+		if tipCap.GT(feeCap) {
+			return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "max priority price %s exceeds fee cap %s", tipCap, feeCap)
+		}
+		baseFee := standardMsgSendEthereumBaseFee(ctx, d.feemarketParams)
+		if feeCap.LT(baseFee) {
+			return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "gas prices too low, got: %s%s required: %s%s", feeCap, denom, baseFee, denom)
+		}
+		effectivePrice = sdkmath.LegacyMinDec(baseFee.Add(tipCap), feeCap)
+	}
+
+	gasLimit := sdkmath.LegacyNewDecFromBigInt(new(big.Int).SetUint64(feeTx.GetGas()))
+	providedFee := effectivePrice.Mul(gasLimit)
+	requiredFee := d.feemarketParams.MinGasPrice.Mul(gasLimit)
+	if providedFee.LT(requiredFee) {
+		return ctx, errorsmod.Wrapf(
+			sdkerrors.ErrInsufficientFee,
+			"provided fee < minimum global fee (%s < %s). Please increase the priority tip (for EIP-1559 txs) or the gas prices (for legacy txs)",
+			providedFee.TruncateInt(),
+			requiredFee.TruncateInt(),
+		)
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// settleStandardMsgSendFees preserves each submitted coin's gas price while
+// replacing the declared gas multiplier with executionGas.
+func settleStandardMsgSendFees(
+	fees sdk.Coins,
+	declaredGas uint64,
+	executionGas uint64,
+) (sdk.Coins, error) {
+	if declaredGas == 0 {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "gas cannot be zero")
+	}
+
+	declaredGasInt := sdkmath.NewIntFromUint64(declaredGas)
+	settlementGas := sdkmath.NewIntFromUint64(executionGas)
+	settled := make(sdk.Coins, len(fees))
+	for i, fee := range fees {
+		amount := sdkmath.LegacyNewDecFromInt(fee.Amount).
+			QuoInt(declaredGasInt).
+			MulInt(settlementGas).
+			Ceil().
+			RoundInt()
+		settled[i] = sdk.NewCoin(fee.Denom, amount)
+	}
+
+	return settled, nil
+}
+
+// checkStandardMsgSendValidatorFee is the local equivalent of the unexported
+// Cosmos SDK v0.53 default checker. It intentionally evaluates the original
+// FeeTx and its declared gas before execution-gas settlement occurs.
+func checkStandardMsgSendValidatorFee(
+	ctx sdk.Context,
+	tx sdk.Tx,
+) (sdk.Coins, int64, error) {
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	fees := feeTx.GetFee()
+	gas := feeTx.GetGas()
+	if ctx.IsCheckTx() && !ctx.MinGasPrices().IsZero() {
+		requiredFees := make(sdk.Coins, len(ctx.MinGasPrices()))
+		gasLimit := sdkmath.LegacyNewDec(int64(gas)) // #nosec G115 -- ValidateBasic bounds gas before fee deduction.
+		for i, gasPrice := range ctx.MinGasPrices() {
+			requiredFee := gasPrice.Amount.Mul(gasLimit)
+			requiredFees[i] = sdk.NewCoin(
+				gasPrice.Denom,
+				requiredFee.Ceil().RoundInt(),
+			)
+		}
+
+		if !fees.IsAnyGTE(requiredFees) {
+			return nil, 0, errorsmod.Wrapf(
+				sdkerrors.ErrInsufficientFee,
+				"insufficient fees; got: %s required: %s",
+				fees,
+				requiredFees,
+			)
+		}
+	}
+
+	return fees, standardMsgSendValidatorPriority(fees, int64(gas)), nil // #nosec G115 -- ValidateBasic bounds gas.
+}
+
+func standardMsgSendValidatorPriority(fees sdk.Coins, gas int64) int64 {
+	if gas <= 0 {
+		return 0
+	}
+
+	var priority int64
+	for _, fee := range fees {
+		candidate := int64(math.MaxInt64)
+		gasPrice := fee.Amount.QuoRaw(gas)
+		if gasPrice.IsInt64() {
+			candidate = gasPrice.Int64()
+		}
+		if priority == 0 || candidate < priority {
+			priority = candidate
+		}
+	}
+	return priority
+}

--- a/app/ante/standard_msgsend_gas.go
+++ b/app/ante/standard_msgsend_gas.go
@@ -1,0 +1,369 @@
+package ante
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+
+	antetypes "github.com/cosmos/evm/ante/types"
+	"github.com/cosmos/evm/crypto/ethsecp256k1"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+const (
+	// StandardMsgSendGas is the intrinsic execution-gas floor for the bounded
+	// MsgSend class.
+	StandardMsgSendGas uint64 = 21_000
+
+	// StandardMsgSendMaxMemoBytes keeps the standard-send class bounded even if the
+	// chain's auth parameter is raised later.
+	StandardMsgSendMaxMemoBytes = 256
+)
+
+// StandardMsgSendGasDecorator assigns Ethereum-compatible minimum execution
+// gas, with a 21k floor, to a deliberately narrow MsgSend shape. The submitted
+// gas limit remains visible as the public meter limit, while internal ante and
+// message work is tracked by an unbounded meter. Transactions outside this
+// class continue through the ordinary Cosmos gas path.
+type StandardMsgSendGasDecorator struct {
+	accountKeeper    authante.AccountKeeper
+	minGasMultiplier sdkmath.LegacyDec
+	maxTxGasWanted   uint64
+}
+
+func NewStandardMsgSendGasDecorator(
+	accountKeeper authante.AccountKeeper,
+	minGasMultiplier sdkmath.LegacyDec,
+	maxTxGasWanted uint64,
+) StandardMsgSendGasDecorator {
+	return StandardMsgSendGasDecorator{
+		accountKeeper:    accountKeeper,
+		minGasMultiplier: minGasMultiplier,
+		maxTxGasWanted:   maxTxGasWanted,
+	}
+}
+
+func (d StandardMsgSendGasDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (sdk.Context, error) {
+	eligible, publicGasLimit, insufficientGas, dependenciesMissing := d.classify(ctx, tx, simulate)
+	if insufficientGas {
+		return ctx, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidGasLimit,
+			"standard MsgSend requires at least %d gas",
+			StandardMsgSendGas,
+		)
+	}
+	if dependenciesMissing {
+		return ctx, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"standard MsgSend gas dependencies are not configured",
+		)
+	}
+	if !eligible {
+		return next(ctx, tx, simulate)
+	}
+
+	executionGas, ok := standardMsgSendExecutionGas(publicGasLimit, d.minGasMultiplier)
+	if !ok {
+		return ctx, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"standard MsgSend minimum gas multiplier is invalid",
+		)
+	}
+
+	actualMeter := storetypes.NewInfiniteGasMeter()
+	if consumed := ctx.GasMeter().GasConsumed(); consumed > 0 {
+		actualMeter.ConsumeGas(consumed, "standard MsgSend pre-classification gas")
+	}
+	gasWanted := publicGasLimit
+	if (ctx.IsCheckTx() || ctx.IsReCheckTx()) &&
+		d.maxTxGasWanted > 0 && gasWanted > d.maxTxGasWanted {
+		gasWanted = d.maxTxGasWanted
+	}
+
+	return next(
+		ctx.
+			WithKVGasConfig(storetypes.GasConfig{}).
+			WithTransientKVGasConfig(storetypes.GasConfig{}).
+			WithGasMeter(newStandardMsgSendGasMeter(
+				actualMeter,
+				gasWanted,
+				executionGas,
+				simulate || (!ctx.IsCheckTx() && !ctx.IsReCheckTx()),
+			)),
+		tx,
+		simulate,
+	)
+}
+
+// standardMsgSendExecutionGas mirrors Cosmos EVM v0.6.1 minimum-gas
+// settlement and preserves the 21k intrinsic floor for a standard send.
+func standardMsgSendExecutionGas(
+	declaredGas uint64,
+	minGasMultiplier sdkmath.LegacyDec,
+) (uint64, bool) {
+	if declaredGas == 0 {
+		return StandardMsgSendGas, true
+	}
+	if minGasMultiplier.IsNil() {
+		minGasMultiplier = sdkmath.LegacyZeroDec()
+	}
+	if minGasMultiplier.IsNegative() || minGasMultiplier.GT(sdkmath.LegacyOneDec()) {
+		return 0, false
+	}
+
+	minimumGasUsed := sdkmath.LegacyNewDecFromInt(sdkmath.NewIntFromUint64(declaredGas)).
+		Mul(minGasMultiplier).
+		TruncateInt()
+	if !minimumGasUsed.IsUint64() {
+		return 0, false
+	}
+
+	executionGas := minimumGasUsed.Uint64()
+	if executionGas < StandardMsgSendGas {
+		executionGas = StandardMsgSendGas
+	}
+
+	return executionGas, true
+}
+
+// classify contains only standard-send classification. The recovery boundary is
+// intentionally narrower than the downstream ante call: malformed fee payer,
+// granter, signer, or message accessors fall back to the ordinary path, where
+// the normal decorators determine the canonical error without replaying work.
+func (d StandardMsgSendGasDecorator) classify(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+) (eligible bool, publicGasLimit uint64, insufficientGas bool, dependenciesMissing bool) {
+	defer func() {
+		if recover() != nil {
+			eligible = false
+			publicGasLimit = 0
+			insufficientGas = false
+			dependenciesMissing = false
+		}
+	}()
+
+	feeTx, msg, candidate := standardMsgSendShapeWithoutGasLimit(tx)
+	if !candidate {
+		return false, 0, false, false
+	}
+
+	declaredGas := feeTx.GetGas()
+	if simulate {
+		switch {
+		case declaredGas == 0:
+			publicGasLimit = StandardMsgSendGas
+		case declaredGas < StandardMsgSendGas:
+			return false, 0, false, false
+		default:
+			publicGasLimit = declaredGas
+		}
+	} else if declaredGas < StandardMsgSendGas {
+		return false, 0, true, false
+	} else {
+		publicGasLimit = declaredGas
+	}
+
+	if d.accountKeeper == nil {
+		return false, 0, false, true
+	}
+
+	feePayer := feeTx.FeePayer()
+	from, err := d.accountKeeper.AddressCodec().StringToBytes(msg.FromAddress)
+	if err != nil || !bytes.Equal(from, feePayer) {
+		return false, 0, false, false
+	}
+	if _, err = d.accountKeeper.AddressCodec().StringToBytes(msg.ToAddress); err != nil ||
+		!d.hasSingleSupportedSigner(ctx, tx, feePayer) {
+		return false, 0, false, false
+	}
+
+	return true, publicGasLimit, false, false
+}
+
+func standardMsgSendShapeWithoutGasLimit(tx sdk.Tx) (sdk.FeeTx, *banktypes.MsgSend, bool) {
+	if tx == nil {
+		return nil, nil, false
+	}
+
+	msgs := tx.GetMsgs()
+	if len(msgs) != 1 {
+		return nil, nil, false
+	}
+	msg, ok := msgs[0].(*banktypes.MsgSend)
+	if !ok || msg == nil || len(msg.Amount) != 1 ||
+		!msg.Amount.IsValid() || !msg.Amount.IsAllPositive() {
+		return nil, nil, false
+	}
+
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok || !feeTx.GetFee().IsValid() ||
+		len(feeTx.FeeGranter()) != 0 || len(feeTx.GetFee()) > 1 {
+		return nil, nil, false
+	}
+	if len(feeTx.GetFee()) == 1 && feeTx.GetFee()[0].Denom != evmtypes.GetEVMCoinDenom() {
+		return nil, nil, false
+	}
+
+	if memoTx, ok := tx.(sdk.TxWithMemo); ok && len(memoTx.GetMemo()) > StandardMsgSendMaxMemoBytes {
+		return nil, nil, false
+	}
+	if unorderedTx, ok := tx.(sdk.TxWithUnordered); ok && unorderedTx.GetUnordered() {
+		return nil, nil, false
+	}
+
+	if extensionTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
+		if len(extensionTx.GetNonCriticalExtensionOptions()) != 0 {
+			return nil, nil, false
+		}
+		extensions := extensionTx.GetExtensionOptions()
+		if len(extensions) > 1 {
+			return nil, nil, false
+		}
+		if len(extensions) == 1 {
+			if _, ok := extensions[0].GetCachedValue().(*antetypes.ExtensionOptionDynamicFeeTx); !ok {
+				return nil, nil, false
+			}
+		}
+	}
+
+	return feeTx, msg, true
+}
+
+func (d StandardMsgSendGasDecorator) hasSingleSupportedSigner(
+	ctx context.Context,
+	tx sdk.Tx,
+	feePayer sdk.AccAddress,
+) bool {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return false
+	}
+
+	signers, err := sigTx.GetSigners()
+	if err != nil || len(signers) != 1 || !bytes.Equal(signers[0], feePayer) {
+		return false
+	}
+	signatures, err := sigTx.GetSignaturesV2()
+	if err != nil || len(signatures) != 1 {
+		return false
+	}
+	pubKeys, err := sigTx.GetPubKeys()
+	if err != nil || len(pubKeys) != 1 {
+		return false
+	}
+
+	pubKey := pubKeys[0]
+	if pubKey == nil {
+		account := d.accountKeeper.GetAccount(ctx, feePayer)
+		if account == nil {
+			return false
+		}
+		pubKey = account.GetPubKey()
+	}
+
+	return hasStandardMsgSendPubKey(pubKey)
+}
+
+func hasStandardMsgSendPubKey(pubKey cryptotypes.PubKey) bool {
+	switch pubKey.(type) {
+	case *secp256k1.PubKey, *ethsecp256k1.PubKey:
+		return true
+	default:
+		return false
+	}
+}
+
+type standardMsgSendGasMeter struct {
+	actual       storetypes.GasMeter
+	limit        storetypes.Gas
+	reportedGas  storetypes.Gas
+	executionGas storetypes.Gas
+}
+
+func newStandardMsgSendGasMeter(
+	actual storetypes.GasMeter,
+	limit uint64,
+	executionGas uint64,
+	reportExecutionGas bool,
+) storetypes.GasMeter {
+	reportedGas := uint64(0)
+	if reportExecutionGas {
+		reportedGas = executionGas
+	}
+
+	return &standardMsgSendGasMeter{
+		actual:       actual,
+		limit:        storetypes.Gas(limit),
+		reportedGas:  storetypes.Gas(reportedGas),
+		executionGas: storetypes.Gas(executionGas),
+	}
+}
+
+func (m *standardMsgSendGasMeter) GasConsumed() storetypes.Gas {
+	return m.reportedGas
+}
+
+func (m *standardMsgSendGasMeter) GasConsumedToLimit() storetypes.Gas {
+	return m.reportedGas
+}
+
+func (m *standardMsgSendGasMeter) GasRemaining() storetypes.Gas {
+	if m.reportedGas >= m.limit {
+		return 0
+	}
+
+	return m.limit - m.reportedGas
+}
+
+func (m *standardMsgSendGasMeter) Limit() storetypes.Gas {
+	return m.limit
+}
+
+func (m *standardMsgSendGasMeter) ConsumeGas(amount storetypes.Gas, descriptor string) {
+	m.actual.ConsumeGas(amount, descriptor)
+}
+
+func (m *standardMsgSendGasMeter) RefundGas(amount storetypes.Gas, descriptor string) {
+	m.actual.RefundGas(amount, descriptor)
+}
+
+func (m *standardMsgSendGasMeter) IsPastLimit() bool {
+	return m.actual.IsPastLimit()
+}
+
+func (m *standardMsgSendGasMeter) IsOutOfGas() bool {
+	return m.actual.IsOutOfGas()
+}
+
+func (m *standardMsgSendGasMeter) String() string {
+	return fmt.Sprintf(
+		"StandardMsgSendGasMeter{limit: %d, execution: %d, reported: %d, actual: %s}",
+		m.limit,
+		m.executionGas,
+		m.reportedGas,
+		m.actual.String(),
+	)
+}
+
+func (m *standardMsgSendGasMeter) actualGasConsumed() storetypes.Gas {
+	return m.actual.GasConsumed()
+}

--- a/app/ante/standard_msgsend_test.go
+++ b/app/ante/standard_msgsend_test.go
@@ -1,0 +1,691 @@
+package ante
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	coreaddress "cosmossdk.io/core/address"
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+
+	evmante "github.com/cosmos/evm/ante"
+	evmanteevm "github.com/cosmos/evm/ante/evm"
+	antetypes "github.com/cosmos/evm/ante/types"
+	evmaddress "github.com/cosmos/evm/encoding/address"
+	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+func TestStandardMsgSendGasDecoratorEligibility(t *testing.T) {
+	configureStandardMsgSendTestDenom()
+
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x11}, 20))
+	other := sdk.AccAddress(bytes.Repeat([]byte{0x22}, 20))
+	dynamicExtension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		simulate         bool
+		mutate           func(*standardMsgSendTestTx)
+		wantStandard     bool
+		wantExecutionGas uint64
+		wantErr          error
+	}{
+		{name: "exact gas", wantStandard: true},
+		{
+			name: "declared gas at multiplier threshold",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = 42_000
+			},
+			wantStandard:     true,
+			wantExecutionGas: StandardMsgSendGas,
+		},
+		{
+			name: "declared gas above standard",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = 200_000
+			},
+			wantStandard:     true,
+			wantExecutionGas: 100_000,
+		},
+		{
+			name: "dynamic fee extension",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.extensions = []*codectypes.Any{dynamicExtension}
+			},
+			wantStandard: true,
+		},
+		{
+			name:     "simulation gas zero",
+			simulate: true,
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = 0
+			},
+			wantStandard: true,
+		},
+		{
+			name: "execution below standard",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = StandardMsgSendGas - 1
+			},
+			wantErr: sdkerrors.ErrInvalidGasLimit,
+		},
+		{
+			name:     "simulation below standard falls back",
+			simulate: true,
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = StandardMsgSendGas - 1
+			},
+		},
+		{
+			name: "memo above bound",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.memo = strings.Repeat("m", StandardMsgSendMaxMemoBytes+1)
+			},
+		},
+		{
+			name: "multiple send denoms",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.NewCoins(
+					sdk.NewInt64Coin("adenom", 1),
+					sdk.NewInt64Coin("bdenom", 1),
+				)
+			},
+		},
+		{
+			name: "invalid recipient",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).ToAddress = "not-an-address"
+			},
+		},
+		{
+			name: "non-positive send amount",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.Coins{
+					sdk.NewInt64Coin("send-denom", 0),
+				}
+			},
+		},
+		{
+			name: "fee grant",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.granter = append(sdk.AccAddress(nil), payer...)
+			},
+		},
+		{
+			name: "fee payer differs from sender",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.payer = append(sdk.AccAddress(nil), other...)
+				tx.signers = [][]byte{append([]byte(nil), other...)}
+			},
+		},
+		{
+			name: "multiple signers",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signers = append(tx.signers, append([]byte(nil), other...))
+			},
+		},
+		{
+			name: "unsupported public key",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.pubKeys = []cryptotypes.PubKey{ed25519.GenPrivKey().PubKey()}
+			},
+		},
+		{
+			name: "large single signature remains eligible",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signatures[0].Data = &signing.SingleSignatureData{
+					Signature: bytes.Repeat([]byte{0x01}, 1_024),
+				}
+			},
+			wantStandard: true,
+		},
+		{
+			name: "multi signature data remains eligible",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.signatures[0].Data = &signing.MultiSignatureData{}
+			},
+			wantStandard: true,
+		},
+	}
+
+	decorator := NewStandardMsgSendGasDecorator(
+		&standardMsgSendAccountKeeper{addressCodec: addressCodec},
+		standardMsgSendTestMinGasMultiplier(),
+		0,
+	)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+			if test.mutate != nil {
+				test.mutate(&tx)
+			}
+
+			originalMeter := storetypes.NewInfiniteGasMeter()
+			ctx := sdk.Context{}.
+				WithGasMeter(originalMeter).
+				WithTxBytes(bytes.Repeat([]byte{0x01}, 4_096))
+			nextCalled := false
+			var nextTx sdk.Tx
+			newCtx, err := decorator.AnteHandle(
+				ctx,
+				&tx,
+				test.simulate,
+				func(ctx sdk.Context, tx sdk.Tx, _ bool) (sdk.Context, error) {
+					nextCalled = true
+					nextTx = tx
+					return ctx, nil
+				},
+			)
+
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+				require.False(t, nextCalled)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, nextCalled)
+			require.Same(t, &tx, nextTx)
+			_, standardized := newCtx.GasMeter().(*standardMsgSendGasMeter)
+			require.Equal(t, test.wantStandard, standardized)
+			if test.wantStandard {
+				wantLimit := tx.gas
+				if wantLimit == 0 {
+					wantLimit = StandardMsgSendGas
+				}
+				wantExecutionGas := test.wantExecutionGas
+				if wantExecutionGas == 0 {
+					wantExecutionGas = StandardMsgSendGas
+				}
+				require.Equal(t, wantExecutionGas, uint64(newCtx.GasMeter().GasConsumed()))
+				require.Equal(t, wantLimit, uint64(newCtx.GasMeter().Limit()))
+				require.Equal(
+					t,
+					wantLimit-wantExecutionGas,
+					uint64(newCtx.GasMeter().GasRemaining()),
+				)
+				standardMeter := newCtx.GasMeter().(*standardMsgSendGasMeter)
+				require.Equal(t, wantExecutionGas, uint64(standardMeter.executionGas))
+			} else {
+				require.Same(t, originalMeter, newCtx.GasMeter())
+			}
+		})
+	}
+}
+
+func TestStandardMsgSendMalformedFeePayerFallsBackToCanonicalAnteValidation(t *testing.T) {
+	configureStandardMsgSendTestDenom()
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x44}, 20))
+	tx := panickingFeePayerTestTx{standardMsgSendTestTx: newStandardMsgSendTestTx(
+		t,
+		addressCodec,
+		payer,
+	)}
+	decorator := NewStandardMsgSendGasDecorator(
+		&standardMsgSendAccountKeeper{addressCodec: addressCodec},
+		standardMsgSendTestMinGasMultiplier(),
+		0,
+	)
+	ctx := sdk.Context{}.WithGasMeter(storetypes.NewInfiniteGasMeter())
+	wantErr := errors.New("downstream canonical validation error")
+	nextCalls := 0
+
+	newCtx, err := decorator.AnteHandle(
+		ctx,
+		tx,
+		false,
+		func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			nextCalls++
+			return nextCtx, wantErr
+		},
+	)
+
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 1, nextCalls)
+	require.Same(t, ctx.GasMeter(), newCtx.GasMeter())
+}
+
+func TestStandardMsgSendGasByExecutionPhase(t *testing.T) {
+	configureStandardMsgSendTestDenom()
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x55}, 20))
+	const declaredGas = uint64(200_000)
+
+	tests := []struct {
+		name         string
+		context      sdk.Context
+		simulate     bool
+		maxCheckGas  uint64
+		wantLimit    uint64
+		wantConsumed uint64
+	}{
+		{
+			name:         "check tx",
+			context:      sdk.Context{}.WithIsCheckTx(true),
+			wantLimit:    declaredGas,
+			wantConsumed: 0,
+		},
+		{
+			name:         "capped recheck tx",
+			context:      sdk.Context{}.WithIsReCheckTx(true),
+			maxCheckGas:  80_000,
+			wantLimit:    80_000,
+			wantConsumed: 0,
+		},
+		{
+			name:         "simulate",
+			context:      sdk.Context{}.WithExecMode(sdk.ExecModeSimulate),
+			simulate:     true,
+			wantLimit:    declaredGas,
+			wantConsumed: 100_000,
+		},
+		{
+			name:         "finalize",
+			context:      sdk.Context{}.WithExecMode(sdk.ExecModeFinalize),
+			wantLimit:    declaredGas,
+			wantConsumed: 100_000,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decorator := NewStandardMsgSendGasDecorator(
+				&standardMsgSendAccountKeeper{addressCodec: addressCodec},
+				standardMsgSendTestMinGasMultiplier(),
+				test.maxCheckGas,
+			)
+			tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+			tx.gas = declaredGas
+			ctx := test.context.WithGasMeter(storetypes.NewGasMeter(tx.gas))
+
+			newCtx, err := decorator.AnteHandle(
+				ctx,
+				tx,
+				test.simulate,
+				func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+					nextCtx.GasMeter().ConsumeGas(tx.gas+1, "internal work above submitted limit")
+					return nextCtx, nil
+				},
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, declaredGas, tx.GetGas())
+			require.Equal(t, test.wantLimit, uint64(newCtx.GasMeter().Limit()))
+			require.Equal(t, test.wantConsumed, uint64(newCtx.GasMeter().GasConsumed()))
+			standardMeter := newCtx.GasMeter().(*standardMsgSendGasMeter)
+			require.Equal(t, uint64(100_000), uint64(standardMeter.executionGas))
+			require.Equal(t, storetypes.GasConfig{}, newCtx.KVGasConfig())
+			require.Equal(t, storetypes.GasConfig{}, newCtx.TransientKVGasConfig())
+			require.False(t, newCtx.GasMeter().IsPastLimit())
+			require.False(t, newCtx.GasMeter().IsOutOfGas())
+		})
+	}
+}
+
+func TestStandardMsgSendFeeAccounting(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x66}, 20))
+	const (
+		declaredGas  = uint64(200_000)
+		executionGas = uint64(100_000)
+		gasPrice     = int64(10)
+	)
+
+	t.Run("London admission uses declared gas and settlement uses execution gas", func(t *testing.T) {
+		baseFee := sdkmath.LegacyNewDec(gasPrice)
+		tipCap := sdkmath.LegacyNewDec(2).MulInt(evmtypes.DefaultPriorityReduction)
+		feeCap := baseFee.Add(
+			sdkmath.LegacyNewDec(3).MulInt(evmtypes.DefaultPriorityReduction),
+		)
+		extension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{
+			MaxPriorityPrice: tipCap,
+		})
+		require.NoError(t, err)
+
+		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+		tx.gas = declaredGas
+		tx.fee = sdk.NewCoins(sdk.NewCoin(
+			"agxn",
+			feeCap.MulInt(sdkmath.NewIntFromUint64(declaredGas)).RoundInt(),
+		))
+		tx.extensions = []*codectypes.Any{extension}
+		params := feemarkettypes.DefaultParams()
+		params.BaseFee = baseFee
+		checker := newStandardMsgSendDynamicFeeChecker(&params)
+		effectivePrice := baseFee.Add(tipCap)
+
+		checkFees, priority, err := checker(
+			standardMsgSendFeeTestContext(1, declaredGas, executionGas, true),
+			tx,
+		)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), priority)
+		require.Equal(
+			t,
+			effectivePrice.MulInt(sdkmath.NewIntFromUint64(declaredGas)).Ceil().RoundInt(),
+			checkFees.AmountOf("agxn"),
+		)
+
+		finalizeFees, _, err := checker(
+			standardMsgSendFeeTestContext(1, declaredGas, executionGas, false),
+			tx,
+		)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			effectivePrice.MulInt(sdkmath.NewIntFromUint64(executionGas)).Ceil().RoundInt(),
+			finalizeFees.AmountOf("agxn"),
+		)
+		require.Equal(t, declaredGas, tx.GetGas())
+	})
+
+	t.Run("fee covering only execution gas fails declared-gas admission", func(t *testing.T) {
+		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+		tx.gas = declaredGas
+		tx.fee = sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(executionGas)*gasPrice))
+		params := feemarkettypes.DefaultParams()
+		params.BaseFee = sdkmath.LegacyNewDec(gasPrice)
+
+		_, _, err := newStandardMsgSendDynamicFeeChecker(&params)(
+			standardMsgSendFeeTestContext(1, declaredGas, executionGas, true),
+			tx,
+		)
+		require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+	})
+
+	t.Run("validator minimum price reserves declared fee then settles execution fee", func(t *testing.T) {
+		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+		tx.gas = declaredGas
+		tx.fee = sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(declaredGas)*gasPrice))
+		checker := newStandardMsgSendValidatorFeeChecker()
+		checkCtx := standardMsgSendFeeTestContext(1, declaredGas, executionGas, true).
+			WithMinGasPrices(sdk.DecCoins{
+				sdk.NewDecCoinFromDec("agxn", sdkmath.LegacyNewDec(gasPrice)),
+			})
+
+		checkFees, priority, err := checker(checkCtx, tx)
+		require.NoError(t, err)
+		require.Equal(t, tx.GetFee(), checkFees)
+		require.Equal(t, gasPrice, priority)
+
+		finalizeFees, _, err := checker(
+			standardMsgSendFeeTestContext(1, declaredGas, executionGas, false),
+			tx,
+		)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(executionGas)*gasPrice)),
+			finalizeFees,
+		)
+	})
+
+	t.Run("ordinary transactions retain the upstream checker", func(t *testing.T) {
+		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+		tx.gas = declaredGas
+		tx.fee = sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(declaredGas)*gasPrice))
+		params := feemarkettypes.DefaultParams()
+		params.BaseFee = sdkmath.LegacyNewDec(gasPrice)
+		ctx := sdk.Context{}.
+			WithBlockHeight(1).
+			WithGasMeter(storetypes.NewInfiniteGasMeter())
+
+		wantFees, wantPriority, err := evmanteevm.NewDynamicFeeChecker(&params)(ctx, tx)
+		require.NoError(t, err)
+		gotFees, gotPriority, err := newStandardMsgSendDynamicFeeChecker(&params)(ctx, tx)
+		require.NoError(t, err)
+		require.Equal(t, wantFees, gotFees)
+		require.Equal(t, wantPriority, gotPriority)
+	})
+}
+
+func TestStandardMsgSendEthereumFeePolicyEdges(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+	ctx := standardMsgSendFeeTestContext(1, 42_000, 21_000, true)
+	params := feemarkettypes.DefaultParams()
+	params.BaseFee = sdkmath.LegacyMustNewDecFromStr("10.9")
+	require.Equal(t, sdkmath.LegacyNewDec(10), standardMsgSendEthereumBaseFee(ctx, &params))
+	params.NoBaseFee = true
+	require.True(t, standardMsgSendEthereumBaseFee(ctx, &params).IsZero())
+
+	params = feemarkettypes.DefaultParams()
+	params.BaseFee = sdkmath.LegacyNewDec(10)
+	params.MinGasPrice = sdkmath.LegacyNewDec(15)
+	extension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{
+		MaxPriorityPrice: sdkmath.LegacyNewDec(1),
+	})
+	require.NoError(t, err)
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	tx := newStandardMsgSendTestTx(
+		t,
+		addressCodec,
+		sdk.AccAddress(bytes.Repeat([]byte{0x77}, 20)),
+	)
+	tx.gas = 42_000
+	tx.fee = sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(tx.gas)*20))
+	tx.extensions = []*codectypes.Any{extension}
+
+	_, err = newStandardMsgSendMinGasPriceDecorator(&params).AnteHandle(
+		ctx,
+		tx,
+		false,
+		func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			return nextCtx, nil
+		},
+	)
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+}
+
+func TestAnteRouterPreservesUpstreamErrors(t *testing.T) {
+	options := evmante.HandlerOptions{}
+	localHandler := NewAnteHandler(options)
+	upstreamHandler := evmante.NewAnteHandler(options)
+	tests := []struct {
+		name string
+		tx   sdk.Tx
+	}{
+		{name: "nil transaction"},
+		{
+			name: "unknown extension",
+			tx: anteRouterTestTx{extensions: []*codectypes.Any{{
+				TypeUrl: "/test.unsupported.ExtensionOption",
+			}}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := sdk.Context{}
+			_, wantErr := upstreamHandler(ctx, test.tx, false)
+			_, gotErr := localHandler(ctx, test.tx, false)
+			require.Error(t, wantErr)
+			require.EqualError(t, gotErr, wantErr.Error())
+		})
+	}
+}
+
+func configureStandardMsgSendFeeTestChain(t *testing.T, londonHeight int64) {
+	t.Helper()
+	configureStandardMsgSendTestDenom()
+	chainConfig := evmtypes.DefaultChainConfig(0)
+	if londonHeight > 0 {
+		height := sdkmath.NewInt(londonHeight)
+		chainConfig.LondonBlock = &height
+		chainConfig.ArrowGlacierBlock = &height
+		chainConfig.GrayGlacierBlock = &height
+		chainConfig.MergeNetsplitBlock = &height
+	}
+	require.NoError(t, evmtypes.SetChainConfig(chainConfig))
+}
+
+func standardMsgSendFeeTestContext(
+	height int64,
+	declaredGas uint64,
+	executionGas uint64,
+	checkTx bool,
+) sdk.Context {
+	return sdk.Context{}.
+		WithBlockHeight(height).
+		WithIsCheckTx(checkTx).
+		WithGasMeter(&standardMsgSendGasMeter{
+			actual:       storetypes.NewInfiniteGasMeter(),
+			limit:        storetypes.Gas(declaredGas),
+			reportedGas:  storetypes.Gas(executionGas),
+			executionGas: storetypes.Gas(executionGas),
+		})
+}
+
+func standardMsgSendTestMinGasMultiplier() sdkmath.LegacyDec {
+	return sdkmath.LegacyNewDecWithPrec(5, 1)
+}
+
+type standardMsgSendAccountKeeper struct {
+	authante.AccountKeeper
+	addressCodec coreaddress.Codec
+	account      sdk.AccountI
+}
+
+func (keeper *standardMsgSendAccountKeeper) AddressCodec() coreaddress.Codec {
+	return keeper.addressCodec
+}
+
+func (keeper *standardMsgSendAccountKeeper) GetAccount(context.Context, sdk.AccAddress) sdk.AccountI {
+	return keeper.account
+}
+
+type standardMsgSendTestTx struct {
+	msgs                  []sdk.Msg
+	fee                   sdk.Coins
+	gas                   uint64
+	payer                 sdk.AccAddress
+	granter               sdk.AccAddress
+	memo                  string
+	unordered             bool
+	extensions            []*codectypes.Any
+	nonCriticalExtensions []*codectypes.Any
+	signers               [][]byte
+	pubKeys               []cryptotypes.PubKey
+	signatures            []signing.SignatureV2
+}
+
+type panickingFeePayerTestTx struct {
+	standardMsgSendTestTx
+}
+
+func (panickingFeePayerTestTx) FeePayer() []byte {
+	panic("malformed fee payer")
+}
+
+type anteRouterTestTx struct {
+	extensions []*codectypes.Any
+}
+
+func (anteRouterTestTx) GetMsgs() []sdk.Msg { return nil }
+
+func (anteRouterTestTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
+
+func (tx anteRouterTestTx) GetExtensionOptions() []*codectypes.Any { return tx.extensions }
+
+func (anteRouterTestTx) GetNonCriticalExtensionOptions() []*codectypes.Any { return nil }
+
+var (
+	_ sdk.FeeTx                      = standardMsgSendTestTx{}
+	_ sdk.TxWithMemo                 = standardMsgSendTestTx{}
+	_ sdk.TxWithUnordered            = standardMsgSendTestTx{}
+	_ authante.HasExtensionOptionsTx = standardMsgSendTestTx{}
+	_ authante.HasExtensionOptionsTx = anteRouterTestTx{}
+	_ authsigning.SigVerifiableTx    = standardMsgSendTestTx{}
+)
+
+func (tx standardMsgSendTestTx) GetMsgs() []sdk.Msg { return tx.msgs }
+
+func (standardMsgSendTestTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
+
+func (tx standardMsgSendTestTx) GetGas() uint64 { return tx.gas }
+
+func (tx standardMsgSendTestTx) GetFee() sdk.Coins { return tx.fee }
+
+func (tx standardMsgSendTestTx) FeePayer() []byte { return tx.payer }
+
+func (tx standardMsgSendTestTx) FeeGranter() []byte { return tx.granter }
+
+func (tx standardMsgSendTestTx) GetMemo() string { return tx.memo }
+
+func (tx standardMsgSendTestTx) GetUnordered() bool { return tx.unordered }
+
+func (standardMsgSendTestTx) GetTimeoutTimeStamp() time.Time { return time.Time{} }
+
+func (tx standardMsgSendTestTx) GetExtensionOptions() []*codectypes.Any { return tx.extensions }
+
+func (tx standardMsgSendTestTx) GetNonCriticalExtensionOptions() []*codectypes.Any {
+	return tx.nonCriticalExtensions
+}
+
+func (tx standardMsgSendTestTx) GetSigners() ([][]byte, error) { return tx.signers, nil }
+
+func (tx standardMsgSendTestTx) GetPubKeys() ([]cryptotypes.PubKey, error) {
+	return tx.pubKeys, nil
+}
+
+func (tx standardMsgSendTestTx) GetSignaturesV2() ([]signing.SignatureV2, error) {
+	return tx.signatures, nil
+}
+
+func newStandardMsgSendTestTx(
+	t *testing.T,
+	addressCodec coreaddress.Codec,
+	payer sdk.AccAddress,
+) standardMsgSendTestTx {
+	t.Helper()
+
+	from, err := addressCodec.BytesToString(payer)
+	require.NoError(t, err)
+	to, err := addressCodec.BytesToString(sdk.AccAddress(bytes.Repeat([]byte{0x77}, 20)))
+	require.NoError(t, err)
+	pubKey := secp256k1.GenPrivKeyFromSecret([]byte("standard-msgsend-test-key")).PubKey()
+
+	return standardMsgSendTestTx{
+		msgs: []sdk.Msg{&banktypes.MsgSend{
+			FromAddress: from,
+			ToAddress:   to,
+			Amount:      sdk.NewCoins(sdk.NewInt64Coin("send-denom", 1)),
+		}},
+		fee:        sdk.NewCoins(sdk.NewInt64Coin(evmtypes.GetEVMCoinDenom(), 1)),
+		gas:        StandardMsgSendGas,
+		payer:      append(sdk.AccAddress(nil), payer...),
+		signers:    [][]byte{append([]byte(nil), payer...)},
+		pubKeys:    []cryptotypes.PubKey{pubKey},
+		signatures: []signing.SignatureV2{{PubKey: pubKey}},
+	}
+}
+
+func configureStandardMsgSendTestDenom() {
+	evmtypes.SetDefaultEvmCoinInfo(evmtypes.EvmCoinInfo{
+		Denom:         "agxn",
+		ExtendedDenom: "agxn",
+		DisplayDenom:  "gxn",
+		Decimals:      18,
+	})
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -97,10 +97,14 @@ func TestApplicationStateMachine(t *testing.T) {
 	requireModulePrecedes(t, initGenesisOrder, evmtypes.ModuleName, erc20types.ModuleName)
 	requireModulePrecedes(t, initGenesisOrder, erc20types.ModuleName, ibctransfertypes.ModuleName)
 
-	privateKey, err := ethsecp256k1.GenerateKey()
+	ethereumPrivateKey, err := ethsecp256k1.GenerateKey()
 	require.NoError(t, err)
-	sender := sdk.AccAddress(privateKey.PubKey().Address())
-	recipient := common.HexToAddress("0x000000000000000000000000000000000000bEEF")
+	cosmosPrivateKey, err := ethsecp256k1.GenerateKey()
+	require.NoError(t, err)
+	ethereumSender := sdk.AccAddress(ethereumPrivateKey.PubKey().Address())
+	cosmosSender := sdk.AccAddress(cosmosPrivateKey.PubKey().Address())
+	ethereumRecipient := common.HexToAddress("0x000000000000000000000000000000000000bEEF")
+	cosmosRecipient := common.HexToAddress("0x000000000000000000000000000000000000CAfE")
 	validatorSet, err := simtestutil.CreateRandomValidatorSet()
 	require.NoError(t, err)
 	proposerAddress := validatorSet.GetProposer().Address
@@ -112,15 +116,28 @@ func TestApplicationStateMachine(t *testing.T) {
 		0,
 		0,
 	)
-	senderAccount := authtypes.NewBaseAccount(sender, nil, 1, 0)
-	recipientAccount := authtypes.NewBaseAccount(sdk.AccAddress(recipient.Bytes()), nil, 2, 0)
+	ethereumSenderAccount := authtypes.NewBaseAccount(ethereumSender, nil, 1, 0)
+	ethereumRecipientAccount := authtypes.NewBaseAccount(
+		sdk.AccAddress(ethereumRecipient.Bytes()), nil, 2, 0,
+	)
+	cosmosSenderAccount := authtypes.NewBaseAccount(cosmosSender, nil, 3, 0)
+	cosmosRecipientAccount := authtypes.NewBaseAccount(
+		sdk.AccAddress(cosmosRecipient.Bytes()), nil, 4, 0,
+	)
 	senderFunds := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, mustInt("10000000000000000000")))
 	genesisWithValidator, err := simtestutil.GenesisStateWithValSet(
 		application.AppCodec(),
 		genesis,
 		validatorSet,
-		[]authtypes.GenesisAccount{validatorAccount, senderAccount, recipientAccount},
-		banktypes.Balance{Address: sender.String(), Coins: senderFunds},
+		[]authtypes.GenesisAccount{
+			validatorAccount,
+			ethereumSenderAccount,
+			ethereumRecipientAccount,
+			cosmosSenderAccount,
+			cosmosRecipientAccount,
+		},
+		banktypes.Balance{Address: ethereumSender.String(), Coins: senderFunds},
+		banktypes.Balance{Address: cosmosSender.String(), Coins: senderFunds},
 	)
 	require.NoError(t, err)
 	genesis = GenesisState(genesisWithValidator)
@@ -265,46 +282,207 @@ func TestApplicationStateMachine(t *testing.T) {
 		require.Equal(t, common.FromHex(preinstall.Code), application.EVMKeeper.GetCode(governanceContext, codeHash))
 	}
 
-	amount := big.NewInt(12_345)
-	successBytes, successTx := signAndEncodeEthereumTx(
+	const submittedGas uint64 = 200_000
+	gasPrice := big.NewInt(2_000_000_000)
+	transferValue := big.NewInt(12_345)
+	minGasMultiplier := application.FeeMarketKeeper.GetParams(queryContext).MinGasMultiplier
+	require.True(t, minGasMultiplier.Equal(feemarkettypes.DefaultMinGasMultiplier))
+	minimumGasUsed := minGasMultiplier.
+		MulInt64(int64(submittedGas)).
+		TruncateInt().Uint64()
+	expectedBlockGasWanted := minGasMultiplier.
+		MulInt64(int64(2 * submittedGas)).
+		TruncateInt().Uint64()
+	protocolFee := sdkmath.NewIntFromUint64(minimumGasUsed).Mul(sdkmath.NewIntFromBigInt(gasPrice))
+	submittedFee := sdkmath.NewIntFromUint64(submittedGas).
+		Mul(sdkmath.NewIntFromBigInt(gasPrice))
+
+	ethereumBytes, ethereumTx := signAndEncodeEthereumTx(
 		t,
 		application,
-		privateKey,
+		ethereumPrivateKey,
 		ethtypes.NewTx(&ethtypes.LegacyTx{
 			Nonce:    0,
-			To:       &recipient,
-			Value:    amount,
-			Gas:      100_000,
-			GasPrice: big.NewInt(2_000_000_000),
+			To:       &ethereumRecipient,
+			Value:    transferValue,
+			Gas:      submittedGas,
+			GasPrice: gasPrice,
 		}),
 	)
-	finalized := finalizeAndCommit(
+	cosmosBytes := signAndEncodeCosmosTx(
 		t,
 		application,
-		2,
-		blockTime.Add(2*time.Second),
-		proposerAddress,
-		[][]byte{successBytes},
+		cosmosPrivateKey,
+		cosmosSenderAccount.GetAccountNumber(),
+		cosmosSenderAccount.GetSequence(),
+		banktypes.NewMsgSend(
+			cosmosSender,
+			sdk.AccAddress(cosmosRecipient.Bytes()),
+			sdk.NewCoins(sdk.NewCoin(
+				config.BaseDenom,
+				sdkmath.NewIntFromBigInt(transferValue),
+			)),
+		),
+		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, submittedFee)),
+		submittedGas,
 	)
-	require.Len(t, finalized.TxResults, 1)
-	require.True(t, finalized.TxResults[0].IsOK(), finalized.TxResults[0].Log)
-	successResult, err := evmtypes.DecodeTxResponse(finalized.TxResults[0].Data)
+
+	const proposalGas uint64 = 60_000_000
+	proposalFee := sdkmath.NewIntFromUint64(proposalGas).
+		Mul(sdkmath.NewIntFromBigInt(gasPrice))
+	proposalEthereumBytes, _ := signAndEncodeEthereumTx(
+		t,
+		application,
+		ethereumPrivateKey,
+		ethtypes.NewTx(&ethtypes.LegacyTx{
+			Nonce:    0,
+			To:       &ethereumRecipient,
+			Value:    transferValue,
+			Gas:      proposalGas,
+			GasPrice: gasPrice,
+		}),
+	)
+	proposalCosmosBytes := signAndEncodeCosmosTx(
+		t,
+		application,
+		cosmosPrivateKey,
+		cosmosSenderAccount.GetAccountNumber(),
+		cosmosSenderAccount.GetSequence(),
+		banktypes.NewMsgSend(
+			cosmosSender,
+			sdk.AccAddress(cosmosRecipient.Bytes()),
+			sdk.NewCoins(sdk.NewCoin(
+				config.BaseDenom,
+				sdkmath.NewIntFromBigInt(transferValue),
+			)),
+		),
+		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, proposalFee)),
+		proposalGas,
+	)
+	for _, proposalTxs := range [][][]byte{
+		{proposalEthereumBytes, proposalCosmosBytes},
+		{proposalCosmosBytes, proposalEthereumBytes},
+	} {
+		proposalGasResult, prepareErr := application.PrepareProposal(&abci.RequestPrepareProposal{
+			Height:     2,
+			Time:       blockTime.Add(2 * time.Second),
+			MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+			Txs:        proposalTxs,
+		})
+		require.NoError(t, prepareErr)
+		require.Equal(t, proposalTxs[:1], proposalGasResult.Txs)
+	}
+
+	require.Zero(t, application.FeeMarketKeeper.GetTransientGasWanted(
+		application.GetContextForCheckTx(nil),
+	))
+	for index, test := range []struct {
+		name    string
+		txBytes []byte
+	}{
+		{name: "ethereum", txBytes: ethereumBytes},
+		{name: "msgsend", txBytes: cosmosBytes},
+	} {
+		t.Run(test.name+" gas queries", func(t *testing.T) {
+			gasInfo, _, simulateErr := application.Simulate(test.txBytes)
+			require.NoError(t, simulateErr)
+			require.Equal(t, submittedGas, gasInfo.GasWanted)
+			require.Equal(t, minimumGasUsed, gasInfo.GasUsed)
+
+			checkResult, checkErr := application.CheckTx(&abci.RequestCheckTx{
+				Tx:   test.txBytes,
+				Type: abci.CheckTxType_New,
+			})
+			require.NoError(t, checkErr)
+			require.Equal(t, abci.CodeTypeOK, checkResult.Code, checkResult.Log)
+			require.Equal(t, int64(submittedGas), checkResult.GasWanted)
+			require.Zero(t, checkResult.GasUsed)
+			require.Equal(
+				t,
+				uint64(index+1)*submittedGas,
+				application.FeeMarketKeeper.GetTransientGasWanted(
+					application.GetContextForCheckTx(nil),
+				),
+			)
+		})
+	}
+
+	prepareResult, err := application.PrepareProposal(&abci.RequestPrepareProposal{
+		Height:     2,
+		Time:       blockTime.Add(2 * time.Second),
+		MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+		Txs:        [][]byte{ethereumBytes, cosmosBytes},
+	})
 	require.NoError(t, err)
-	require.False(t, successResult.Failed(), successResult.VmError)
-	require.Equal(t, successTx.Hash().Hex(), successResult.Hash)
+	require.Equal(t, [][]byte{ethereumBytes, cosmosBytes}, prepareResult.Txs)
+	processResult, err := application.ProcessProposal(&abci.RequestProcessProposal{
+		Height: 2,
+		Time:   blockTime.Add(2 * time.Second),
+		Txs:    prepareResult.Txs,
+	})
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, processResult.Status)
+
+	finalized, err := application.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height:          2,
+		Time:            blockTime.Add(2 * time.Second),
+		ProposerAddress: proposerAddress,
+		Txs:             prepareResult.Txs,
+	})
+	require.NoError(t, err)
+	require.Len(t, finalized.TxResults, 2)
+	for index, result := range finalized.TxResults {
+		require.True(t, result.IsOK(), result.Log)
+		require.Equal(t, int64(submittedGas), result.GasWanted)
+		require.Equal(t, int64(minimumGasUsed), result.GasUsed)
+		if index == 0 {
+			ethereumResult, decodeErr := evmtypes.DecodeTxResponse(result.Data)
+			require.NoError(t, decodeErr)
+			require.False(t, ethereumResult.Failed(), ethereumResult.VmError)
+			require.Equal(t, ethereumTx.Hash().Hex(), ethereumResult.Hash)
+		}
+	}
+	finalizeContext := application.GetContextForFinalizeBlock(nil)
+	require.Equal(
+		t,
+		2*submittedGas,
+		application.FeeMarketKeeper.GetTransientGasWanted(finalizeContext),
+	)
+	require.Equal(
+		t,
+		expectedBlockGasWanted,
+		application.FeeMarketKeeper.GetBlockGasWanted(finalizeContext),
+	)
+	_, err = application.Commit()
+	require.NoError(t, err)
 
 	queryContext = committedContext(t, application)
-	recipientBalance := application.BankKeeper.GetBalance(
-		queryContext,
-		sdk.AccAddress(recipient.Bytes()),
-		config.BaseDenom,
+	expectedSenderBalance := senderFunds.AmountOf(config.BaseDenom).
+		Sub(sdkmath.NewIntFromBigInt(transferValue)).
+		Sub(protocolFee)
+	for _, sender := range []sdk.AccAddress{ethereumSender, cosmosSender} {
+		require.True(t, application.BankKeeper.GetBalance(
+			queryContext,
+			sender,
+			config.BaseDenom,
+		).Amount.Equal(expectedSenderBalance))
+	}
+	for _, recipient := range []common.Address{ethereumRecipient, cosmosRecipient} {
+		require.True(t, application.BankKeeper.GetBalance(
+			queryContext,
+			sdk.AccAddress(recipient.Bytes()),
+			config.BaseDenom,
+		).Amount.Equal(sdkmath.NewIntFromBigInt(transferValue)))
+	}
+	require.Equal(
+		t,
+		expectedBlockGasWanted,
+		application.FeeMarketKeeper.GetBlockGasWanted(queryContext),
 	)
-	require.Equal(t, amount.String(), recipientBalance.Amount.String())
-	senderBalanceAfterSuccess := application.BankKeeper.GetBalance(queryContext, sender, config.BaseDenom)
-	amountWithoutFee := senderFunds.AmountOf(config.BaseDenom).Sub(sdkmath.NewIntFromBigInt(amount))
-	require.True(t, senderBalanceAfterSuccess.Amount.LT(amountWithoutFee))
-	senderEVMAddress := common.BytesToAddress(sender)
+
+	senderEVMAddress := common.BytesToAddress(ethereumSender)
 	require.Equal(t, uint64(1), application.EVMKeeper.GetNonce(queryContext, senderEVMAddress))
+	require.Equal(t, uint64(1), application.AccountKeeper.GetAccount(queryContext, cosmosSender).GetSequence())
 
 	const revertGasLimit uint64 = 100_000
 	revertGasPrice := big.NewInt(2_000_000_000)
@@ -312,7 +490,7 @@ func TestApplicationStateMachine(t *testing.T) {
 	revertBytes, _ := signAndEncodeEthereumTx(
 		t,
 		application,
-		privateKey,
+		ethereumPrivateKey,
 		ethtypes.NewTx(&ethtypes.LegacyTx{
 			Nonce:    1,
 			Value:    revertValue,
@@ -320,6 +498,11 @@ func TestApplicationStateMachine(t *testing.T) {
 			GasPrice: revertGasPrice,
 			Data:     common.FromHex("0x60006000fd"),
 		}),
+	)
+	senderBalanceBeforeRevert := application.BankKeeper.GetBalance(
+		queryContext,
+		ethereumSender,
+		config.BaseDenom,
 	)
 	finalized = finalizeAndCommit(
 		t,
@@ -343,66 +526,26 @@ func TestApplicationStateMachine(t *testing.T) {
 		sdk.AccAddress(createdContract.Bytes()),
 		config.BaseDenom,
 	).IsZero())
-	require.Equal(t, amount.String(), application.BankKeeper.GetBalance(
-		queryContext,
-		sdk.AccAddress(recipient.Bytes()),
-		config.BaseDenom,
-	).Amount.String())
-	require.Equal(t, uint64(2), application.EVMKeeper.GetNonce(queryContext, senderEVMAddress))
-	senderBalanceAfterRevert := application.BankKeeper.GetBalance(queryContext, sender, config.BaseDenom)
-	revertCharge := senderBalanceAfterSuccess.Amount.Sub(senderBalanceAfterRevert.Amount)
-	expectedRevertFee := sdkmath.NewIntFromUint64(revertResult.GasUsed).Mul(sdkmath.NewIntFromBigInt(revertGasPrice))
-	require.True(t, revertCharge.Equal(expectedRevertFee))
-
-	senderAccountAfterRevert := application.AccountKeeper.GetAccount(queryContext, sender)
-	require.NotNil(t, senderAccountAfterRevert)
-	require.Equal(t, uint64(2), senderAccountAfterRevert.GetSequence())
-	cosmosValue := sdkmath.NewInt(777)
-	cosmosFee := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, mustInt("1000000000000000")))
-	cosmosBytes := signAndEncodeCosmosTx(
-		t,
-		application,
-		privateKey,
-		senderAccountAfterRevert.GetAccountNumber(),
-		senderAccountAfterRevert.GetSequence(),
-		banktypes.NewMsgSend(
-			sender,
-			sdk.AccAddress(recipient.Bytes()),
-			sdk.NewCoins(sdk.NewCoin(config.BaseDenom, cosmosValue)),
-		),
-		cosmosFee,
-		200_000,
-	)
-	finalized = finalizeAndCommit(
-		t,
-		application,
-		4,
-		blockTime.Add(4*time.Second),
-		proposerAddress,
-		[][]byte{cosmosBytes},
-	)
-	require.Len(t, finalized.TxResults, 1)
-	require.True(t, finalized.TxResults[0].IsOK(), finalized.TxResults[0].Log)
-
-	queryContext = committedContext(t, application)
-	finalRecipientAmount := sdkmath.NewIntFromBigInt(amount).Add(cosmosValue)
-	require.Equal(t, finalRecipientAmount.String(), application.BankKeeper.GetBalance(
-		queryContext,
-		sdk.AccAddress(recipient.Bytes()),
-		config.BaseDenom,
-	).Amount.String())
 	require.True(t, application.BankKeeper.GetBalance(
 		queryContext,
-		sender,
+		sdk.AccAddress(ethereumRecipient.Bytes()),
 		config.BaseDenom,
-	).Amount.Equal(senderBalanceAfterRevert.Amount.Sub(cosmosValue).Sub(cosmosFee.AmountOf(config.BaseDenom))))
-	require.Equal(t, uint64(3), application.AccountKeeper.GetAccount(queryContext, sender).GetSequence())
-	require.Equal(t, uint64(3), application.EVMKeeper.GetNonce(queryContext, senderEVMAddress))
-	require.Equal(t, int64(4), application.LastBlockHeight())
+	).Amount.Equal(sdkmath.NewIntFromBigInt(transferValue)))
+	require.Equal(t, uint64(2), application.EVMKeeper.GetNonce(queryContext, senderEVMAddress))
+	senderBalanceAfterRevert := application.BankKeeper.GetBalance(
+		queryContext,
+		ethereumSender,
+		config.BaseDenom,
+	)
+	revertCharge := senderBalanceBeforeRevert.Amount.Sub(senderBalanceAfterRevert.Amount)
+	expectedRevertFee := sdkmath.NewIntFromUint64(revertResult.GasUsed).
+		Mul(sdkmath.NewIntFromBigInt(revertGasPrice))
+	require.True(t, revertCharge.Equal(expectedRevertFee))
+	require.Equal(t, int64(3), application.LastBlockHeight())
 
 	exported, err := application.ExportAppStateAndValidators(false, nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, int64(5), exported.Height)
+	require.Equal(t, int64(4), exported.Height)
 	var exportedGenesis GenesisState
 	require.NoError(t, json.Unmarshal(exported.AppState, &exportedGenesis))
 	require.NoError(t, application.ValidateGenesis(exportedGenesis))

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -6,6 +6,8 @@ import (
 	evmante "github.com/cosmos/evm/ante"
 	anteevmtypes "github.com/cosmos/evm/ante/types"
 	"github.com/ethereum/go-ethereum/common"
+
+	appante "github.com/gurufinglobal/guru/v2/app/ante"
 )
 
 func (app *App) configureAnteHandler(maxTxGasWanted uint64) error {
@@ -27,7 +29,7 @@ func (app *App) configureAnteHandler(maxTxGasWanted uint64) error {
 	if err := options.Validate(); err != nil {
 		return fmt.Errorf("validate ante handler options: %w", err)
 	}
-	app.anteHandler = evmante.NewAnteHandler(options)
+	app.anteHandler = appante.NewAnteHandler(options)
 	app.SetAnteHandler(app.anteHandler)
 	return nil
 }


### PR DESCRIPTION
# Description

Aligns eligible Cosmos `MsgSend` transactions with Cosmos EVM v0.6.1 simple EOA transfer gas and fee semantics.

For submitted gas `D`, execution gas is calculated as:

`E = max(21,000, floor(D × MinGasMultiplier))`

The implementation:

- preserves submitted gas `D` for admission, proposal selection, `GasWanted`, FeeMarket transient accounting, fee-cap validation, and maximum-cost checks
- reports execution gas `E` during simulation and finalization
- reports zero gas used during `CheckTx`, matching the Ethereum path
- deducts the final `E × effective gas price` fee directly instead of implementing Ethereum’s upfront deduction and refund flow
- reserves the submitted maximum fee during `CheckTx`
- validates the sender’s maximum native-token cost
- supports legacy and dynamic fee transactions
- delegates Ethereum transactions and unsupported extension options to the upstream Cosmos EVM v0.6.1 ante handler
- retains the SDK default proposal handlers
- intentionally adds no transaction-size, signature-data-type, or signature-length restriction

Expected behavior for an eligible `MsgSend`:

| Phase | Gas wanted | Gas used |
|---|---:|---:|
| Simulate | `D` | `E` |
| CheckTx/ReCheckTx | `D` | `0` |
| FinalizeBlock | `D` | `E` |

For example, when `D = 42,000` and `MinGasMultiplier = 0.5`, `E = 21,000`.

Critical files to review:

- `app/ante/handler.go`: ante routing and decorator ordering
- `app/ante/standard_msgsend_gas.go`: eligibility and gas-meter behavior
- `app/ante/standard_msgsend_fee.go`: admission and final fee calculations
- `app/ante/standard_msgsend_max_cost.go`: maximum-cost validation
- `app/handlers.go`: application wiring
- `app/app_test.go`: Ethereum and MsgSend parity tests

Review instructions:

1. Confirm ineligible Cosmos transactions retain upstream behavior.
2. Confirm eligible `MsgSend` transactions preserve the original transaction and submitted `GetGas()` value.
3. Compare an Ethereum native transfer and eligible native `MsgSend` using the same gas limit, gas price, and transfer value.
4. Verify simulation, `CheckTx`, finalization, final balances, FeeMarket accounting, and proposal weighting.

Validation completed:

- focused `app/ante` and `app` tests
- full repository test suite
- race-enabled `app/ante` and `app` tests
- full repository `go vet`

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code — N/A: this PR intentionally changes ante-handler production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed