### PR TITLE
fix: complete fee distribution policy wiring

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -128,6 +128,9 @@ func TestApplicationStateMachine(t *testing.T) {
 
 	genesis := application.DefaultGenesis()
 	require.Contains(t, genesis, oracletypes.ModuleName)
+	distributionGenesis := distrtypes.DefaultGenesisState()
+	application.AppCodec().MustUnmarshalJSON(genesis[distrtypes.ModuleName], distributionGenesis)
+	require.True(t, distributionGenesis.Params.CommunityTax.IsZero())
 	feeMarketGenesis := new(feemarkettypes.GenesisState)
 	application.AppCodec().MustUnmarshalJSON(genesis[feemarkettypes.ModuleName], feeMarketGenesis)
 	require.True(t, feeMarketGenesis.Params.NoBaseFee)

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -9,6 +9,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
@@ -59,6 +60,11 @@ func (app *App) DefaultGenesis() GenesisState {
 		sdk.NewCoin(config.BaseDenom, oneToken.MulRaw(5)),
 	)
 	genesis[govtypes.ModuleName] = app.AppCodec().MustMarshalJSON(govGenesis)
+
+	distributionGenesis := distrtypes.DefaultGenesisState()
+	app.unmarshalGenesis(genesis, distrtypes.ModuleName, distributionGenesis)
+	distributionGenesis.Params.CommunityTax = sdkmath.LegacyZeroDec()
+	genesis[distrtypes.ModuleName] = app.AppCodec().MustMarshalJSON(distributionGenesis)
 
 	feeMarketGenesis := feemarkettypes.DefaultGenesisState()
 	app.unmarshalGenesis(genesis, feemarkettypes.ModuleName, feeMarketGenesis)

--- a/cmd/gurud/cmd/cli.go
+++ b/cmd/gurud/cmd/cli.go
@@ -49,6 +49,7 @@ import (
 
 	guruapp "github.com/gurufinglobal/guru/v2/app"
 	chainconfig "github.com/gurufinglobal/guru/v2/config"
+	constitutioncli "github.com/gurufinglobal/guru/v2/x/constitution/client/cli"
 	oraclecli "github.com/gurufinglobal/guru/v2/x/oracle/client/cli"
 )
 
@@ -73,7 +74,10 @@ func newQueryCommand() *cobra.Command {
 	// commands rather than AutoCLI descriptors. The stateless basic manager
 	// adds those commands without constructing an App or consuming EVM globals.
 	guruapp.NewBasicManager().AddQueryCommands(command)
-	command.AddCommand(oraclecli.GetQueryCmd())
+	command.AddCommand(
+		constitutioncli.GetQueryCmd(),
+		oraclecli.GetQueryCmd(),
+	)
 	command.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")
 	return command
 }
@@ -114,6 +118,7 @@ func newTxCommand() *cobra.Command {
 		vestingcli.GetTxCmd(accountCodec),
 		erc20.AppModuleBasic{}.GetTxCmd(),
 		transfer.AppModuleBasic{}.GetTxCmd(),
+		constitutioncli.GetTxCmd(),
 		oraclecli.GetTxCmd(),
 	)
 	command.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")

--- a/cmd/gurud/cmd/cli_test.go
+++ b/cmd/gurud/cmd/cli_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstitutionCommandRootsAreRegistered(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		root *cobra.Command
+	}{
+		{name: "query", root: newQueryCommand()},
+		{name: "tx", root: newTxCommand()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotNil(t, findImmediateSubcommand(tc.root, "constitution"))
+		})
+	}
+}
+
+func findImmediateSubcommand(root *cobra.Command, name string) *cobra.Command {
+	for _, command := range root.Commands() {
+		if command.Name() == name {
+			return command
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

This PR completes the remaining application-level wiring for the fee distribution policy.

The core `base / burn / validators` separation logic already exists in `x/constitution`. This PR addresses the remaining genesis policy and CLI integration gaps.

## Changes

- Sets `distribution.community_tax` to `0` in the default genesis.
  - Prevents the validator remainder from being taxed again by the SDK default 2% community tax.
  - Preserves the remaining distribution genesis parameters.
- Registers the existing Constitution CLI commands:
  - `gurud query constitution`
  - `gurud tx constitution`
- Adds regression coverage for:
  - the zero community tax genesis policy
  - Constitution query and transaction command registration

## Critical Files to Review

- `app/genesis.go`
  - Applies the zero community tax policy to newly generated genesis state.
- `cmd/gurud/cmd/cli.go`
  - Registers the Constitution query and transaction command roots.
- `app/app_test.go`
  - Verifies the default genesis policy.
- `cmd/gurud/cmd/cli_test.go`
  - Verifies CLI command registration.

## Review Instructions

1. Confirm that `DefaultGenesis()` overrides only `distribution.community_tax`.
2. Confirm that the Constitution CLI roots do not conflict with commands registered by `BasicManager`.
3. Confirm that the existing PPM calculation, burn path, and BeginBlock ordering remain unchanged.

## Operational Notes

- This change affects genesis generated by a new `gurud init`.
- It does not migrate or modify the distribution parameters of an already running chain.
- No changes were made to the existing fee separation calculation or module account permissions.

## Validation

Executed on `IDC_2_TEST` using Go 1.24.6:

```text
make test
```

All main application, Constitution, Oracle, staking, and `oracle` submodule tests passed.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
  - N/A: this PR changes default genesis policy and CLI production wiring.
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed