### PR TITLE
feat(staking): enforce Constitution minimum self-bond

### DIFF
--- a/app/ante/self_bond.go
+++ b/app/ante/self_bond.go
@@ -1,0 +1,24 @@
+package ante
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type SelfBondConstraintKeeper interface {
+	ValidateTxSelfBondConstraints(ctx context.Context, tx sdk.Tx) error
+}
+
+func WrapAnteHandlerWithSelfBondCheck(
+	next sdk.AnteHandler,
+	keeper SelfBondConstraintKeeper,
+) sdk.AnteHandler {
+	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		if err := keeper.ValidateTxSelfBondConstraints(ctx, tx); err != nil {
+			return ctx, err
+		}
+
+		return next(ctx, tx, simulate)
+	}
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -26,6 +26,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
 	evmmempool "github.com/cosmos/evm/mempool"
 	evmutils "github.com/cosmos/evm/utils"
@@ -43,6 +44,7 @@ import (
 	"github.com/gurufinglobal/guru/v2/config"
 	constitutiontypes "github.com/gurufinglobal/guru/v2/x/constitution/types"
 	oracletypes "github.com/gurufinglobal/guru/v2/x/oracle/types"
+	customstaking "github.com/gurufinglobal/guru/v2/x/staking"
 )
 
 // Cosmos EVM production configuration is process-global, so this test creates
@@ -66,7 +68,9 @@ func TestApplicationStateMachine(t *testing.T) {
 	require.IsType(t, sdkmempool.NoOpMempool{}, application.Mempool())
 	require.NotNil(t, application.OracleProposalHandler)
 	require.NotNil(t, application.oracleVoteHandler)
+	require.NotNil(t, application.CustomStakingKeeper)
 	require.Contains(t, application.ModuleManager.Modules, oracletypes.ModuleName)
+	require.IsType(t, customstaking.AppModule{}, application.ModuleManager.Modules[stakingtypes.ModuleName])
 	baseEncoding, err := MakeEncodingConfig()
 	require.NoError(t, err)
 	require.NotContains(
@@ -173,6 +177,77 @@ func TestApplicationStateMachine(t *testing.T) {
 	genesis[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(bankGenesis)
 	require.NoError(t, application.ValidateGenesis(genesis))
 
+	stakingGenesis := stakingtypes.DefaultGenesisState()
+	application.AppCodec().MustUnmarshalJSON(genesis[stakingtypes.ModuleName], stakingGenesis)
+	require.Len(t, stakingGenesis.Validators, 1)
+	require.Len(t, stakingGenesis.Delegations, 1)
+	genesisSelfBond := stakingGenesis.Validators[0].TokensFromSharesTruncated(
+		stakingGenesis.Delegations[0].GetShares(),
+	).TruncateInt()
+	require.True(t, genesisSelfBond.IsPositive())
+
+	belowMinGenesis := cloneGenesisState(genesis)
+	setGenesisMinValidatorBond(t, application, belowMinGenesis, genesisSelfBond.AddRaw(1))
+	require.ErrorContains(
+		t,
+		application.ValidateGenesis(belowMinGenesis),
+		"genesis self-bond "+genesisSelfBond.String()+" below constitution minimum "+genesisSelfBond.AddRaw(1).String(),
+	)
+
+	atMinGenesis := cloneGenesisState(genesis)
+	setGenesisMinValidatorBond(t, application, atMinGenesis, genesisSelfBond)
+	require.NoError(t, application.ValidateGenesis(atMinGenesis))
+
+	duplicateSelfDelegationGenesis := cloneGenesisState(genesis)
+	duplicateStakingGenesis := stakingtypes.DefaultGenesisState()
+	application.AppCodec().MustUnmarshalJSON(
+		duplicateSelfDelegationGenesis[stakingtypes.ModuleName],
+		duplicateStakingGenesis,
+	)
+	duplicateStakingGenesis.Delegations = append(
+		duplicateStakingGenesis.Delegations,
+		duplicateStakingGenesis.Delegations[0],
+	)
+	duplicateSelfDelegationGenesis[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+		duplicateStakingGenesis,
+	)
+	require.ErrorContains(
+		t,
+		application.ValidateGenesis(duplicateSelfDelegationGenesis),
+		"duplicate genesis self-delegation",
+	)
+
+	exportedInactiveGenesis := cloneGenesisState(belowMinGenesis)
+	exportedInactiveStakingGenesis := stakingtypes.DefaultGenesisState()
+	application.AppCodec().MustUnmarshalJSON(
+		exportedInactiveGenesis[stakingtypes.ModuleName],
+		exportedInactiveStakingGenesis,
+	)
+	exportedInactiveStakingGenesis.Exported = true
+	exportedInactiveStakingGenesis.LastValidatorPowers = nil
+	exportedInactiveGenesis[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+		exportedInactiveStakingGenesis,
+	)
+	require.NoError(t, application.ValidateGenesis(exportedInactiveGenesis))
+
+	exportedActiveGenesis := cloneGenesisState(belowMinGenesis)
+	exportedActiveStakingGenesis := stakingtypes.DefaultGenesisState()
+	application.AppCodec().MustUnmarshalJSON(
+		exportedActiveGenesis[stakingtypes.ModuleName],
+		exportedActiveStakingGenesis,
+	)
+	exportedActiveStakingGenesis.Exported = true
+	exportedActiveStakingGenesis.LastValidatorPowers = []stakingtypes.LastValidatorPower{
+		{
+			Address: exportedActiveStakingGenesis.Validators[0].GetOperator(),
+			Power:   1,
+		},
+	}
+	exportedActiveGenesis[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+		exportedActiveStakingGenesis,
+	)
+	require.ErrorContains(t, application.ValidateGenesis(exportedActiveGenesis), "genesis self-bond")
+
 	for _, tc := range []struct {
 		name        string
 		mutate      func(*feemarkettypes.Params)
@@ -274,6 +349,26 @@ func TestApplicationStateMachine(t *testing.T) {
 	belowPegResponse, err := application.CheckTx(&abci.RequestCheckTx{Tx: belowPegBytes})
 	require.NoError(t, err)
 	require.False(t, belowPegResponse.IsOK())
+	validatorAddress, err := application.StakingKeeper.ValidatorAddressCodec().BytesToString(cosmosSender)
+	require.NoError(t, err)
+	belowMinSelfBondBytes := signAndEncodeCosmosTx(
+		t,
+		application,
+		cosmosPrivateKey,
+		cosmosSenderAccount.GetAccountNumber(),
+		cosmosSenderAccount.GetSequence(),
+		&stakingtypes.MsgCreateValidator{
+			DelegatorAddress: cosmosSender.String(),
+			ValidatorAddress: validatorAddress,
+			Value:            sdk.NewInt64Coin(config.BaseDenom, 9),
+		},
+		nil,
+		0,
+	)
+	belowMinSelfBondResponse, err := application.CheckTx(&abci.RequestCheckTx{Tx: belowMinSelfBondBytes})
+	require.NoError(t, err)
+	require.False(t, belowMinSelfBondResponse.IsOK())
+	require.Contains(t, belowMinSelfBondResponse.Log, "self-bond below minimum")
 	require.True(t, application.EVMKeeper.IsContract(queryContext, ethparams.HistoryStorageAddress))
 	historyCodeHash := application.EVMKeeper.GetCodeHash(queryContext, ethparams.HistoryStorageAddress)
 	require.Equal(t, ethparams.HistoryStorageCode, application.EVMKeeper.GetCode(queryContext, historyCodeHash))
@@ -643,6 +738,22 @@ func cloneGenesisState(genesis GenesisState) GenesisState {
 		cloned[moduleName] = slices.Clone(state)
 	}
 	return cloned
+}
+
+func setGenesisMinValidatorBond(
+	t *testing.T,
+	application *App,
+	genesis GenesisState,
+	amount sdkmath.Int,
+) {
+	t.Helper()
+	constitutionGenesis := new(constitutiontypes.GenesisState)
+	application.AppCodec().MustUnmarshalJSON(genesis[constitutiontypes.ModuleName], constitutionGenesis)
+	constitutionGenesis.Params.MinValidatorBondAmount = &sdk.Coin{
+		Denom:  config.BaseDenom,
+		Amount: amount,
+	}
+	genesis[constitutiontypes.ModuleName] = application.AppCodec().MustMarshalJSON(constitutionGenesis)
 }
 
 func finalizeAndCommit(

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -124,7 +125,7 @@ func (app *App) unmarshalGenesis(
 }
 
 // ValidateGenesis delegates structural validation to the wired modules and
-// then enforces Guru's Oracle-pegged FeeMarket policy.
+// then enforces Guru's cross-module self-bond and FeeMarket policies.
 func (app *App) ValidateGenesis(genesis GenesisState) error {
 	if err := app.BasicModuleManager.ValidateGenesis(
 		app.AppCodec(),
@@ -133,10 +134,150 @@ func (app *App) ValidateGenesis(genesis GenesisState) error {
 	); err != nil {
 		return fmt.Errorf("validate module genesis: %w", err)
 	}
+	if err := app.validateGenesisValidatorSelfBonds(genesis); err != nil {
+		return err
+	}
 	if err := app.validateFeeMarketGenesisPolicy(genesis); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (app *App) validateGenesisValidatorSelfBonds(genesis GenesisState) error {
+	stakingGenesis := stakingtypes.DefaultGenesisState()
+	if raw, ok := genesis[stakingtypes.ModuleName]; ok {
+		if err := app.AppCodec().UnmarshalJSON(raw, stakingGenesis); err != nil {
+			return fmt.Errorf("decode staking genesis: %w", err)
+		}
+	}
+
+	constitutionGenesis := new(constitutiontypes.GenesisState)
+	if raw, ok := genesis[constitutiontypes.ModuleName]; ok {
+		if err := app.AppCodec().UnmarshalJSON(raw, constitutionGenesis); err != nil {
+			return fmt.Errorf("decode constitution genesis: %w", err)
+		}
+	}
+
+	params := constitutionGenesis.GetParams()
+	if params == nil {
+		defaultGenesis, err := app.defaultConstitutionGenesis()
+		if err != nil {
+			return err
+		}
+		params = defaultGenesis.GetParams()
+	}
+	minBondCoin := params.GetMinValidatorBondAmount()
+	if minBondCoin == nil {
+		return fmt.Errorf("constitution min_validator_bond_amount cannot be nil")
+	}
+	if minBondCoin.Denom != config.BaseDenom {
+		return fmt.Errorf(
+			"constitution min_validator_bond_amount denom must be %q, got %q",
+			config.BaseDenom,
+			minBondCoin.Denom,
+		)
+	}
+	if minBondCoin.Amount.IsNil() {
+		return fmt.Errorf("constitution min_validator_bond_amount amount cannot be nil")
+	}
+	minBond := minBondCoin.Amount
+
+	activeExportedValidators, err := app.activeExportedGenesisValidators(stakingGenesis)
+	if err != nil {
+		return err
+	}
+	for _, validator := range stakingGenesis.Validators {
+		validatorAddr, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(validator.GetOperator())
+		if err != nil {
+			return fmt.Errorf("invalid genesis validator address %s: %w", validator.GetOperator(), err)
+		}
+		if activeExportedValidators != nil {
+			if _, ok := activeExportedValidators[string(validatorAddr)]; !ok {
+				continue
+			}
+		}
+
+		selfBond, err := app.genesisValidatorSelfBond(stakingGenesis.Delegations, validator, validatorAddr)
+		if err != nil {
+			return err
+		}
+		if selfBond.LT(minBond) {
+			return fmt.Errorf(
+				"validator %s genesis self-bond %s below constitution minimum %s",
+				validator.GetOperator(),
+				selfBond.String(),
+				minBond.String(),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (app *App) defaultConstitutionGenesis() (*constitutiontypes.GenesisState, error) {
+	defaultGenesis := app.BasicModuleManager.DefaultGenesis(app.AppCodec())
+	raw, ok := defaultGenesis[constitutiontypes.ModuleName]
+	if !ok {
+		return nil, fmt.Errorf("constitution default genesis missing")
+	}
+
+	constitutionGenesis := new(constitutiontypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, constitutionGenesis); err != nil {
+		return nil, fmt.Errorf("decode constitution default genesis: %w", err)
+	}
+
+	return constitutionGenesis, nil
+}
+
+func (app *App) activeExportedGenesisValidators(stakingGenesis *stakingtypes.GenesisState) (map[string]struct{}, error) {
+	if !stakingGenesis.GetExported() {
+		return nil, nil
+	}
+
+	activeValidators := make(map[string]struct{}, len(stakingGenesis.GetLastValidatorPowers()))
+	for _, lastValidatorPower := range stakingGenesis.GetLastValidatorPowers() {
+		validatorAddr, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(lastValidatorPower.Address)
+		if err != nil {
+			return nil, fmt.Errorf("invalid exported last validator address %s: %w", lastValidatorPower.Address, err)
+		}
+		activeValidators[string(validatorAddr)] = struct{}{}
+	}
+
+	return activeValidators, nil
+}
+
+func (app *App) genesisValidatorSelfBond(
+	delegations []stakingtypes.Delegation,
+	validator stakingtypes.Validator,
+	validatorAddr []byte,
+) (sdkmath.Int, error) {
+	selfBond := sdkmath.ZeroInt()
+	selfDelegationFound := false
+	for _, delegation := range delegations {
+		delegationValidatorAddr, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(delegation.ValidatorAddress)
+		if err != nil {
+			return sdkmath.Int{}, fmt.Errorf("invalid genesis delegation validator address %s: %w", delegation.ValidatorAddress, err)
+		}
+		if !bytes.Equal(delegationValidatorAddr, validatorAddr) {
+			continue
+		}
+
+		delegatorAddr, err := app.AccountKeeper.AddressCodec().StringToBytes(delegation.DelegatorAddress)
+		if err != nil {
+			return sdkmath.Int{}, fmt.Errorf("invalid genesis delegation delegator address %s: %w", delegation.DelegatorAddress, err)
+		}
+		if !bytes.Equal(delegatorAddr, validatorAddr) {
+			continue
+		}
+
+		if selfDelegationFound {
+			return sdkmath.Int{}, fmt.Errorf("duplicate genesis self-delegation for validator %s", validator.GetOperator())
+		}
+		selfDelegationFound = true
+		selfBond = selfBond.Add(validator.TokensFromSharesTruncated(delegation.GetShares()).TruncateInt())
+	}
+
+	return selfBond, nil
 }
 
 func (app *App) validateFeeMarketGenesisPolicy(genesis GenesisState) error {

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -29,9 +29,10 @@ func (app *App) configureAnteHandler(maxTxGasWanted uint64) error {
 	if err := options.Validate(); err != nil {
 		return fmt.Errorf("validate ante handler options: %w", err)
 	}
-	app.anteHandler = appante.WrapAnteHandlerWithOracleProposalOptionBlock(
-		appante.NewAnteHandler(options),
-	)
+	anteHandler := appante.NewAnteHandler(options)
+	anteHandler = appante.WrapAnteHandlerWithSelfBondCheck(anteHandler, app.CustomStakingKeeper)
+	anteHandler = appante.WrapAnteHandlerWithOracleProposalOptionBlock(anteHandler)
+	app.anteHandler = anteHandler
 	app.SetAnteHandler(app.anteHandler)
 	return nil
 }

--- a/app/keepers.go
+++ b/app/keepers.go
@@ -49,6 +49,7 @@ import (
 	constitutiontypes "github.com/gurufinglobal/guru/v2/x/constitution/types"
 	oraclekeeper "github.com/gurufinglobal/guru/v2/x/oracle/keeper"
 	oracletypes "github.com/gurufinglobal/guru/v2/x/oracle/types"
+	customstakingkeeper "github.com/gurufinglobal/guru/v2/x/staking/keeper"
 )
 
 // AppKeepers owns the stateful dependencies used by the Guru application.
@@ -60,6 +61,7 @@ type AppKeepers struct {
 	AccountKeeper         authkeeper.AccountKeeper
 	BankKeeper            bankkeeper.Keeper
 	StakingKeeper         *stakingkeeper.Keeper
+	CustomStakingKeeper   *customstakingkeeper.Keeper
 	SlashingKeeper        slashingkeeper.Keeper
 	MintKeeper            mintkeeper.Keeper
 	DistrKeeper           distrkeeper.Keeper
@@ -244,6 +246,11 @@ func newAppKeepers(cfg keeperConfig) (*AppKeepers, error) {
 		keepers.BankKeeper,
 	)
 	keepers.ConstitutionKeeper.SetFeeMarketKeeper(keepers.FeeMarketAdapter)
+	keepers.CustomStakingKeeper = customstakingkeeper.NewKeeper(
+		keepers.StakingKeeper,
+		&keepers.ConstitutionKeeper,
+		keepers.AccountKeeper.AddressCodec(),
+	)
 	keepers.OracleKeeper = oraclekeeper.NewKeeper(
 		runtime.NewKVStoreService(keys.getKVStoreKey(oracletypes.StoreKey)),
 		cfg.codec,

--- a/app/modules.go
+++ b/app/modules.go
@@ -32,7 +32,7 @@ import (
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
-	"github.com/cosmos/cosmos-sdk/x/staking"
+	sdkstaking "github.com/cosmos/cosmos-sdk/x/staking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/evm/x/erc20"
 	erc20types "github.com/cosmos/evm/x/erc20/types"
@@ -54,6 +54,7 @@ import (
 	constitutiontypes "github.com/gurufinglobal/guru/v2/x/constitution/types"
 	oracle "github.com/gurufinglobal/guru/v2/x/oracle"
 	oracletypes "github.com/gurufinglobal/guru/v2/x/oracle/types"
+	customstaking "github.com/gurufinglobal/guru/v2/x/staking"
 )
 
 var (
@@ -168,7 +169,10 @@ func (app *App) configureModules(tmLightClient ibctm.LightClientModule) error {
 		mint.NewAppModule(app.AppCodec(), app.MintKeeper, app.AccountKeeper, nil, nil),
 		slashing.NewAppModule(app.AppCodec(), app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper, nil, app.InterfaceRegistry()),
 		distribution.NewAppModule(app.AppCodec(), app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper, nil),
-		staking.NewAppModule(app.AppCodec(), app.StakingKeeper, app.AccountKeeper, app.BankKeeper, nil),
+		customstaking.NewAppModule(
+			sdkstaking.NewAppModule(app.AppCodec(), app.StakingKeeper, app.AccountKeeper, app.BankKeeper, nil),
+			app.CustomStakingKeeper,
+		),
 		upgrade.NewAppModule(app.UpgradeKeeper, app.AccountKeeper.AddressCodec()),
 		evidence.NewAppModule(app.EvidenceKeeper),
 		authzmodule.NewAppModule(app.AppCodec(), app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.InterfaceRegistry()),
@@ -220,7 +224,7 @@ func NewBasicManager() module.BasicManager {
 		mint.AppModuleBasic{},
 		slashing.AppModuleBasic{},
 		distribution.AppModuleBasic{},
-		staking.AppModuleBasic{},
+		sdkstaking.AppModuleBasic{},
 		upgrade.AppModuleBasic{},
 		evidence.NewAppModuleBasic(),
 		authzmodule.AppModuleBasic{},

--- a/x/staking/keeper/expected_keepers.go
+++ b/x/staking/keeper/expected_keepers.go
@@ -1,0 +1,11 @@
+package keeper
+
+import (
+	"context"
+
+	"cosmossdk.io/math"
+)
+
+type MinValidatorBondSource interface {
+	GetMinValidatorBondAmount(ctx context.Context) (math.Int, error)
+}

--- a/x/staking/keeper/genesis.go
+++ b/x/staking/keeper/genesis.go
@@ -1,0 +1,64 @@
+package keeper
+
+import (
+	"context"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cryptoproto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// InitGenesis delegates base staking initialization and reapplies validator set
+// updates through the custom path to enforce min self-bond at genesis.
+func (k *Keeper) InitGenesis(ctx context.Context, data *stakingtypes.GenesisState) (res []abci.ValidatorUpdate) {
+	baseUpdates := k.Keeper.InitGenesis(ctx, data)
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx).WithBlockHeight(1 - sdk.ValidatorUpdateDelay)
+	updates, err := k.ApplyAndReturnValidatorSetUpdates(sdkCtx)
+	if err != nil {
+		panic(err)
+	}
+
+	return mergeValidatorUpdates(baseUpdates, updates)
+}
+
+func mergeValidatorUpdates(base []abci.ValidatorUpdate, overrides []abci.ValidatorUpdate) []abci.ValidatorUpdate {
+	if len(overrides) == 0 {
+		return base
+	}
+
+	merged := make(map[string]abci.ValidatorUpdate, len(base)+len(overrides))
+	order := make([]string, 0, len(base)+len(overrides))
+
+	add := func(updates []abci.ValidatorUpdate) {
+		for _, update := range updates {
+			key := validatorUpdateKey(update)
+			if _, exists := merged[key]; !exists {
+				order = append(order, key)
+			}
+			merged[key] = update
+		}
+	}
+
+	add(base)
+	add(overrides)
+
+	out := make([]abci.ValidatorUpdate, 0, len(order))
+	for _, key := range order {
+		out = append(out, merged[key])
+	}
+
+	return out
+}
+
+func validatorUpdateKey(update abci.ValidatorUpdate) string {
+	switch pubKey := update.PubKey.GetSum().(type) {
+	case *cryptoproto.PublicKey_Ed25519:
+		return "ed25519:" + string(pubKey.Ed25519)
+	case *cryptoproto.PublicKey_Secp256K1:
+		return "secp256k1:" + string(pubKey.Secp256K1)
+	default:
+		panic("unknown validator update public key type")
+	}
+}

--- a/x/staking/keeper/genesis_test.go
+++ b/x/staking/keeper/genesis_test.go
@@ -1,0 +1,79 @@
+package keeper
+
+import (
+	"context"
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cryptoproto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitGenesisPanicsWhenBaseKeeperIsNil(t *testing.T) {
+	k := &Keeper{}
+	ctx := sdk.Context{}.WithContext(context.Background())
+
+	require.Panics(t, func() {
+		_ = k.InitGenesis(ctx, stakingtypes.DefaultGenesisState())
+	})
+}
+
+func TestMergeValidatorUpdatesUsesBaseWhenNoOverrides(t *testing.T) {
+	base := []abci.ValidatorUpdate{
+		{
+			PubKey: cryptoproto.PublicKey{Sum: &cryptoproto.PublicKey_Ed25519{Ed25519: []byte{0x01}}},
+			Power:  10,
+		},
+	}
+
+	merged := mergeValidatorUpdates(base, nil)
+	require.Equal(t, base, merged)
+}
+
+func TestMergeValidatorUpdatesAppliesOverrideByPubKey(t *testing.T) {
+	base := []abci.ValidatorUpdate{
+		{
+			PubKey: cryptoproto.PublicKey{Sum: &cryptoproto.PublicKey_Ed25519{Ed25519: []byte{0x01}}},
+			Power:  10,
+		},
+		{
+			PubKey: cryptoproto.PublicKey{Sum: &cryptoproto.PublicKey_Ed25519{Ed25519: []byte{0x02}}},
+			Power:  20,
+		},
+	}
+
+	overrides := []abci.ValidatorUpdate{
+		{
+			PubKey: cryptoproto.PublicKey{Sum: &cryptoproto.PublicKey_Ed25519{Ed25519: []byte{0x01}}},
+			Power:  0,
+		},
+	}
+
+	merged := mergeValidatorUpdates(base, overrides)
+	require.Len(t, merged, 2)
+	require.Equal(t, int64(0), merged[0].Power)
+	require.Equal(t, int64(20), merged[1].Power)
+}
+
+func TestMergeValidatorUpdatesKeepsDifferentPubKeyTypes(t *testing.T) {
+	base := []abci.ValidatorUpdate{
+		{
+			PubKey: cryptoproto.PublicKey{Sum: &cryptoproto.PublicKey_Ed25519{Ed25519: []byte{0x01}}},
+			Power:  10,
+		},
+	}
+
+	overrides := []abci.ValidatorUpdate{
+		{
+			PubKey: cryptoproto.PublicKey{Sum: &cryptoproto.PublicKey_Secp256K1{Secp256K1: []byte{0x01}}},
+			Power:  20,
+		},
+	}
+
+	merged := mergeValidatorUpdates(base, overrides)
+	require.Len(t, merged, 2)
+	require.Equal(t, int64(10), merged[0].Power)
+	require.Equal(t, int64(20), merged[1].Power)
+}

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -1,0 +1,196 @@
+package keeper
+
+import (
+	"context"
+	"errors"
+
+	"cosmossdk.io/core/address"
+	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+type Keeper struct {
+	*stakingkeeper.Keeper
+	minBondSource MinValidatorBondSource
+	accountCodec  address.Codec
+}
+
+func NewKeeper(
+	stakingKeeper *stakingkeeper.Keeper,
+	minBondSource MinValidatorBondSource,
+	accountCodec address.Codec,
+) *Keeper {
+	return &Keeper{
+		Keeper:        stakingKeeper,
+		minBondSource: minBondSource,
+		accountCodec:  accountCodec,
+	}
+}
+
+func (k *Keeper) EndBlocker(ctx context.Context) ([]abci.ValidatorUpdate, error) {
+	defer telemetry.ModuleMeasureSince(stakingtypes.ModuleName, telemetry.Now(), telemetry.MetricKeyEndBlocker) //nolint:staticcheck // TODO: switch to OpenTelemetry
+	return k.BlockValidatorUpdates(ctx)
+}
+
+func (k *Keeper) BlockValidatorUpdates(ctx context.Context) ([]abci.ValidatorUpdate, error) {
+	validatorUpdates, err := k.ApplyAndReturnValidatorSetUpdates(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := k.UnbondAllMatureValidators(ctx); err != nil {
+		return nil, err
+	}
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	matureUnbonds, err := k.DequeueAllMatureUBDQueue(ctx, sdkCtx.BlockHeader().Time)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dvPair := range matureUnbonds {
+		validatorAddr, err := k.ValidatorAddressCodec().StringToBytes(dvPair.ValidatorAddress)
+		if err != nil {
+			return nil, err
+		}
+		delegatorAddr, err := k.accountCodec.StringToBytes(dvPair.DelegatorAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		balances, err := k.CompleteUnbonding(ctx, delegatorAddr, validatorAddr)
+		if err != nil {
+			continue
+		}
+
+		sdkCtx.EventManager().EmitEvent(
+			sdk.NewEvent(
+				stakingtypes.EventTypeCompleteUnbonding,
+				sdk.NewAttribute(sdk.AttributeKeyAmount, balances.String()),
+				sdk.NewAttribute(stakingtypes.AttributeKeyValidator, dvPair.ValidatorAddress),
+				sdk.NewAttribute(stakingtypes.AttributeKeyDelegator, dvPair.DelegatorAddress),
+			),
+		)
+	}
+
+	matureRedelegations, err := k.DequeueAllMatureRedelegationQueue(ctx, sdkCtx.BlockHeader().Time)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dvvTriplet := range matureRedelegations {
+		valSrcAddr, err := k.ValidatorAddressCodec().StringToBytes(dvvTriplet.ValidatorSrcAddress)
+		if err != nil {
+			return nil, err
+		}
+		valDstAddr, err := k.ValidatorAddressCodec().StringToBytes(dvvTriplet.ValidatorDstAddress)
+		if err != nil {
+			return nil, err
+		}
+		delegatorAddr, err := k.accountCodec.StringToBytes(dvvTriplet.DelegatorAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		balances, err := k.CompleteRedelegation(ctx, delegatorAddr, valSrcAddr, valDstAddr)
+		if err != nil {
+			continue
+		}
+
+		sdkCtx.EventManager().EmitEvent(
+			sdk.NewEvent(
+				stakingtypes.EventTypeCompleteRedelegation,
+				sdk.NewAttribute(sdk.AttributeKeyAmount, balances.String()),
+				sdk.NewAttribute(stakingtypes.AttributeKeyDelegator, dvvTriplet.DelegatorAddress),
+				sdk.NewAttribute(stakingtypes.AttributeKeySrcValidator, dvvTriplet.ValidatorSrcAddress),
+				sdk.NewAttribute(stakingtypes.AttributeKeyDstValidator, dvvTriplet.ValidatorDstAddress),
+			),
+		)
+	}
+
+	return validatorUpdates, nil
+}
+
+func (k *Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) ([]abci.ValidatorUpdate, error) {
+	if err := k.excludeValidatorsBelowMinSelfBondFromPowerIndex(ctx); err != nil {
+		return nil, err
+	}
+
+	return k.Keeper.ApplyAndReturnValidatorSetUpdates(ctx)
+}
+
+func (k *Keeper) excludeValidatorsBelowMinSelfBondFromPowerIndex(ctx context.Context) error {
+	minBond, err := k.minBondSource.GetMinValidatorBondAmount(ctx)
+	if err != nil {
+		return err
+	}
+
+	iterator, err := k.ValidatorsPowerStoreIterator(ctx)
+	if err != nil {
+		return err
+	}
+	iteratorClosed := false
+	defer func() {
+		if !iteratorClosed {
+			_ = iterator.Close()
+		}
+	}()
+
+	validatorsToRemove := make([]stakingtypes.Validator, 0)
+	for ; iterator.Valid(); iterator.Next() {
+		validatorAddr := sdk.ValAddress(iterator.Value())
+		validator, err := k.GetValidator(ctx, validatorAddr)
+		if err != nil {
+			return err
+		}
+
+		selfBond, err := k.getValidatorSelfBondFromDelegation(ctx, validatorAddr, validator)
+		if err != nil {
+			return err
+		}
+		if selfBond.LT(minBond) {
+			validatorsToRemove = append(validatorsToRemove, validator)
+		}
+	}
+	_ = iterator.Close()
+	iteratorClosed = true
+
+	for _, validator := range validatorsToRemove {
+		if err := k.DeleteValidatorByPowerIndex(ctx, validator); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (k *Keeper) GetValidatorSelfBond(ctx context.Context, validatorAddr sdk.ValAddress) (sdkmath.Int, error) {
+	validator, err := k.GetValidator(ctx, validatorAddr)
+	if err != nil {
+		return sdkmath.Int{}, err
+	}
+
+	selfBond, err := k.getValidatorSelfBondFromDelegation(ctx, validatorAddr, validator)
+	if err != nil {
+		return sdkmath.Int{}, err
+	}
+
+	return selfBond, nil
+}
+
+func (k *Keeper) getValidatorSelfBondFromDelegation(ctx context.Context, validatorAddr sdk.ValAddress, validator stakingtypes.Validator) (sdkmath.Int, error) {
+	delegation, err := k.GetDelegation(ctx, sdk.AccAddress(validatorAddr), validatorAddr)
+	if err != nil {
+		if errors.Is(err, stakingtypes.ErrNoDelegation) {
+			return sdkmath.ZeroInt(), nil
+		}
+
+		return sdkmath.Int{}, err
+	}
+
+	return validator.TokensFromSharesTruncated(delegation.GetShares()).TruncateInt(), nil
+}

--- a/x/staking/keeper/self_bond_ante.go
+++ b/x/staking/keeper/self_bond_ante.go
@@ -1,0 +1,90 @@
+package keeper
+
+import (
+	"context"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/gurufinglobal/guru/v2/config"
+	constitutiontypes "github.com/gurufinglobal/guru/v2/x/constitution/types"
+)
+
+func (k *Keeper) ValidateTxSelfBondConstraints(ctx context.Context, tx sdk.Tx) error {
+	if tx == nil {
+		return nil
+	}
+
+	var (
+		minBond       sdkmath.Int
+		minBondLoaded bool
+	)
+	getMinBond := func() (sdkmath.Int, error) {
+		if minBondLoaded {
+			return minBond, nil
+		}
+		loadedMinBond, err := k.minBondSource.GetMinValidatorBondAmount(ctx)
+		if err != nil {
+			return sdkmath.Int{}, err
+		}
+		minBond = loadedMinBond
+		minBondLoaded = true
+		return minBond, nil
+	}
+
+	for _, msg := range tx.GetMsgs() {
+		if err := k.validateMsgSelfBondConstraints(msg, getMinBond); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type minBondGetter func() (sdkmath.Int, error)
+
+func (k *Keeper) validateMsgSelfBondConstraints(
+	msg sdk.Msg,
+	getMinBond minBondGetter,
+) error {
+	switch m := msg.(type) {
+	case *stakingtypes.MsgCreateValidator:
+		return k.validateCreateValidatorSelfBond(m, getMinBond)
+	case *authztypes.MsgExec:
+		msgs, err := m.GetMessages()
+		if err != nil {
+			return err
+		}
+		for _, nested := range msgs {
+			if err := k.validateMsgSelfBondConstraints(nested, getMinBond); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (k *Keeper) validateCreateValidatorSelfBond(
+	msg *stakingtypes.MsgCreateValidator,
+	getMinBond minBondGetter,
+) error {
+	if msg.Value.Denom != config.BaseDenom {
+		return nil
+	}
+
+	minBond, err := getMinBond()
+	if err != nil {
+		return err
+	}
+	if msg.Value.Amount.LT(minBond) {
+		return constitutiontypes.ErrSelfBondBelowMin.Wrapf(
+			"msg create validator self-bond %s below minimum %s",
+			msg.Value.Amount,
+			minBond,
+		)
+	}
+
+	return nil
+}

--- a/x/staking/keeper/self_bond_ante_test.go
+++ b/x/staking/keeper/self_bond_ante_test.go
@@ -1,0 +1,435 @@
+package keeper
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	coreaddress "cosmossdk.io/core/address"
+	corestore "cosmossdk.io/core/store"
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtestutil "github.com/cosmos/cosmos-sdk/x/staking/testutil"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	evmaddress "github.com/cosmos/evm/encoding/address"
+	"github.com/gurufinglobal/guru/v2/config"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	protov2 "google.golang.org/protobuf/proto"
+)
+
+type mockMinValidatorBondSource struct {
+	minBond sdkmath.Int
+	err     error
+}
+
+func (m mockMinValidatorBondSource) GetMinValidatorBondAmount(context.Context) (sdkmath.Int, error) {
+	if m.err != nil {
+		return sdkmath.Int{}, m.err
+	}
+
+	return m.minBond, nil
+}
+
+type testTx struct {
+	msgs []sdk.Msg
+}
+
+func (tx testTx) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx testTx) GetMsgsV2() ([]protov2.Message, error) {
+	return nil, nil
+}
+
+type anteKeeperFixture struct {
+	ctx                  sdk.Context
+	keeper               *Keeper
+	accountCodec         coreaddress.Codec
+	valCodec             coreaddress.Codec
+	validatorAddr        sdk.ValAddress
+	validatorAddress     string
+	selfDelegatorAddress string
+	storeService         corestore.KVStoreService
+}
+
+func mustInt(t *testing.T, amount string) sdkmath.Int {
+	t.Helper()
+
+	value, ok := sdkmath.NewIntFromString(amount)
+	if !ok {
+		t.Fatalf("failed to parse int: %s", amount)
+	}
+
+	return value
+}
+
+func mustAnyWithValue(t *testing.T, msg sdk.Msg) *codectypes.Any {
+	t.Helper()
+
+	any, err := codectypes.NewAnyWithValue(msg)
+	if err != nil {
+		t.Fatalf("failed to pack message into Any: %v", err)
+	}
+
+	return any
+}
+
+func setupAnteKeeperFixture(t *testing.T, minBond string) anteKeeperFixture {
+	t.Helper()
+
+	key := storetypes.NewKVStoreKey(stakingtypes.StoreKey)
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := sdktestutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_staking_test"))
+
+	accountCodec := evmaddress.NewEvmCodec(config.Bech32PrefixAccAddr)
+	valCodec := evmaddress.NewEvmCodec(config.Bech32PrefixValAddr)
+	consCodec := evmaddress.NewEvmCodec(config.Bech32PrefixConsAddr)
+
+	ctrl := gomock.NewController(t)
+	accountKeeper := stakingtestutil.NewMockAccountKeeper(ctrl)
+	accountKeeper.EXPECT().GetModuleAddress(stakingtypes.BondedPoolName).
+		Return(authtypes.NewEmptyModuleAccount(stakingtypes.BondedPoolName).GetAddress()).
+		AnyTimes()
+	accountKeeper.EXPECT().GetModuleAddress(stakingtypes.NotBondedPoolName).
+		Return(authtypes.NewEmptyModuleAccount(stakingtypes.NotBondedPoolName).GetAddress()).
+		AnyTimes()
+	accountKeeper.EXPECT().AddressCodec().Return(accountCodec).AnyTimes()
+
+	bankKeeper := stakingtestutil.NewMockBankKeeper(ctrl)
+	authority, err := accountCodec.BytesToString(authtypes.NewModuleAddress(govtypes.ModuleName))
+	require.NoError(t, err)
+
+	encCfg := moduletestutil.MakeTestEncodingConfig()
+	baseKeeper := stakingkeeper.NewKeeper(
+		encCfg.Codec,
+		storeService,
+		accountKeeper,
+		bankKeeper,
+		authority,
+		valCodec,
+		consCodec,
+	)
+	require.NoError(t, baseKeeper.SetParams(testCtx.Ctx, stakingtypes.DefaultParams()))
+
+	customKeeper := &Keeper{
+		Keeper:        baseKeeper,
+		minBondSource: mockMinValidatorBondSource{minBond: mustInt(t, minBond)},
+		accountCodec:  accountCodec,
+	}
+
+	validatorAddr := sdk.ValAddress(bytes.Repeat([]byte{0x11}, 20))
+	validatorAddress, err := valCodec.BytesToString(validatorAddr)
+	require.NoError(t, err)
+	delegatorAddress, err := accountCodec.BytesToString(validatorAddr)
+	require.NoError(t, err)
+
+	shares := sdkmath.LegacyNewDec(120)
+	validator := stakingtypes.Validator{
+		OperatorAddress: validatorAddress,
+		Status:          stakingtypes.Bonded,
+		Tokens:          mustInt(t, "120"),
+		DelegatorShares: shares,
+	}
+	require.NoError(t, customKeeper.SetValidator(testCtx.Ctx, validator))
+	require.NoError(t, customKeeper.SetDelegation(testCtx.Ctx, stakingtypes.NewDelegation(delegatorAddress, validatorAddress, shares)))
+
+	return anteKeeperFixture{
+		ctx:                  testCtx.Ctx,
+		keeper:               customKeeper,
+		accountCodec:         accountCodec,
+		valCodec:             valCodec,
+		validatorAddr:        validatorAddr,
+		validatorAddress:     validatorAddress,
+		selfDelegatorAddress: delegatorAddress,
+		storeService:         storeService,
+	}
+}
+
+func TestValidateTxSelfBondConstraints(t *testing.T) {
+	f := setupAnteKeeperFixture(t, "100")
+
+	otherDelegatorAddress, err := f.accountCodec.BytesToString(bytes.Repeat([]byte{0x22}, 20))
+	require.NoError(t, err)
+	otherValidatorAddress, err := f.valCodec.BytesToString(bytes.Repeat([]byte{0x44}, 20))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		tx        sdk.Tx
+		shouldErr bool
+	}{
+		{"nil tx ignored", nil, false},
+		{
+			name: "rejects create validator below minimum",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgCreateValidator{
+					ValidatorAddress: f.validatorAddress,
+					Value:            sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "99")},
+				},
+			}},
+			shouldErr: true,
+		},
+		{
+			name: "allows create validator at minimum",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgCreateValidator{
+					ValidatorAddress: f.validatorAddress,
+					Value:            sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "100")},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "allows self delegate",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgDelegate{
+					DelegatorAddress: f.selfDelegatorAddress,
+					ValidatorAddress: f.validatorAddress,
+					Amount:           sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "1")},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "allows self undelegate below minimum",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgUndelegate{
+					DelegatorAddress: f.selfDelegatorAddress,
+					ValidatorAddress: f.validatorAddress,
+					Amount:           sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "30")},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "allows self begin redelegate below minimum",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgBeginRedelegate{
+					DelegatorAddress:    f.selfDelegatorAddress,
+					ValidatorSrcAddress: f.validatorAddress,
+					ValidatorDstAddress: otherValidatorAddress,
+					Amount:              sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "30")},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "allows self cancel unbonding delegation below minimum",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgCancelUnbondingDelegation{
+					DelegatorAddress: f.selfDelegatorAddress,
+					ValidatorAddress: f.validatorAddress,
+					Amount:           sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "30")},
+					CreationHeight:   1,
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "allows non-self undelegate",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgUndelegate{
+					DelegatorAddress: otherDelegatorAddress,
+					ValidatorAddress: f.validatorAddress,
+					Amount:           sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "30")},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "allows nested authz undelegate below minimum",
+			tx: testTx{msgs: []sdk.Msg{
+				&authztypes.MsgExec{
+					Grantee: "grantee",
+					Msgs: []*codectypes.Any{
+						mustAnyWithValue(t, &stakingtypes.MsgUndelegate{
+							DelegatorAddress: f.selfDelegatorAddress,
+							ValidatorAddress: f.validatorAddress,
+							Amount:           sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "30")},
+						}),
+					},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "allows nested authz begin redelegate below minimum",
+			tx: testTx{msgs: []sdk.Msg{
+				&authztypes.MsgExec{
+					Grantee: "grantee",
+					Msgs: []*codectypes.Any{
+						mustAnyWithValue(t, &stakingtypes.MsgBeginRedelegate{
+							DelegatorAddress:    f.selfDelegatorAddress,
+							ValidatorSrcAddress: f.validatorAddress,
+							ValidatorDstAddress: otherValidatorAddress,
+							Amount:              sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "30")},
+						}),
+					},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "rejects nested authz create validator below minimum",
+			tx: testTx{msgs: []sdk.Msg{
+				&authztypes.MsgExec{
+					Grantee: "grantee",
+					Msgs: []*codectypes.Any{
+						mustAnyWithValue(t, &stakingtypes.MsgCreateValidator{
+							ValidatorAddress: f.validatorAddress,
+							Value:            sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "99")},
+						}),
+					},
+				},
+			}},
+			shouldErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := f.keeper.ValidateTxSelfBondConstraints(f.ctx, tc.tx)
+			if tc.shouldErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateTxSelfBondConstraintsLoadsMinBondOnlyForBaseCreateValidator(t *testing.T) {
+	f := setupAnteKeeperFixture(t, "100")
+	f.keeper.minBondSource = mockMinValidatorBondSource{err: errors.New("min bond loaded")}
+
+	tests := []struct {
+		name      string
+		tx        sdk.Tx
+		shouldErr bool
+	}{
+		{
+			name: "self delegate does not load min bond",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgDelegate{
+					DelegatorAddress: f.selfDelegatorAddress,
+					ValidatorAddress: f.validatorAddress,
+					Amount:           sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "1")},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "non-base create validator does not load min bond",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgCreateValidator{
+					ValidatorAddress: f.validatorAddress,
+					Value:            sdk.Coin{Denom: "stake", Amount: mustInt(t, "1")},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "nested non-create message does not load min bond",
+			tx: testTx{msgs: []sdk.Msg{
+				&authztypes.MsgExec{
+					Grantee: "grantee",
+					Msgs: []*codectypes.Any{
+						mustAnyWithValue(t, &stakingtypes.MsgUndelegate{
+							DelegatorAddress: f.selfDelegatorAddress,
+							ValidatorAddress: f.validatorAddress,
+							Amount:           sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "1")},
+						}),
+					},
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			name: "base create validator loads min bond",
+			tx: testTx{msgs: []sdk.Msg{
+				&stakingtypes.MsgCreateValidator{
+					ValidatorAddress: f.validatorAddress,
+					Value:            sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "100")},
+				},
+			}},
+			shouldErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := f.keeper.ValidateTxSelfBondConstraints(f.ctx, tc.tx)
+			if tc.shouldErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "min bond loaded")
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateTxSelfBondConstraintsHandlesMissingValidator(t *testing.T) {
+	f := setupAnteKeeperFixture(t, "100")
+
+	missingValAddr := sdk.ValAddress(bytes.Repeat([]byte{0x33}, 20))
+	validatorAddress, err := f.valCodec.BytesToString(missingValAddr)
+	require.NoError(t, err)
+	delegatorAddress, err := f.accountCodec.BytesToString(missingValAddr)
+	require.NoError(t, err)
+
+	tx := testTx{msgs: []sdk.Msg{
+		&stakingtypes.MsgUndelegate{
+			DelegatorAddress: delegatorAddress,
+			ValidatorAddress: validatorAddress,
+			Amount:           sdk.Coin{Denom: config.BaseDenom, Amount: mustInt(t, "1")},
+		},
+	}}
+
+	require.NoError(t, f.keeper.ValidateTxSelfBondConstraints(f.ctx, tx))
+}
+
+func TestGetValidatorSelfBond(t *testing.T) {
+	f := setupAnteKeeperFixture(t, "100")
+
+	selfBond, err := f.keeper.GetValidatorSelfBond(f.ctx, f.validatorAddr)
+	require.NoError(t, err)
+	require.Equal(t, "120", selfBond.String())
+}
+
+func TestGetValidatorSelfBondReturnsZeroWhenNoDelegation(t *testing.T) {
+	f := setupAnteKeeperFixture(t, "100")
+
+	delegation, err := f.keeper.GetDelegation(f.ctx, sdk.AccAddress(f.validatorAddr), f.validatorAddr)
+	require.NoError(t, err)
+	require.NoError(t, f.keeper.RemoveDelegation(f.ctx, delegation))
+
+	selfBond, err := f.keeper.GetValidatorSelfBond(f.ctx, f.validatorAddr)
+	require.NoError(t, err)
+	require.True(t, selfBond.IsZero())
+}
+
+func TestGetValidatorSelfBondPropagatesDelegationError(t *testing.T) {
+	f := setupAnteKeeperFixture(t, "100")
+
+	store := f.storeService.OpenKVStore(f.ctx)
+	err := store.Set(stakingtypes.GetDelegationKey(sdk.AccAddress(f.validatorAddr), f.validatorAddr), []byte("not-a-valid-delegation"))
+	require.NoError(t, err)
+
+	_, err = f.keeper.GetValidatorSelfBond(f.ctx, f.validatorAddr)
+	require.Error(t, err)
+}

--- a/x/staking/keeper/validator_set_test.go
+++ b/x/staking/keeper/validator_set_test.go
@@ -1,0 +1,279 @@
+package keeper
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	coreaddress "cosmossdk.io/core/address"
+	corestore "cosmossdk.io/core/store"
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtestutil "github.com/cosmos/cosmos-sdk/x/staking/testutil"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	evmaddress "github.com/cosmos/evm/encoding/address"
+	"github.com/gurufinglobal/guru/v2/config"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type mutableMinValidatorBondSource struct {
+	minBond sdkmath.Int
+}
+
+func (m *mutableMinValidatorBondSource) GetMinValidatorBondAmount(context.Context) (sdkmath.Int, error) {
+	return m.minBond, nil
+}
+
+type validatorSetFixture struct {
+	ctx           sdk.Context
+	keeper        *Keeper
+	minBondSource *mutableMinValidatorBondSource
+	storeService  corestore.KVStoreService
+	valAddrs      []sdk.ValAddress
+}
+
+func setupValidatorSetFixture(t *testing.T, minBondPower int64) validatorSetFixture {
+	t.Helper()
+
+	key := storetypes.NewKVStoreKey(stakingtypes.StoreKey)
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := sdktestutilDefaultContextWithDB(t, key)
+
+	accountCodec := evmaddress.NewEvmCodec(config.Bech32PrefixAccAddr)
+	valCodec := evmaddress.NewEvmCodec(config.Bech32PrefixValAddr)
+	consCodec := evmaddress.NewEvmCodec(config.Bech32PrefixConsAddr)
+
+	ctrl := gomock.NewController(t)
+	accountKeeper := stakingtestutil.NewMockAccountKeeper(ctrl)
+	accountKeeper.EXPECT().GetModuleAddress(stakingtypes.BondedPoolName).
+		Return(authtypes.NewEmptyModuleAccount(stakingtypes.BondedPoolName).GetAddress()).
+		AnyTimes()
+	accountKeeper.EXPECT().GetModuleAddress(stakingtypes.NotBondedPoolName).
+		Return(authtypes.NewEmptyModuleAccount(stakingtypes.NotBondedPoolName).GetAddress()).
+		AnyTimes()
+	accountKeeper.EXPECT().AddressCodec().Return(accountCodec).AnyTimes()
+
+	bankKeeper := stakingtestutil.NewMockBankKeeper(ctrl)
+	bankKeeper.EXPECT().
+		SendCoinsFromModuleToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+
+	authority, err := accountCodec.BytesToString(authtypes.NewModuleAddress(govtypes.ModuleName))
+	require.NoError(t, err)
+
+	encCfg := moduletestutil.MakeTestEncodingConfig()
+	baseKeeper := stakingkeeper.NewKeeper(
+		encCfg.Codec,
+		storeService,
+		accountKeeper,
+		bankKeeper,
+		authority,
+		valCodec,
+		consCodec,
+	)
+	params := stakingtypes.DefaultParams()
+	params.BondDenom = config.BaseDenom
+	require.NoError(t, baseKeeper.SetParams(testCtx, params))
+
+	minBondSource := &mutableMinValidatorBondSource{
+		minBond: baseKeeper.TokensFromConsensusPower(testCtx, minBondPower),
+	}
+	customKeeper := NewKeeper(baseKeeper, minBondSource, accountCodec)
+
+	pks := simtestutil.CreateTestPubKeys(3)
+	valAddrs := []sdk.ValAddress{
+		sdk.ValAddress(pks[0].Address().Bytes()),
+		sdk.ValAddress(pks[1].Address().Bytes()),
+		sdk.ValAddress(pks[2].Address().Bytes()),
+	}
+
+	for i, valAddr := range valAddrs {
+		validator := newTestValidator(t, valCodec, valAddr, pks[i])
+		require.NoError(t, customKeeper.SetValidator(testCtx, validator))
+		require.NoError(t, customKeeper.SetValidatorByConsAddr(testCtx, validator))
+	}
+
+	return validatorSetFixture{
+		ctx:           testCtx,
+		keeper:        customKeeper,
+		minBondSource: minBondSource,
+		storeService:  storeService,
+		valAddrs:      valAddrs,
+	}
+}
+
+func newTestValidator(
+	t *testing.T,
+	valCodec coreaddress.Codec,
+	valAddr sdk.ValAddress,
+	pubKey cryptotypes.PubKey,
+) stakingtypes.Validator {
+	t.Helper()
+
+	validatorAddress, err := valCodec.BytesToString(valAddr)
+	require.NoError(t, err)
+	validator, err := stakingtypes.NewValidator(validatorAddress, pubKey, stakingtypes.Description{})
+	require.NoError(t, err)
+	return validator
+}
+
+func sdktestutilDefaultContextWithDB(t *testing.T, key *storetypes.KVStoreKey) sdk.Context {
+	t.Helper()
+
+	return sdktestutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_validator_set_test")).Ctx
+}
+
+func (f validatorSetFixture) setValidatorWithDelegations(
+	t *testing.T,
+	valAddr sdk.ValAddress,
+	status stakingtypes.BondStatus,
+	selfBondPower int64,
+	otherBondPower int64,
+) stakingtypes.Validator {
+	t.Helper()
+
+	selfTokens := f.keeper.TokensFromConsensusPower(f.ctx, selfBondPower)
+	otherTokens := f.keeper.TokensFromConsensusPower(f.ctx, otherBondPower)
+	totalTokens := selfTokens.Add(otherTokens)
+	totalShares := sdkmath.LegacyNewDecFromInt(totalTokens)
+
+	validator, err := f.keeper.GetValidator(f.ctx, valAddr)
+	require.NoError(t, err)
+	validator = validator.UpdateStatus(status)
+	validator.Tokens = totalTokens
+	validator.DelegatorShares = totalShares
+
+	f.deleteValidatorPowerIndexEntries(t, valAddr)
+	require.NoError(t, f.keeper.SetValidator(f.ctx, validator))
+	require.NoError(t, f.keeper.SetValidatorByPowerIndex(f.ctx, validator))
+
+	validatorAddress, err := f.keeper.ValidatorAddressCodec().BytesToString(valAddr)
+	require.NoError(t, err)
+	selfDelegatorAddress, err := f.keeper.accountCodec.BytesToString(sdk.AccAddress(valAddr))
+	require.NoError(t, err)
+	require.NoError(t, f.keeper.SetDelegation(
+		f.ctx,
+		stakingtypes.NewDelegation(selfDelegatorAddress, validatorAddress, sdkmath.LegacyNewDecFromInt(selfTokens)),
+	))
+
+	if !otherTokens.IsZero() {
+		otherDelegatorAddress, err := f.keeper.accountCodec.BytesToString(sdk.AccAddress([]byte("other_delegator_addr")[:20]))
+		require.NoError(t, err)
+		require.NoError(t, f.keeper.SetDelegation(
+			f.ctx,
+			stakingtypes.NewDelegation(otherDelegatorAddress, validatorAddress, sdkmath.LegacyNewDecFromInt(otherTokens)),
+		))
+	}
+
+	return validator
+}
+
+func (f validatorSetFixture) deleteValidatorPowerIndexEntries(t *testing.T, valAddr sdk.ValAddress) {
+	t.Helper()
+
+	store := f.storeService.OpenKVStore(f.ctx)
+	iterator, err := store.Iterator(
+		stakingtypes.ValidatorsByPowerIndexKey,
+		storetypes.PrefixEndBytes(stakingtypes.ValidatorsByPowerIndexKey),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, iterator.Close()) }()
+
+	for ; iterator.Valid(); iterator.Next() {
+		indexedValAddr := stakingtypes.ParseValidatorPowerRankKey(iterator.Key())
+		if bytes.Equal(indexedValAddr, valAddr) {
+			require.NoError(t, store.Delete(iterator.Key()))
+		}
+	}
+}
+
+func TestApplyAndReturnValidatorSetUpdatesExcludesBelowMinSelfBond(t *testing.T) {
+	f := setupValidatorSetFixture(t, 100)
+	f.setValidatorWithDelegations(t, f.valAddrs[0], stakingtypes.Unbonded, 90, 1000)
+
+	updates, err := f.keeper.ApplyAndReturnValidatorSetUpdates(f.ctx)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+
+	lastValidators, err := f.keeper.GetLastValidators(f.ctx)
+	require.NoError(t, err)
+	require.Empty(t, lastValidators)
+
+	validator, err := f.keeper.GetValidator(f.ctx, f.valAddrs[0])
+	require.NoError(t, err)
+	require.True(t, validator.IsUnbonded())
+}
+
+func TestApplyAndReturnValidatorSetUpdatesRemovesBondedValidatorBelowMinSelfBond(t *testing.T) {
+	f := setupValidatorSetFixture(t, 100)
+	f.setValidatorWithDelegations(t, f.valAddrs[0], stakingtypes.Unbonded, 120, 0)
+
+	updates, err := f.keeper.ApplyAndReturnValidatorSetUpdates(f.ctx)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	require.Positive(t, updates[0].Power)
+
+	f.setValidatorWithDelegations(t, f.valAddrs[0], stakingtypes.Bonded, 90, 0)
+	updates, err = f.keeper.ApplyAndReturnValidatorSetUpdates(f.ctx)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	require.Zero(t, updates[0].Power)
+
+	lastValidators, err := f.keeper.GetLastValidators(f.ctx)
+	require.NoError(t, err)
+	require.Empty(t, lastValidators)
+
+	validator, err := f.keeper.GetValidator(f.ctx, f.valAddrs[0])
+	require.NoError(t, err)
+	require.True(t, validator.IsUnbonding())
+}
+
+func TestApplyAndReturnValidatorSetUpdatesAllowsRestoredSelfBondToReenter(t *testing.T) {
+	f := setupValidatorSetFixture(t, 100)
+	f.setValidatorWithDelegations(t, f.valAddrs[0], stakingtypes.Unbonded, 90, 1000)
+
+	updates, err := f.keeper.ApplyAndReturnValidatorSetUpdates(f.ctx)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+
+	f.setValidatorWithDelegations(t, f.valAddrs[0], stakingtypes.Unbonded, 100, 1000)
+	updates, err = f.keeper.ApplyAndReturnValidatorSetUpdates(f.ctx)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	require.Positive(t, updates[0].Power)
+
+	lastValidators, err := f.keeper.GetLastValidators(f.ctx)
+	require.NoError(t, err)
+	require.Len(t, lastValidators, 1)
+}
+
+func TestApplyAndReturnValidatorSetUpdatesExcludesAfterMinBondIncrease(t *testing.T) {
+	f := setupValidatorSetFixture(t, 100)
+	f.setValidatorWithDelegations(t, f.valAddrs[0], stakingtypes.Unbonded, 120, 0)
+
+	updates, err := f.keeper.ApplyAndReturnValidatorSetUpdates(f.ctx)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	require.Positive(t, updates[0].Power)
+
+	f.minBondSource.minBond = f.keeper.TokensFromConsensusPower(f.ctx, 130)
+	updates, err = f.keeper.ApplyAndReturnValidatorSetUpdates(f.ctx)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	require.Zero(t, updates[0].Power)
+
+	lastValidators, err := f.keeper.GetLastValidators(f.ctx)
+	require.NoError(t, err)
+	require.Empty(t, lastValidators)
+}

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -1,0 +1,48 @@
+package staking
+
+import (
+	"context"
+	"encoding/json"
+
+	"cosmossdk.io/core/appmodule"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	sdkstaking "github.com/cosmos/cosmos-sdk/x/staking"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	customkeeper "github.com/gurufinglobal/guru/v2/x/staking/keeper"
+)
+
+var (
+	_ appmodule.AppModule       = AppModule{}
+	_ appmodule.HasBeginBlocker = AppModule{}
+	_ module.HasABCIEndBlock    = AppModule{}
+	_ module.HasABCIGenesis     = AppModule{}
+)
+
+type AppModule struct {
+	sdkstaking.AppModule
+
+	keeper *customkeeper.Keeper
+}
+
+func NewAppModule(baseModule sdkstaking.AppModule, keeper *customkeeper.Keeper) AppModule {
+	return AppModule{
+		AppModule: baseModule,
+		keeper:    keeper,
+	}
+}
+
+func (am AppModule) EndBlock(ctx context.Context) ([]abci.ValidatorUpdate, error) {
+	return am.keeper.EndBlocker(ctx)
+}
+
+// InitGenesis runs SDK staking initialization, then reapplies validator-set updates
+// through the custom keeper path so the min self-bond filter is enforced from genesis.
+func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.RawMessage) []abci.ValidatorUpdate {
+	var genesisState stakingtypes.GenesisState
+	cdc.MustUnmarshalJSON(data, &genesisState)
+
+	return am.keeper.InitGenesis(ctx, &genesisState)
+}

--- a/x/staking/module_test.go
+++ b/x/staking/module_test.go
@@ -1,0 +1,16 @@
+package staking
+
+import (
+	"testing"
+
+	sdkstaking "github.com/cosmos/cosmos-sdk/x/staking"
+	customkeeper "github.com/gurufinglobal/guru/v2/x/staking/keeper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAppModuleKeepsCustomKeeper(t *testing.T) {
+	keeper := &customkeeper.Keeper{}
+	module := NewAppModule(sdkstaking.AppModule{}, keeper)
+
+	require.Equal(t, keeper, module.keeper)
+}


### PR DESCRIPTION
# Description

This PR backports the minimum validator self-bond enforcement from `dev-v3` to the Cosmos SDK `v0.53.6` / Cosmos EVM `v0.6.1` bootstrap branch.

The minimum amount is read from:

```text
constitution.params.min_validator_bond_amount
```

The default value remains `10agxn`.

### Behavior

- Rejects `MsgCreateValidator` when its initial self-bond is below the configured minimum.
- Applies the same validation to `MsgCreateValidator` messages nested inside `authz.MsgExec`.
- Evaluates each validator's actual self-delegation before the staking validator-set update.
- Removes validators below the minimum from the active validator set at EndBlock.
- Allows validators to re-enter the active set after restoring sufficient self-bond.
- Rejects initial and active exported genesis validators below the configured minimum.
- Rejects duplicate genesis self-delegations.
- Preserves the upstream staking keeper for existing module dependencies while overriding staking InitGenesis and EndBlock behavior through a custom module wrapper.

### Critical files to review

- `x/staking/keeper/keeper.go`
  - EndBlock validator-set filtering and actual self-bond calculation.
- `x/staking/keeper/self_bond_ante.go`
  - Direct and authz-nested `MsgCreateValidator` validation.
- `x/staking/keeper/genesis.go`
  - Genesis validator-update filtering and update merging.
- `x/staking/module.go`
  - Custom staking InitGenesis and EndBlock routing.
- `app/keepers.go`
  - Constitution-backed custom staking keeper construction.
- `app/modules.go`
  - Replacement of the upstream staking AppModule with the custom wrapper.
- `app/handlers.go`
  - Self-bond Ante wrapper registration.
- `app/genesis.go`
  - Cross-module genesis self-bond validation.

### Backport-specific changes

The enforcement semantics remain aligned with `dev-v3`. Only the following compatibility adjustments were made:

- Changed Guru imports from `/v3` to `/v2`.
- Replaced `app/params` references with the target branch's `config` package.
- Adapted test stores from SDK `store/v2` to `cosmossdk.io/store/types`.
- Removed the BLS12381 validator-update branch because CometBFT `v0.38.21` only exposes Ed25519 and Secp256k1 consensus public keys.

No new store key, protobuf schema, module account, or migration is introduced. The required Constitution parameter is already available in the target branch.

### Review instructions

1. Confirm that `CustomStakingKeeper` wraps the existing SDK staking keeper and uses `ConstitutionKeeper` as the minimum bond source.
2. Confirm that only validator creation is rejected by Ante; undelegation and redelegation remain allowed and are handled through EndBlock validator-set removal.
3. Confirm that filtering happens before the SDK's `ApplyAndReturnValidatorSetUpdates`.
4. Confirm that genesis update merging allows a zero-power custom update to override the SDK's initial validator update.
5. Run:

```bash
GOTOOLCHAIN=go1.23.8+auto go test -mod=readonly -count=1 ./x/staking/... ./app/...
GOTOOLCHAIN=go1.23.8+auto go test -race -mod=readonly -count=1 ./x/staking/... ./app/...
GOTOOLCHAIN=go1.23.8+auto make test EXTRA_ARGS=-count=1
GOTOOLCHAIN=go1.23.8+auto make lint
```

### Runtime verification

A real `gurud` single-validator node was initialized and started.

- A validator with `1e18agxn` self-bond successfully initialized and committed through block height 2.
- A validator gentx with `9agxn` self-bond was rejected during InitChain against the default `10agxn` minimum:

```text
msg create validator self-bond 9 below minimum 10: self-bond below minimum
```

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [ ] targeted the `main` branch — N/A: this PR targets `feat/cosmos-evm-v061-app-bootstrap` because it depends on the previously merged Constitution parameter and wiring

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code — N/A: this PR intentionally changes consensus-critical staking production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed