### PR TITLE
feat: add testnet validator mempool preflight validation

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -16,6 +16,7 @@ import (
 	evidencetypes "cosmossdk.io/x/evidence/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
@@ -62,6 +63,9 @@ func TestApplicationStateMachine(t *testing.T) {
 		HomePath:   t.TempDir(),
 		ChainID:    testChainID,
 		EVMChainID: testEVMChainID,
+		BaseAppOptions: []func(*baseapp.BaseApp){
+			baseapp.SetMempool(sdkmempool.NewSenderNonceMempool()),
+		},
 	})
 	require.NoError(t, err)
 	require.Equal(t, testChainID, application.ChainID())

--- a/docs/operations/testnet-validator-mempool.md
+++ b/docs/operations/testnet-validator-mempool.md
@@ -1,0 +1,81 @@
+# Testnet validator mempool profile
+
+This profile covers the rendered mempool files supplied to a Testnet
+validator. Network capacity and timeout choices remain local to each node.
+
+## Policy
+
+| Setting | Classification | Result |
+|---|---|---|
+| `app.toml:mempool.max-txs=-1` | required | missing, wrong type, or mismatch fails |
+| `config.toml:mempool.type="flood"` | required | missing, wrong type, or mismatch fails |
+| node binary `server_name="gurud"` | required | mismatch fails |
+| `config.toml:mempool.recheck=true` | recommended | `false` warns and exits successfully; missing or wrong type fails |
+| `broadcast`, `keep-invalid-txs-in-cache`, `wal_dir` | node-local | typed values are recorded without imposing global values |
+| `size`, `max_txs_bytes`, `cache_size`, `max_tx_bytes`, `max_batch_bytes` | node-local | non-negative integer values are recorded without imposing global values |
+| `recheck_timeout`, experimental gossip connection limits | node-local | typed values are recorded without imposing global values |
+
+`app.toml` and CometBFT's `config.toml` contain different `[mempool]`
+tables. The rendered values are:
+
+```toml
+# app.toml
+[mempool]
+max-txs = -1
+```
+
+```toml
+# config.toml
+[mempool]
+type = "flood"
+recheck = true
+```
+
+The application separately uses BaseApp's `NoOpMempool`; `max-txs=-1` is a
+deployment-profile guard, not an application-side mempool activation switch.
+
+With `recheck=true`, CometBFT submits remaining transactions to `ReCheckTx`
+after a commit and can evict transactions whose recheck result no longer meets
+a raised MGP. Transactions removed while MGP is high are not restored
+automatically if MGP later falls. Disabling recheck does not bypass the
+deterministic `FinalizeBlock` ante check, but can waste mempool and proposal
+capacity.
+
+## Preflight command
+
+Run the standalone Bash script against a rendered home and its deployment
+binary:
+
+```bash
+bash scripts/verify-validator-mempool-config.sh \
+  --home /var/lib/guru \
+  --validator-id validator-seoul-01 \
+  --node-binary /opt/guru/bin/gurud \
+  --output /var/lib/guru-evidence/validator-seoul-01.json
+```
+
+Bash, `jq`, and either `sha256sum` or `shasum` are required. The script uses
+the supplied binary's `config view` command for both TOML files and its
+`version --long --output json` command.
+
+- Exit `0`: required and structural checks pass, including a `recheck=false`
+  recommendation warning.
+- Exit `1`: parsed configuration has a policy or structural failure.
+- Exit `2`: inputs, parser output, or evidence generation could not be handled.
+
+The JSON status is `pass`, `pass_with_warnings`, or `fail`. When `--output` is
+provided, the report is written with private permissions and an atomic rename;
+otherwise it is written to standard output. Direct, symlink, and existing
+hardlink collisions with input files are refused.
+
+## Evidence boundary
+
+Evidence includes validator ID, UTC time, chain ID, input paths,
+SHA-256 hashes, binary version and commit, typed checks, node-local values, and
+warnings. The script parses private snapshots with the matching binary snapshot,
+uses `gurud`'s normal typed config loading, and rehashes the originals before
+publication.
+
+The scope is the rendered files and supplied binary only. The report does not
+claim to observe a later process's CLI flags, service environment, or file
+changes, and the script does not change `gurud` startup behavior.

--- a/scripts/verify-validator-mempool-config.sh
+++ b/scripts/verify-validator-mempool-config.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+
+# Validate rendered validator configuration. This is not a startup hook and
+# does not inspect CLI or service-environment overrides of a later process.
+
+set -u
+set -o pipefail
+
+readonly schema="guru.validator-mempool-preflight/v2"
+readonly exit_policy=1
+readonly exit_error=2
+
+home=""
+validator_id=""
+binary=""
+output=""
+scratch=""
+
+usage() {
+  printf '%s\n' \
+    'Usage: verify-validator-mempool-config.sh --home PATH --validator-id ID' \
+    '       --node-binary PATH [--output PATH]'
+}
+
+die() {
+  printf 'preflight error: %s\n' "$*" >&2
+  exit "$exit_error"
+}
+
+cleanup() {
+  [[ -n "$scratch" && -d "$scratch" ]] || return 0
+  case "$scratch" in
+    */.validator-mempool-preflight.*) rm -rf "$scratch" ;;
+  esac
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' HUP TERM
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --home|--validator-id|--node-binary|--output)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      case "$1" in
+        --home) home=$2 ;;
+        --validator-id) validator_id=$2 ;;
+        --node-binary) binary=$2 ;;
+        --output) output=$2 ;;
+      esac
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$home" ]] || die "--home is required"
+[[ -n "$validator_id" ]] || die "--validator-id is required"
+[[ -n "$binary" ]] || die "--node-binary is required"
+command -v jq >/dev/null 2>&1 || die "jq is required"
+jq -n -e --arg id "$validator_id" '$id | test("\\S")' >/dev/null \
+  || die "--validator-id must contain a non-whitespace character"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  hash_command=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+  hash_command=(shasum -a 256)
+else
+  die "sha256sum or shasum is required"
+fi
+
+absolute_file() {
+  local directory
+  directory=$(cd -P "$(dirname "$1")" 2>/dev/null && pwd -P) || return 1
+  printf '%s/%s\n' "$directory" "$(basename "$1")"
+}
+
+home=$(cd -P "$home" 2>/dev/null && pwd -P) || die "home: cannot resolve directory"
+app="$home/config/app.toml"
+config="$home/config/config.toml"
+genesis="$home/config/genesis.json"
+for path in "$app" "$config" "$genesis"; do
+  [[ -f "$path" ]] || die "input: expected regular file, got $path"
+done
+app=$(absolute_file "$app") || die "app.toml: cannot resolve path"
+config=$(absolute_file "$config") || die "config.toml: cannot resolve path"
+genesis=$(absolute_file "$genesis") || die "genesis.json: cannot resolve path"
+binary=$(absolute_file "$binary") || die "node binary: cannot resolve path"
+[[ -f "$binary" && -x "$binary" ]] || die "node binary: expected executable regular file, got $binary"
+
+output_path=""
+if [[ -n "$output" ]]; then
+  [[ ! -L "$output" ]] || die "output: symlink targets are not allowed: $output"
+  [[ ! -e "$output" || -f "$output" ]] || die "output: expected regular file target: $output"
+  output_parent=$(dirname "$output")
+  mkdir -p "$output_parent" || die "output: cannot create parent directory"
+  output_parent=$(cd -P "$output_parent" && pwd -P) || die "output: cannot resolve parent directory"
+  output_path="$output_parent/$(basename "$output")"
+  for path in "$app" "$config" "$genesis" "$binary"; do
+    [[ "$output_path" != "$path" ]] || die "output: must not overwrite input $path"
+    if [[ -e "$output_path" && "$output_path" -ef "$path" ]]; then
+      die "output: hardlink alias of input $path"
+    fi
+  done
+  scratch_parent=$output_parent
+else
+  scratch_parent=${TMPDIR:-$PWD}
+  scratch_parent=$(cd -P "$scratch_parent" 2>/dev/null && pwd -P) \
+    || die "scratch: cannot resolve TMPDIR or current directory"
+fi
+
+umask 077
+scratch=$(mktemp -d "$scratch_parent/.validator-mempool-preflight.XXXXXX") \
+  || die "scratch: cannot create private directory under $scratch_parent"
+
+hash_file() {
+  local digest
+  digest=$("${hash_command[@]}" <"$1" | awk 'NR == 1 {print $1}') || return 1
+  [[ "$digest" =~ ^[0-9a-fA-F]{64}$ ]] || return 1
+  printf '%s\n' "$digest"
+}
+app_hash=$(hash_file "$app") || die "app.toml: cannot calculate SHA-256"
+config_hash=$(hash_file "$config") || die "config.toml: cannot calculate SHA-256"
+genesis_hash=$(hash_file "$genesis") || die "genesis.json: cannot calculate SHA-256"
+binary_hash=$(hash_file "$binary") || die "node binary: cannot calculate SHA-256"
+
+snapshot="$scratch/snapshot"
+snapshot_binary_dir="$snapshot/bin"
+mkdir -p "$snapshot_binary_dir" || die "snapshot: cannot create private directory"
+snapshot_app="$snapshot/app.toml"
+snapshot_config="$snapshot/config.toml"
+snapshot_genesis="$snapshot/genesis.json"
+snapshot_binary="$snapshot_binary_dir/gurud"
+command cp "$app" "$snapshot_app" || die "app.toml: cannot create private snapshot"
+command cp "$config" "$snapshot_config" || die "config.toml: cannot create private snapshot"
+command cp "$genesis" "$snapshot_genesis" || die "genesis.json: cannot create private snapshot"
+command cp "$binary" "$snapshot_binary" || die "node binary: cannot create private snapshot"
+chmod 700 "$snapshot_binary" || die "node binary: cannot secure private snapshot"
+[[ "$(hash_file "$snapshot_app")" == "$app_hash" ]] \
+  || die "app.toml: file changed while creating snapshot"
+[[ "$(hash_file "$snapshot_config")" == "$config_hash" ]] \
+  || die "config.toml: file changed while creating snapshot"
+[[ "$(hash_file "$snapshot_genesis")" == "$genesis_hash" ]] \
+  || die "genesis.json: file changed while creating snapshot"
+[[ "$(hash_file "$snapshot_binary")" == "$binary_hash" ]] \
+  || die "node binary: file changed while creating snapshot"
+
+run_json() {
+  local label=$1 destination=$2 status detail
+  shift 2
+  if env -i HOME="$parser_home" PATH="${PATH:-/usr/bin:/bin}" TMPDIR="$scratch" \
+    "$snapshot_binary" "$@" >"$destination" 2>"$scratch/stderr"; then
+    :
+  else
+    status=$?
+    detail=$(tr '\n' ' ' <"$scratch/stderr")
+    [[ -n "$detail" ]] || detail="exit status $status"
+    die "$label: gurud command failed: $detail"
+  fi
+  jq -s -e 'length == 1 and (.[0] | type == "object")' \
+    "$destination" >/dev/null 2>&1 \
+    || die "$label: gurud output must be exactly one JSON object"
+}
+
+parser_home="$scratch/parser-home"
+mkdir -p "$parser_home/config" || die "parser: cannot create private home"
+ln -s "$snapshot_app" "$parser_home/config/app.toml" \
+  || die "app.toml: cannot create runtime parser input"
+ln -s "$snapshot_config" "$parser_home/config/config.toml" \
+  || die "config.toml: cannot create runtime parser input"
+run_json "node version" "$scratch/version.json" \
+  --home "$parser_home" version --long --output json
+ln -s "$snapshot_app" "$parser_home/config/rendered-app.toml" \
+  || die "app.toml: cannot create parser input"
+ln -s "$snapshot_config" "$parser_home/config/rendered-config.toml" \
+  || die "config.toml: cannot create parser input"
+run_json "app.toml" "$scratch/app.json" \
+  --home "$parser_home" config view rendered-app --output-format json
+run_json "config.toml" "$scratch/config.json" \
+  --home "$parser_home" config view rendered-config --output-format json
+
+jq -e '
+  (if (.server_name | type) == "string" then (.server_name | test("\\S")) else false end) and
+  ((.version | type) == "string") and ((.commit | type) == "string")
+' \
+  "$scratch/version.json" >/dev/null 2>&1 \
+  || die "node version: server_name must be non-empty; version and commit must be strings"
+jq -e 'if type == "object" then
+  (.chain_id | if type == "string" then test("\\S") else false end)
+  else false end' \
+  "$snapshot_genesis" >/dev/null 2>&1 \
+  || die "genesis.json: chain_id must be a non-empty string"
+jq '{chain_id}' "$snapshot_genesis" >"$scratch/network.json" \
+  || die "genesis.json: cannot record chain_id"
+
+checked_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || die "cannot determine UTC time"
+
+jq -n \
+  --arg schema "$schema" --arg checked_at "$checked_at" \
+  --arg validator_id "$validator_id" --arg home "$home" \
+  --arg binary "$binary" --arg binary_hash "$binary_hash" \
+  --arg app_path "$app" --arg app_hash "$app_hash" \
+  --arg config_path "$config" --arg config_hash "$config_hash" \
+  --arg genesis_path "$genesis" --arg genesis_hash "$genesis_hash" \
+  --slurpfile app "$scratch/app.json" --slurpfile config "$scratch/config.json" \
+  --slurpfile version "$scratch/version.json" --slurpfile network "$scratch/network.json" '
+    def field($doc; $key):
+      if (($doc.mempool? | type) == "object") then
+        if ($doc.mempool | has($key))
+        then {present: true, value: $doc.mempool[$key]}
+        else {present: false, value: "<missing>"}
+        end
+      else {present: false, value: "<missing>"}
+      end;
+    def typename($f): if $f.present then ($f.value | type) else "missing" end;
+    def check($key; $class; $f; $expected; $ok): {
+      key: $key, classification: $class, actual: $f.value, expected: $expected,
+      status: (if $ok then "pass" else "fail" end), actual_type: typename($f)
+    };
+    def boolok($f): $f.present and (($f.value | type) == "boolean");
+    def intok($f):
+      if $f.present and (($f.value | type) == "number")
+      then ($f.value >= 0) and (($f.value | floor) == $f.value)
+      else false end;
+    def durationok($f):
+      if $f.present and (($f.value | type) == "string")
+      then ($f.value | test("^[+-]?(?:0|(?:(?:[0-9]+(?:\\.[0-9]*)?|\\.[0-9]+)(?:ns|us|µs|μs|ms|s|m|h))+)$"))
+      else false end;
+
+    $app[0] as $a | $config[0] as $c | $version[0] as $v |
+    field($a; "max-txs") as $max | field($c; "type") as $type |
+    field($c; "recheck") as $recheck | field($c; "broadcast") as $broadcast |
+    field($c; "keep-invalid-txs-in-cache") as $invalid_cache |
+    field($c; "wal_dir") as $wal_dir |
+    field($c; "size") as $size | field($c; "max_txs_bytes") as $max_bytes |
+    field($c; "cache_size") as $cache | field($c; "max_tx_bytes") as $max_tx |
+    field($c; "max_batch_bytes") as $max_batch |
+    field($c; "recheck_timeout") as $timeout |
+    field($c; "experimental_max_gossip_connections_to_persistent_peers") as $persistent_gossip |
+    field($c; "experimental_max_gossip_connections_to_non_persistent_peers") as $non_persistent_gossip |
+    [
+      check("app.toml:mempool.max-txs"; "required"; $max; -1; $max.present and $max.value == -1),
+      check("config.toml:mempool.type"; "required"; $type; "flood"; $type.present and $type.value == "flood"),
+      check("config.toml:mempool.recheck"; "structural"; $recheck; "boolean"; boolok($recheck)),
+      check("config.toml:mempool.broadcast"; "structural"; $broadcast; "boolean"; boolok($broadcast)),
+      check("config.toml:mempool.keep-invalid-txs-in-cache"; "structural"; $invalid_cache; "boolean"; boolok($invalid_cache)),
+      check("config.toml:mempool.wal_dir"; "structural"; $wal_dir; "string"; $wal_dir.present and (($wal_dir.value | type) == "string")),
+      check("config.toml:mempool.size"; "structural"; $size; "non-negative integer"; intok($size)),
+      check("config.toml:mempool.max_txs_bytes"; "structural"; $max_bytes; "non-negative integer"; intok($max_bytes)),
+      check("config.toml:mempool.cache_size"; "structural"; $cache; "non-negative integer"; intok($cache)),
+      check("config.toml:mempool.max_tx_bytes"; "structural"; $max_tx; "non-negative integer"; intok($max_tx)),
+      check("config.toml:mempool.max_batch_bytes"; "structural"; $max_batch; "non-negative integer"; intok($max_batch)),
+      check("config.toml:mempool.recheck_timeout"; "structural"; $timeout; "Go duration string"; durationok($timeout)),
+      check("config.toml:mempool.experimental_max_gossip_connections_to_persistent_peers"; "structural"; $persistent_gossip; "non-negative integer"; intok($persistent_gossip)),
+      check("config.toml:mempool.experimental_max_gossip_connections_to_non_persistent_peers"; "structural"; $non_persistent_gossip; "non-negative integer"; intok($non_persistent_gossip)),
+      check("node.server_name"; "required"; {present: true, value: $v.server_name}; "gurud"; $v.server_name == "gurud")
+    ] as $checks |
+    (if boolok($recheck) and ($recheck.value == false) then [{
+      code: "MEMPOOL_RECHECK_DISABLED", severity: "warning",
+      key: "config.toml:mempool.recheck", actual: false, recommended: true
+    }] else [] end) as $warnings |
+    (if any($checks[]; .status == "fail") then "fail"
+     elif ($warnings | length) > 0 then "pass_with_warnings" else "pass" end) as $status |
+    {
+      schema: $schema, status: $status, checked_at: $checked_at,
+      validator_id: $validator_id, home: $home,
+      scope: {kind: "rendered-config-files", runtime_overrides_checked: false,
+        note: "Evidence covers the rendered files and binary hashes below; CLI and service-environment overrides are outside its scope."},
+      node: {path: $binary, sha256: $binary_hash, server_name: $v.server_name,
+        version: $v.version, commit: $v.commit, version_info: $v},
+      network: $network[0],
+      files: {
+        "app.toml": {path: $app_path, sha256: $app_hash},
+        "config.toml": {path: $config_path, sha256: $config_hash},
+        "genesis.json": {path: $genesis_path, sha256: $genesis_hash}
+      },
+      checks: $checks, warnings: $warnings
+    }
+  ' >"$scratch/evidence.json" || die "cannot construct JSON evidence"
+
+unchanged() {
+  local current
+  current=$(hash_file "$2") || die "$1: cannot recalculate SHA-256"
+  [[ "$current" == "$3" ]] || die "$1: file changed during verification"
+}
+unchanged "app.toml" "$app" "$app_hash"
+unchanged "config.toml" "$config" "$config_hash"
+unchanged "genesis.json" "$genesis" "$genesis_hash"
+unchanged "node binary" "$binary" "$binary_hash"
+
+status=$(jq -r '.status' "$scratch/evidence.json") || die "cannot read evidence status"
+jq -r '.checks[] | select(.status == "fail") |
+  (if .classification == "required" then "REQUIRED" else "STRUCTURAL" end) +
+  " " + .key + ": got " + (.actual | tojson) + "; want " + (.expected | tojson)' \
+  "$scratch/evidence.json" >&2
+jq -r '.warnings[] | "WARNING " + .key + ": got " + (.actual | tojson) +
+  "; recommend " + (.recommended | tojson) + "; code=" + .code' \
+  "$scratch/evidence.json" >&2
+
+evidence="$scratch/evidence.json"
+if [[ -n "$output_path" ]]; then
+  [[ ! -L "$output_path" ]] || die "output: symlink targets are not allowed: $output_path"
+  [[ ! -e "$output_path" || -f "$output_path" ]] \
+    || die "output: expected regular file target: $output_path"
+  for path in "$app" "$config" "$genesis" "$binary"; do
+    [[ "$output_path" != "$path" ]] || die "output: must not overwrite input $path"
+    if [[ -e "$output_path" && "$output_path" -ef "$path" ]]; then
+      die "output: hardlink alias of input $path"
+    fi
+  done
+  chmod 600 "$evidence" || die "output: cannot set private permissions"
+  mv -f "$evidence" "$output_path" || die "output: cannot atomically publish $output_path"
+  evidence=$output_path
+else
+  command cat "$evidence" || die "cannot write evidence to stdout"
+fi
+[[ "$status" != "fail" ]] || exit "$exit_policy"

--- a/tests/integration/mempool/recheck_test.go
+++ b/tests/integration/mempool/recheck_test.go
@@ -1,0 +1,142 @@
+package mempool_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtconfig "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/libs/log"
+	cmtmempool "github.com/cometbft/cometbft/mempool"
+	"github.com/cometbft/cometbft/proxy"
+	cmttypes "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCListMempoolRecheckEvictionAndFreshInstance(t *testing.T) {
+	application := newMinimumGasPriceApplication(10)
+	mempool := newCometMempool(t, application)
+	lowFeeTx := cmttypes.Tx{10, 1}
+	highFeeTx := cmttypes.Tx{20, 2}
+
+	require.True(t, submitTx(t, mempool, lowFeeTx).IsOK())
+	require.True(t, submitTx(t, mempool, highFeeTx).IsOK())
+	require.Equal(t, cmttypes.Txs{lowFeeTx, highFeeTx}, mempool.ReapMaxTxs(-1))
+
+	// A threshold increase is observed by CheckTxType_Recheck on Update.
+	// The transaction below the new threshold is evicted while the still-valid
+	// transaction retains its FIFO position.
+	application.setMinimumGasPrice(15)
+	updateMempool(t, mempool, 1)
+	require.Equal(t, cmttypes.Txs{highFeeTx}, mempool.ReapMaxTxs(-1))
+
+	// Lowering MGP does not recreate an evicted transaction. Because invalid
+	// transactions are not retained in the cache, an explicit resubmission is
+	// checked as New and can become eligible again.
+	application.setMinimumGasPrice(5)
+	require.Equal(t, cmttypes.Txs{highFeeTx}, mempool.ReapMaxTxs(-1))
+	require.True(t, submitTx(t, mempool, lowFeeTx).IsOK())
+	require.Equal(t, cmttypes.Txs{highFeeTx, lowFeeTx}, mempool.ReapMaxTxs(-1))
+
+	// A fresh in-memory mempool starts empty. A resubmitted transaction is
+	// evaluated against the application's current threshold.
+	restartedMempool := newCometMempool(t, application)
+	require.Empty(t, restartedMempool.ReapMaxTxs(-1))
+	require.True(t, submitTx(t, restartedMempool, lowFeeTx).IsOK())
+	require.Equal(t, cmttypes.Txs{lowFeeTx}, restartedMempool.ReapMaxTxs(-1))
+
+	require.Equal(t, []abci.CheckTxType{
+		abci.CheckTxType_New,
+		abci.CheckTxType_New,
+		abci.CheckTxType_Recheck,
+		abci.CheckTxType_Recheck,
+		abci.CheckTxType_New,
+		abci.CheckTxType_New,
+	}, application.checkTypes())
+}
+
+type minimumGasPriceApplication struct {
+	abci.BaseApplication
+
+	mutex           sync.Mutex
+	minimumGasPrice byte
+	requests        []abci.CheckTxType
+}
+
+func newMinimumGasPriceApplication(minimumGasPrice byte) *minimumGasPriceApplication {
+	return &minimumGasPriceApplication{minimumGasPrice: minimumGasPrice}
+}
+
+func (application *minimumGasPriceApplication) CheckTx(
+	_ context.Context,
+	request *abci.RequestCheckTx,
+) (*abci.ResponseCheckTx, error) {
+	application.mutex.Lock()
+	defer application.mutex.Unlock()
+	application.requests = append(application.requests, request.Type)
+
+	if len(request.Tx) < 2 {
+		return &abci.ResponseCheckTx{Code: 1, Log: "malformed test transaction"}, nil
+	}
+	if request.Tx[0] < application.minimumGasPrice {
+		return &abci.ResponseCheckTx{Code: 1, Log: "gas price below minimum"}, nil
+	}
+	return &abci.ResponseCheckTx{Code: abci.CodeTypeOK}, nil
+}
+
+func (application *minimumGasPriceApplication) setMinimumGasPrice(value byte) {
+	application.mutex.Lock()
+	defer application.mutex.Unlock()
+	application.minimumGasPrice = value
+}
+
+func (application *minimumGasPriceApplication) checkTypes() []abci.CheckTxType {
+	application.mutex.Lock()
+	defer application.mutex.Unlock()
+	return append([]abci.CheckTxType(nil), application.requests...)
+}
+
+func newCometMempool(t *testing.T, application abci.Application) *cmtmempool.CListMempool {
+	t.Helper()
+	creator := proxy.NewLocalClientCreator(application)
+	client, err := creator.NewABCIClient()
+	require.NoError(t, err)
+	client.SetLogger(log.NewNopLogger())
+	require.NoError(t, client.Start())
+	t.Cleanup(func() {
+		if client.IsRunning() {
+			require.NoError(t, client.Stop())
+		}
+	})
+
+	config := cmtconfig.DefaultMempoolConfig()
+	config.RootDir = t.TempDir()
+	config.Recheck = true
+	config.RecheckTimeout = time.Second
+	config.KeepInvalidTxsInCache = false
+	return cmtmempool.NewCListMempool(config, client, 0)
+}
+
+func submitTx(
+	t *testing.T,
+	mempool *cmtmempool.CListMempool,
+	tx cmttypes.Tx,
+) *abci.ResponseCheckTx {
+	t.Helper()
+	var response *abci.ResponseCheckTx
+	require.NoError(t, mempool.CheckTx(tx, func(result *abci.ResponseCheckTx) {
+		response = result
+	}, cmtmempool.TxInfo{}))
+	require.NotNil(t, response)
+	return response
+}
+
+func updateMempool(t *testing.T, mempool *cmtmempool.CListMempool, height int64) {
+	t.Helper()
+	mempool.Lock()
+	err := mempool.Update(height, nil, nil, nil, nil)
+	mempool.Unlock()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
# Description

This PR adds an opt-in preflight check for the rendered mempool configuration of
a testnet validator. It does not add a startup hook or change the node's
transaction execution, consensus, or proposal-processing paths.

The standalone Bash verifier:

- requires `app.toml:mempool.max-txs=-1`,
  `config.toml:mempool.type="flood"`, and a `gurud` binary;
- treats `config.toml:mempool.recheck=true` as an operational recommendation,
  reporting `false` as `pass_with_warnings` without rejecting the configuration;
- validates the remaining CometBFT mempool fields structurally while leaving
  node-local capacity, timeout, cache, broadcast, and gossip values unrestricted;
- parses private snapshots through the supplied `gurud` binary and emits JSON
  evidence containing the validator ID, chain ID, typed checks, version
  information, and SHA-256 hashes; and
- detects changes to the original configuration and binary before publishing
  the evidence.

The operations guide documents the required, recommended, and node-local
settings together with the command, dependencies, exit codes, and evidence
boundary.

The test changes:

- verify that application construction restores BaseApp's `NoOpMempool` even
  when a caller supplies a different app-side mempool option; and
- exercise CometBFT `CListMempool` recheck eviction, explicit resubmission, and
  fresh in-memory instance behavior with a fake ABCI application.

The CList test is a component-level test. It is not a full Guru node,
persisted-mempool, process-restart, or network E2E test.

## Critical files to review

- `scripts/verify-validator-mempool-config.sh`
  - policy checks, parser isolation, evidence generation, and exit semantics
- `docs/operations/testnet-validator-mempool.md`
  - operational policy and the documented evidence boundary
- `app/app_test.go`
  - final `NoOpMempool` wiring assertion
- `tests/integration/mempool/recheck_test.go`
  - component-level CometBFT recheck behavior

## Review instructions

1. Confirm that only `max-txs=-1`, `type="flood"`, and the `gurud` binary
   identity are mandatory policy checks.
2. Confirm that `recheck=false` produces a warning and exit code `0`, while a
   missing or malformed value remains a structural error.
3. Run the documented preflight command against a rendered validator home and
   its matching `gurud` binary.
4. Inspect the JSON evidence for the input paths and hashes, binary version,
   chain ID, typed checks, warnings, and `runtime_overrides_checked=false`.
5. Confirm that the app regression test finishes with `NoOpMempool`.
6. Review the CList test as an in-process component test, not as full-node or
   restart E2E coverage.

## Validation

The following checks were run using the dedicated remote test runner:

- `make verify`
  - module verification for the root and Oracle modules
  - Go formatting checks
  - `go vet` for the root and Oracle modules
  - root and Oracle unit tests
- `make test-cover`
  - root and Oracle coverage-mode tests matching the PR CI test job
- `make version-smoke`
  - `gurud` and `oracled` build and embedded-version checks
- `go test -race -mod=readonly -count=1 -run '^(TestApplicationStateMachine|TestCListMempoolRecheckEvictionAndFreshInstance)$' ./app ./tests/integration/mempool`
- `bash -n scripts/verify-validator-mempool-config.sh`
- Real-`gurud` preflight smoke cases:
  - compliant profile: `pass`, exit `0`
  - `recheck=false`: `pass_with_warnings`, exit `0`
  - `mempool.type="nop"`: `fail`, exit `1`
  - configuration rejected by typed `gurud` loading: preflight error, exit `2`

## Compatibility and operational impact

There is no node runtime or consensus-code change and no configuration
migration. The verifier runs only when invoked by an operator and requires
Bash, `jq`, and either `sha256sum` or `shasum`.

Evidence is limited to the rendered files and supplied binary examined by the
command. It does not observe later CLI flags, service-environment overrides,
process startup, or subsequent artifact changes.

Closes: N/A

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member — the validator mempool profile and validation scope were reviewed with the team
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch — N/A: this v2.1 change targets `dev-v2.1` as required by `CONTRIBUTING.md`

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md` — N/A: `CHANGELOG.md` is not present in the `dev-v2.1` base
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code — no node runtime, consensus, ante-handler, Oracle, or proposal-processing code is modified; this PR adds standalone operational tooling, documentation, and tests
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed