### PR TITLE
fix(ante): enforce effective gas-price floor for Cosmos dynamic txs

### DIFF
--- a/app/ante/handler.go
+++ b/app/ante/handler.go
@@ -1,14 +1,19 @@
 package ante
 
 import (
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+
 	evmante "github.com/cosmos/evm/ante"
 	cosmosante "github.com/cosmos/evm/ante/cosmos"
 	evmanteevm "github.com/cosmos/evm/ante/evm"
 	antetypes "github.com/cosmos/evm/ante/types"
+	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 	ibcante "github.com/cosmos/ibc-go/v10/modules/core/ante"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
@@ -19,8 +24,8 @@ var (
 )
 
 // NewAnteHandler preserves the upstream Cosmos EVM v0.6.2 Ethereum path and
-// routes Cosmos transactions through the application-local standard MsgSend
-// gas extension.
+// routes Cosmos transactions through the application-local fee policy and
+// standard MsgSend gas extension.
 func NewAnteHandler(options evmante.HandlerOptions) sdk.AnteHandler {
 	upstreamHandler := evmante.NewAnteHandler(options)
 
@@ -54,7 +59,7 @@ func newCosmosAnteHandler(ctx sdk.Context, options evmante.HandlerOptions) sdk.A
 
 	var txFeeChecker authante.TxFeeChecker
 	if options.DynamicFeeChecker {
-		txFeeChecker = newStandardMsgSendDynamicFeeChecker(&feemarketParams)
+		txFeeChecker = newCosmosDynamicFeeChecker(&feemarketParams)
 	} else {
 		txFeeChecker = newStandardMsgSendValidatorFeeChecker()
 	}
@@ -95,4 +100,95 @@ func newCosmosAnteHandler(ctx sdk.Context, options evmante.HandlerOptions) sdk.A
 			&feemarketParams,
 		),
 	)
+}
+
+// newCosmosDynamicFeeChecker owns the application-wide Cosmos dynamic-fee
+// policy. Ordinary transactions preserve the upstream Cosmos EVM v0.6.2 fee,
+// priority, fallback, and error ordering, then enforce the global floor against
+// the exact dynamic effective price. Eligible MsgSend transactions delegate to
+// the separate FixedSendGas fee and settlement policy.
+func newCosmosDynamicFeeChecker(
+	feemarketParams *feemarkettypes.Params,
+) authante.TxFeeChecker {
+	upstream := evmanteevm.NewDynamicFeeChecker(feemarketParams)
+
+	return func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+		if isStandardMsgSendGasContext(ctx) {
+			return checkStandardMsgSendDynamicFee(ctx, tx, feemarketParams, upstream)
+		}
+
+		feeTx, ok := tx.(sdk.FeeTx)
+		if !ok {
+			return upstream(ctx, tx)
+		}
+		fees, priority, err := upstream(ctx, tx)
+		if err != nil {
+			return fees, priority, err
+		}
+		if err := checkOrdinaryDynamicFeeFloor(ctx, feeTx, feemarketParams); err != nil {
+			return nil, 0, err
+		}
+		return fees, priority, nil
+	}
+}
+
+// checkOrdinaryDynamicFeeFloor reconstructs the exact LegacyDec price used by
+// the upstream v0.6.2 dynamic checker. It runs only after that checker succeeds,
+// preserving its fallback and error ordering without deriving price from the
+// rounded effective fee.
+func checkOrdinaryDynamicFeeFloor(
+	ctx sdk.Context,
+	feeTx sdk.FeeTx,
+	feemarketParams *feemarkettypes.Params,
+) error {
+	if ctx.BlockHeight() == 0 ||
+		!evmtypes.IsLondon(evmtypes.GetEthChainConfig(), ctx.BlockHeight()) ||
+		feemarketParams.MinGasPrice.IsZero() {
+		return nil
+	}
+
+	dynamicFee, ok := dynamicFeeExtension(feeTx)
+	if !ok {
+		return nil
+	}
+
+	baseFee := feemarketParams.BaseFee
+	if baseFee.IsNil() {
+		baseFee = sdkmath.LegacyZeroDec()
+	}
+	tipCap := dynamicFee.MaxPriorityPrice
+	if tipCap.IsNil() {
+		tipCap = sdkmath.LegacyZeroDec()
+	}
+
+	denom := evmtypes.GetEVMCoinDenom()
+	gas := sdkmath.NewIntFromUint64(feeTx.GetGas())
+	feeAmount := feeTx.GetFee().AmountOf(denom)
+	feeCap := sdkmath.LegacyNewDecFromInt(feeAmount).QuoInt(gas)
+	effectivePrice := sdkmath.LegacyMinDec(baseFee.Add(tipCap), feeCap)
+	if effectivePrice.LT(feemarketParams.MinGasPrice) {
+		return errorsmod.Wrapf(
+			sdkerrors.ErrInsufficientFee,
+			"effective gas price below minimum global gas price (%s%s < %s%s)",
+			effectivePrice,
+			denom,
+			feemarketParams.MinGasPrice,
+			denom,
+		)
+	}
+
+	return nil
+}
+
+func dynamicFeeExtension(feeTx sdk.FeeTx) (*antetypes.ExtensionOptionDynamicFeeTx, bool) {
+	extensionTx, ok := feeTx.(authante.HasExtensionOptionsTx)
+	if !ok {
+		return nil, false
+	}
+	for _, option := range extensionTx.GetExtensionOptions() {
+		if dynamicFee, ok := option.GetCachedValue().(*antetypes.ExtensionOptionDynamicFeeTx); ok {
+			return dynamicFee, true
+		}
+	}
+	return nil, false
 }

--- a/app/ante/standard_msgsend_fee.go
+++ b/app/ante/standard_msgsend_fee.go
@@ -10,8 +10,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 
 	cosmosante "github.com/cosmos/evm/ante/cosmos"
-	evmanteevm "github.com/cosmos/evm/ante/evm"
-	antetypes "github.com/cosmos/evm/ante/types"
 	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
@@ -20,61 +18,56 @@ import (
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 )
 
-// newStandardMsgSendDynamicFeeChecker leaves ordinary transactions on the
-// upstream Cosmos EVM v0.6.2 checker. Eligible MsgSend transactions use the
-// Ethereum transaction price model against declared gas D, then settle that
-// price against execution gas E.
+// checkStandardMsgSendDynamicFee applies the FixedSendGas fee and settlement
+// policy after the application-wide Cosmos checker selects an eligible MsgSend.
+// It uses the Ethereum transaction price model against declared gas D, then
+// settles that price against execution gas E.
 //
 // This application's native EVM denom has 18 decimals. Consequently, the EVM
 // path's ConvertAmountTo18DecimalsLegacy step is a no-op, while converting the
 // LegacyDec base fee to *big.Int still truncates its fractional component.
-func newStandardMsgSendDynamicFeeChecker(
+func checkStandardMsgSendDynamicFee(
+	ctx sdk.Context,
+	tx sdk.Tx,
 	feemarketParams *feemarkettypes.Params,
-) authante.TxFeeChecker {
-	upstream := evmanteevm.NewDynamicFeeChecker(feemarketParams)
+	upstream authante.TxFeeChecker,
+) (sdk.Coins, int64, error) {
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+	settlementGas, ok := standardMsgSendSettlementGas(ctx)
+	if !ok {
+		return nil, 0, errorsmod.Wrap(sdkerrors.ErrLogic, "standard MsgSend execution gas is unavailable")
+	}
+	if ctx.BlockHeight() == 0 ||
+		!evmtypes.IsLondon(evmtypes.GetEthChainConfig(), ctx.BlockHeight()) {
+		fees, priority, err := upstream(ctx, tx)
+		if err != nil || isStandardMsgSendAdmissionContext(ctx) {
+			return fees, priority, err
+		}
+		settled, settleErr := settleStandardMsgSendFees(
+			fees,
+			feeTx.GetGas(),
+			settlementGas,
+		)
+		return settled, priority, settleErr
+	}
 
-	return func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
-		if !isStandardMsgSendGasContext(ctx) {
-			return upstream(ctx, tx)
-		}
-
-		feeTx, ok := tx.(sdk.FeeTx)
-		if !ok {
-			return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
-		}
-		settlementGas, ok := standardMsgSendSettlementGas(ctx)
-		if !ok {
-			return nil, 0, errorsmod.Wrap(sdkerrors.ErrLogic, "standard MsgSend execution gas is unavailable")
-		}
-		if ctx.BlockHeight() == 0 ||
-			!evmtypes.IsLondon(evmtypes.GetEthChainConfig(), ctx.BlockHeight()) {
-			fees, priority, err := upstream(ctx, tx)
-			if err != nil || isStandardMsgSendAdmissionContext(ctx) {
-				return fees, priority, err
-			}
-			settled, settleErr := settleStandardMsgSendFees(
-				fees,
-				feeTx.GetGas(),
-				settlementGas,
-			)
-			return settled, priority, settleErr
-		}
-
-		if isStandardMsgSendAdmissionContext(ctx) {
-			return checkAndSettleStandardMsgSendFee(
-				ctx,
-				feeTx,
-				feemarketParams,
-				feeTx.GetGas(),
-			)
-		}
+	if isStandardMsgSendAdmissionContext(ctx) {
 		return checkAndSettleStandardMsgSendFee(
 			ctx,
 			feeTx,
 			feemarketParams,
-			settlementGas,
+			feeTx.GetGas(),
 		)
 	}
+	return checkAndSettleStandardMsgSendFee(
+		ctx,
+		feeTx,
+		feemarketParams,
+		settlementGas,
+	)
 }
 
 // newStandardMsgSendValidatorFeeChecker mirrors the Cosmos SDK v0.53
@@ -151,7 +144,7 @@ func checkAndSettleStandardMsgSendFee(
 	feeCap := sdkmath.LegacyNewDecFromInt(feeAmount).QuoInt(declaredGasInt)
 	baseFee := standardMsgSendEthereumBaseFee(ctx, feemarketParams)
 
-	dynamicFee, hasDynamicFee := standardMsgSendDynamicFee(feeTx)
+	dynamicFee, hasDynamicFee := dynamicFeeExtension(feeTx)
 	effectivePrice := feeCap
 	priorityPrice := feeCap.Sub(baseFee)
 	if hasDynamicFee {
@@ -226,19 +219,6 @@ func standardMsgSendEthereumBaseFee(
 	return sdkmath.LegacyNewDecFromInt(baseFee.TruncateInt())
 }
 
-func standardMsgSendDynamicFee(feeTx sdk.FeeTx) (*antetypes.ExtensionOptionDynamicFeeTx, bool) {
-	extensionTx, ok := feeTx.(authante.HasExtensionOptionsTx)
-	if !ok {
-		return nil, false
-	}
-	for _, option := range extensionTx.GetExtensionOptions() {
-		if dynamicFee, ok := option.GetCachedValue().(*antetypes.ExtensionOptionDynamicFeeTx); ok {
-			return dynamicFee, true
-		}
-	}
-	return nil, false
-}
-
 // standardMsgSendMinGasPriceDecorator preserves the upstream Cosmos decorator
 // for ordinary transactions. For an eligible MsgSend it checks the Ethereum
 // effective price P against the global minimum price, both multiplied by D.
@@ -288,7 +268,7 @@ func (d standardMsgSendMinGasPriceDecorator) AnteHandle(
 	feeCap := sdkmath.LegacyNewDecFromInt(feeCoins.AmountOf(denom)).
 		QuoInt(sdkmath.NewIntFromUint64(feeTx.GetGas()))
 	effectivePrice := feeCap
-	if dynamicFee, ok := standardMsgSendDynamicFee(feeTx); ok {
+	if dynamicFee, ok := dynamicFeeExtension(feeTx); ok {
 		tipCap := dynamicFee.MaxPriorityPrice
 		if tipCap.IsNil() {
 			tipCap = sdkmath.LegacyZeroDec()

--- a/app/ante/standard_msgsend_test.go
+++ b/app/ante/standard_msgsend_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
@@ -373,7 +374,7 @@ func TestStandardMsgSendFeeAccounting(t *testing.T) {
 		tx.extensions = []*codectypes.Any{extension}
 		params := feemarkettypes.DefaultParams()
 		params.BaseFee = baseFee
-		checker := newStandardMsgSendDynamicFeeChecker(&params)
+		checker := newCosmosDynamicFeeChecker(&params)
 		effectivePrice := baseFee.Add(tipCap)
 
 		checkFees, priority, err := checker(
@@ -408,11 +409,30 @@ func TestStandardMsgSendFeeAccounting(t *testing.T) {
 		params := feemarkettypes.DefaultParams()
 		params.BaseFee = sdkmath.LegacyNewDec(gasPrice)
 
-		_, _, err := newStandardMsgSendDynamicFeeChecker(&params)(
+		_, _, err := newCosmosDynamicFeeChecker(&params)(
 			standardMsgSendFeeTestContext(1, declaredGas, executionGas, true),
 			tx,
 		)
 		require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+	})
+
+	t.Run("standard dispatch does not apply upstream raw fractional base fee", func(t *testing.T) {
+		feeCap := sdkmath.LegacyMustNewDecFromStr("10.5")
+		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+		tx.gas = declaredGas
+		tx.fee = sdk.NewCoins(sdk.NewCoin(
+			"agxn",
+			feeCap.MulInt(sdkmath.NewIntFromUint64(declaredGas)).RoundInt(),
+		))
+		params := feemarkettypes.DefaultParams()
+		params.BaseFee = sdkmath.LegacyMustNewDecFromStr("10.9")
+
+		fees, _, err := newCosmosDynamicFeeChecker(&params)(
+			standardMsgSendFeeTestContext(1, declaredGas, executionGas, true),
+			tx,
+		)
+		require.NoError(t, err)
+		require.Equal(t, tx.GetFee(), fees)
 	})
 
 	t.Run("validator minimum price reserves declared fee then settles execution fee", func(t *testing.T) {
@@ -454,7 +474,7 @@ func TestStandardMsgSendFeeAccounting(t *testing.T) {
 
 		wantFees, wantPriority, err := evmanteevm.NewDynamicFeeChecker(&params)(ctx, tx)
 		require.NoError(t, err)
-		gotFees, gotPriority, err := newStandardMsgSendDynamicFeeChecker(&params)(ctx, tx)
+		gotFees, gotPriority, err := newCosmosDynamicFeeChecker(&params)(ctx, tx)
 		require.NoError(t, err)
 		require.Equal(t, wantFees, gotFees)
 		require.Equal(t, wantPriority, gotPriority)
@@ -524,6 +544,456 @@ func TestAnteRouterPreservesUpstreamErrors(t *testing.T) {
 			require.EqualError(t, gotErr, wantErr.Error())
 		})
 	}
+}
+
+func TestOrdinaryDynamicFeeEffectivePriceFloor(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	const gas = uint64(100)
+	tests := []struct {
+		name           string
+		baseFee        string
+		baseFeeNil     bool
+		minGasPrice    string
+		feeCap         string
+		tipCap         *string
+		effectivePrice string
+		wantErr        bool
+	}{
+		{
+			name:           "below floor",
+			baseFee:        "10",
+			minGasPrice:    "15",
+			feeCap:         "20",
+			tipCap:         decString("1"),
+			effectivePrice: "11",
+			wantErr:        true,
+		},
+		{
+			name:           "exact floor",
+			baseFee:        "10",
+			minGasPrice:    "15",
+			feeCap:         "20",
+			tipCap:         decString("5"),
+			effectivePrice: "15",
+		},
+		{
+			name:           "above floor",
+			baseFee:        "10",
+			minGasPrice:    "15",
+			feeCap:         "20",
+			tipCap:         decString("6"),
+			effectivePrice: "16",
+		},
+		{
+			name:           "nil tip",
+			baseFee:        "10",
+			minGasPrice:    "15",
+			feeCap:         "20",
+			effectivePrice: "10",
+			wantErr:        true,
+		},
+		{
+			name:           "zero tip",
+			baseFee:        "10",
+			minGasPrice:    "15",
+			feeCap:         "20",
+			tipCap:         decString("0"),
+			effectivePrice: "10",
+			wantErr:        true,
+		},
+		{
+			name:           "zero base fee",
+			baseFee:        "0",
+			minGasPrice:    "15",
+			feeCap:         "20",
+			tipCap:         decString("14"),
+			effectivePrice: "14",
+			wantErr:        true,
+		},
+		{
+			name:           "nil base fee",
+			baseFee:        "0",
+			baseFeeNil:     true,
+			minGasPrice:    "15",
+			feeCap:         "20",
+			tipCap:         decString("14"),
+			effectivePrice: "14",
+			wantErr:        true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			params := dynamicFeeFloorParams(test.baseFee, test.minGasPrice)
+			if test.baseFeeNil {
+				params.BaseFee = sdkmath.LegacyDec{}
+			}
+			tx := newOrdinaryDynamicFeeTestTx(t, gas, test.feeCap, test.tipCap)
+			ctx := ordinaryDynamicFeeTestContext(1)
+
+			feeCap := sdkmath.LegacyNewDecFromInt(tx.GetFee().AmountOf(evmtypes.GetEVMCoinDenom())).
+				QuoInt(sdkmath.NewIntFromUint64(gas))
+			requiredTotal := params.MinGasPrice.MulInt64(int64(gas)).Ceil().RoundInt()
+			require.True(t, feeCap.GTE(params.MinGasPrice), "upfront fee cap must satisfy the global floor")
+			require.True(t, tx.GetFee().AmountOf(evmtypes.GetEVMCoinDenom()).GTE(requiredTotal))
+
+			wantFees, wantPriority, upstreamErr := evmanteevm.NewDynamicFeeChecker(&params)(ctx, tx)
+			require.NoError(t, upstreamErr, "the upstream checker must accept the regression input")
+			effectivePrice := sdkmath.LegacyMustNewDecFromStr(test.effectivePrice)
+			require.Equal(
+				t,
+				effectivePrice.MulInt64(int64(gas)).Ceil().RoundInt(),
+				wantFees.AmountOf(evmtypes.GetEVMCoinDenom()),
+			)
+
+			gotFees, gotPriority, err := newCosmosDynamicFeeChecker(&params)(ctx, tx)
+			if test.wantErr {
+				require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+				require.Nil(t, gotFees)
+				require.Zero(t, gotPriority)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, wantFees, gotFees)
+			require.Equal(t, wantPriority, gotPriority)
+		})
+	}
+}
+
+func TestOrdinaryDynamicFeeFloorUsesDecimalPriceNotRoundedTotal(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	const gas = uint64(10)
+	params := dynamicFeeFloorParams("1.08", "1.1")
+	tx := newOrdinaryDynamicFeeTestTx(t, gas, "1.1", decString("0.01"))
+	ctx := ordinaryDynamicFeeTestContext(1)
+
+	providedRoundedTotal := sdkmath.LegacyMustNewDecFromStr("1.09").
+		MulInt64(int64(gas)).
+		Ceil().
+		RoundInt()
+	requiredRoundedTotal := params.MinGasPrice.
+		MulInt64(int64(gas)).
+		Ceil().
+		RoundInt()
+	require.Equal(t, requiredRoundedTotal, providedRoundedTotal, "rounded totals are intentionally equal")
+	require.Equal(t, sdkmath.NewInt(11), tx.GetFee().AmountOf(evmtypes.GetEVMCoinDenom()))
+
+	_, _, upstreamErr := evmanteevm.NewDynamicFeeChecker(&params)(ctx, tx)
+	require.NoError(t, upstreamErr)
+	_, _, err := newCosmosDynamicFeeChecker(&params)(ctx, tx)
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+}
+
+func TestOrdinaryDynamicFeeFloorPreservesUpstreamSemantics(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	t.Run("minimum gas price zero", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10", "0")
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0"))
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+
+	t.Run("dynamic extension absent", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10", "15")
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0"))
+		tx.extensions = nil
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+
+	t.Run("genesis fallback", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10", "15")
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0"))
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(0), &params, tx)
+	})
+
+	t.Run("negative tip error", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10", "15")
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("-1"))
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+
+	t.Run("zero gas error", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10", "15")
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("1"))
+		tx.gas = 0
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+
+	t.Run("fee cap below base fee error", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10", "15")
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "9", decString("1"))
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+
+	t.Run("tip above fee cap remains capped", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10", "15")
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("25"))
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+
+	t.Run("raw fractional base fee is preserved when no base fee flag is set", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10.9", "11")
+		params.NoBaseFee = true
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0.1"))
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+
+	t.Run("future base fee enable height still uses raw base fee", func(t *testing.T) {
+		params := dynamicFeeFloorParams("10.9", "11")
+		params.EnableHeight = 100
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0.1"))
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+
+	t.Run("pre London fallback", func(t *testing.T) {
+		configureStandardMsgSendFeeTestChain(t, 100)
+		t.Cleanup(func() { configureStandardMsgSendFeeTestChain(t, 0) })
+		params := dynamicFeeFloorParams("10", "15")
+		tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("-1"))
+		assertOrdinaryDynamicCheckerMatchesUpstream(t, ordinaryDynamicFeeTestContext(1), &params, tx)
+	})
+}
+
+func TestOrdinaryDynamicFeeFloorRejectsBeforeDeductionAndDownstream(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	params := dynamicFeeFloorParams("10", "15")
+	tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0"))
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x81}, 20))
+	tx.payer = payer
+	accountKeeper := &dynamicFeeFloorAccountKeeper{
+		addressCodec:  evmaddress.NewEvmCodec("guru"),
+		account:       authtypes.NewBaseAccountWithAddress(payer),
+		moduleAddress: sdk.AccAddress(bytes.Repeat([]byte{0x82}, 20)),
+	}
+	bankKeeper := &dynamicFeeFloorBankKeeper{}
+	decorator := authante.NewDeductFeeDecorator(
+		accountKeeper,
+		bankKeeper,
+		nil,
+		newCosmosDynamicFeeChecker(&params),
+	)
+	ctx := ordinaryDynamicFeeTestContext(1).WithEventManager(sdk.NewEventManager())
+	nextCalls := 0
+
+	_, err := decorator.AnteHandle(ctx, tx, false, func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		nextCalls++
+		return nextCtx, nil
+	})
+
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+	require.Zero(t, bankKeeper.sendCalls)
+	require.Zero(t, nextCalls)
+}
+
+func TestOrdinaryDynamicFeeFloorPreservesSimulation(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	params := dynamicFeeFloorParams("10", "15")
+	tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0"))
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x91}, 20))
+	tx.payer = payer
+	accountKeeper := &dynamicFeeFloorAccountKeeper{
+		addressCodec:  evmaddress.NewEvmCodec("guru"),
+		account:       authtypes.NewBaseAccountWithAddress(payer),
+		moduleAddress: sdk.AccAddress(bytes.Repeat([]byte{0x92}, 20)),
+	}
+	bankKeeper := &dynamicFeeFloorBankKeeper{}
+	decorator := authante.NewDeductFeeDecorator(
+		accountKeeper,
+		bankKeeper,
+		nil,
+		newCosmosDynamicFeeChecker(&params),
+	)
+	ctx := ordinaryDynamicFeeTestContext(1).WithEventManager(sdk.NewEventManager())
+	nextCalls := 0
+
+	_, err := decorator.AnteHandle(ctx, tx, true, func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		nextCalls++
+		return nextCtx, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, bankKeeper.sendCalls)
+	require.Equal(t, 1, nextCalls)
+}
+
+func TestOrdinaryDynamicFeeFloorCoversStandardMsgSendFallbacks(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	params := dynamicFeeFloorParams("10", "15")
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	decorator := NewStandardMsgSendGasDecorator(
+		&standardMsgSendAccountKeeper{addressCodec: addressCodec},
+		standardMsgSendTestMinGasMultiplier(),
+		0,
+	)
+	tests := []struct {
+		name   string
+		mutate func(*standardMsgSendTestTx)
+	}{
+		{
+			name: "multiple messages",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs = append(tx.msgs, tx.msgs[0])
+			},
+		},
+		{
+			name: "fee grant",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.granter = append(sdk.AccAddress(nil), tx.payer...)
+			},
+		},
+		{
+			name: "classifier fallback MsgSend",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.memo = strings.Repeat("m", StandardMsgSendMaxMemoBytes+1)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0"))
+			test.mutate(&tx)
+			checkerCalls := 0
+
+			_, err := decorator.AnteHandle(
+				ordinaryDynamicFeeTestContext(1),
+				tx,
+				false,
+				func(nextCtx sdk.Context, nextTx sdk.Tx, _ bool) (sdk.Context, error) {
+					checkerCalls++
+					require.False(t, isStandardMsgSendGasContext(nextCtx))
+					_, _, checkErr := newCosmosDynamicFeeChecker(&params)(nextCtx, nextTx)
+					return nextCtx, checkErr
+				},
+			)
+
+			require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+			require.Equal(t, 1, checkerCalls)
+		})
+	}
+}
+
+func TestOrdinaryDynamicFeeFloorUsesUpdatedMinGasPrice(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	params := dynamicFeeFloorParams("10", "10")
+	tx := newOrdinaryDynamicFeeTestTx(t, 100, "20", decString("0"))
+	checker := newCosmosDynamicFeeChecker(&params)
+	ctx := ordinaryDynamicFeeTestContext(1)
+
+	_, _, err := checker(ctx, tx)
+	require.NoError(t, err)
+
+	params.MinGasPrice = sdkmath.LegacyMustNewDecFromStr("10.000000000000000001")
+	_, _, err = checker(ctx, tx)
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+}
+
+func dynamicFeeFloorParams(baseFee string, minGasPrice string) feemarkettypes.Params {
+	params := feemarkettypes.DefaultParams()
+	params.BaseFee = sdkmath.LegacyMustNewDecFromStr(baseFee)
+	params.MinGasPrice = sdkmath.LegacyMustNewDecFromStr(minGasPrice)
+	return params
+}
+
+func newOrdinaryDynamicFeeTestTx(
+	t *testing.T,
+	gas uint64,
+	feeCap string,
+	tipCap *string,
+) standardMsgSendTestTx {
+	t.Helper()
+
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x80}, 20))
+	tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+	tx.gas = gas
+	feeCapDec := sdkmath.LegacyMustNewDecFromStr(feeCap)
+	feeAmount := feeCapDec.MulInt(sdkmath.NewIntFromUint64(gas)).Ceil().RoundInt()
+	tx.fee = sdk.NewCoins(sdk.NewCoin(evmtypes.GetEVMCoinDenom(), feeAmount))
+
+	var tip sdkmath.LegacyDec
+	if tipCap != nil {
+		tip = sdkmath.LegacyMustNewDecFromStr(*tipCap)
+	}
+	extension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{
+		MaxPriorityPrice: tip,
+	})
+	require.NoError(t, err)
+	tx.extensions = []*codectypes.Any{extension}
+	return tx
+}
+
+func ordinaryDynamicFeeTestContext(height int64) sdk.Context {
+	return sdk.Context{}.
+		WithBlockHeight(height).
+		WithGasMeter(storetypes.NewInfiniteGasMeter())
+}
+
+func assertOrdinaryDynamicCheckerMatchesUpstream(
+	t *testing.T,
+	ctx sdk.Context,
+	params *feemarkettypes.Params,
+	tx standardMsgSendTestTx,
+) {
+	t.Helper()
+
+	wantFees, wantPriority, wantErr := evmanteevm.NewDynamicFeeChecker(params)(ctx, tx)
+	gotFees, gotPriority, gotErr := newCosmosDynamicFeeChecker(params)(ctx, tx)
+	if wantErr != nil {
+		require.EqualError(t, gotErr, wantErr.Error())
+		require.Equal(t, wantFees, gotFees)
+		require.Equal(t, wantPriority, gotPriority)
+		return
+	}
+
+	require.NoError(t, gotErr)
+	require.Equal(t, wantFees, gotFees)
+	require.Equal(t, wantPriority, gotPriority)
+}
+
+func decString(value string) *string {
+	return &value
+}
+
+type dynamicFeeFloorAccountKeeper struct {
+	authante.AccountKeeper
+	addressCodec  coreaddress.Codec
+	account       sdk.AccountI
+	moduleAddress sdk.AccAddress
+}
+
+func (keeper *dynamicFeeFloorAccountKeeper) AddressCodec() coreaddress.Codec {
+	return keeper.addressCodec
+}
+
+func (keeper *dynamicFeeFloorAccountKeeper) GetAccount(context.Context, sdk.AccAddress) sdk.AccountI {
+	return keeper.account
+}
+
+func (keeper *dynamicFeeFloorAccountKeeper) GetModuleAddress(string) sdk.AccAddress {
+	return keeper.moduleAddress
+}
+
+type dynamicFeeFloorBankKeeper struct {
+	authtypes.BankKeeper
+	sendCalls int
+}
+
+func (keeper *dynamicFeeFloorBankKeeper) SendCoinsFromAccountToModule(
+	context.Context,
+	sdk.AccAddress,
+	string,
+	sdk.Coins,
+) error {
+	keeper.sendCalls++
+	return nil
 }
 
 func configureStandardMsgSendFeeTestChain(t *testing.T, londonHeight int64) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -18,17 +18,21 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 	signing "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	antetypes "github.com/cosmos/evm/ante/types"
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
 	evmmempool "github.com/cosmos/evm/mempool"
 	evmutils "github.com/cosmos/evm/utils"
@@ -342,6 +346,115 @@ func TestApplicationStateMachine(t *testing.T) {
 	require.True(t, application.FeeMarketAdapter.GetMinGasPrice(
 		queryContext,
 	).Equal(mustInt(constitutiontypes.MinGasPriceScaleFactor).ToLegacyDec()))
+	const ordinaryDynamicFloorGas = uint64(200_000)
+	var ordinaryDynamicFloorTxBytes []byte
+	t.Run("ordinary SDK dynamic fee enforces effective price floor", func(t *testing.T) {
+		minGasPrice := feeMarketParams.MinGasPrice
+		nominalFee := minGasPrice.
+			MulInt(sdkmath.NewIntFromUint64(ordinaryDynamicFloorGas)).
+			Ceil().
+			RoundInt()
+		feeCap := sdkmath.LegacyNewDecFromInt(nominalFee).
+			QuoInt(sdkmath.NewIntFromUint64(ordinaryDynamicFloorGas))
+		require.True(t, feeCap.GTE(minGasPrice))
+		require.True(t, feeMarketParams.BaseFee.IsZero())
+
+		transferCoin := sdk.NewInt64Coin(config.BaseDenom, 1)
+		ordinaryMessage := &banktypes.MsgMultiSend{
+			Inputs: []banktypes.Input{{
+				Address: cosmosSender.String(),
+				Coins:   sdk.NewCoins(transferCoin),
+			}},
+			Outputs: []banktypes.Output{{
+				Address: sdk.AccAddress(cosmosRecipient.Bytes()).String(),
+				Coins:   sdk.NewCoins(transferCoin),
+			}},
+		}
+		dynamicExtension, extensionErr := codectypes.NewAnyWithValue(
+			&antetypes.ExtensionOptionDynamicFeeTx{},
+		)
+		require.NoError(t, extensionErr)
+		ordinaryDynamicFloorTxBytes = signAndEncodeCosmosTx(
+			t,
+			application,
+			cosmosPrivateKey,
+			cosmosSenderAccount.GetAccountNumber(),
+			cosmosSenderAccount.GetSequence(),
+			ordinaryMessage,
+			sdk.NewCoins(sdk.NewCoin(config.BaseDenom, nominalFee)),
+			ordinaryDynamicFloorGas,
+			dynamicExtension,
+		)
+
+		type stateSnapshot struct {
+			senderBalance    sdkmath.Int
+			recipientBalance sdkmath.Int
+			collectorBalance sdkmath.Int
+			sequence         uint64
+		}
+		feeCollector := authtypes.NewModuleAddress(authtypes.FeeCollectorName)
+		snapshot := func(ctx sdk.Context) stateSnapshot {
+			account := application.AccountKeeper.GetAccount(ctx, cosmosSender)
+			require.NotNil(t, account)
+			return stateSnapshot{
+				senderBalance: application.BankKeeper.GetBalance(
+					ctx,
+					cosmosSender,
+					config.BaseDenom,
+				).Amount,
+				recipientBalance: application.BankKeeper.GetBalance(
+					ctx,
+					sdk.AccAddress(cosmosRecipient.Bytes()),
+					config.BaseDenom,
+				).Amount,
+				collectorBalance: application.BankKeeper.GetBalance(
+					ctx,
+					feeCollector,
+					config.BaseDenom,
+				).Amount,
+				sequence: account.GetSequence(),
+			}
+		}
+		assertUnchanged := func(before stateSnapshot, ctx sdk.Context) {
+			t.Helper()
+			require.Equal(t, before, snapshot(ctx))
+		}
+
+		simulateBefore := snapshot(queryContext)
+		_, _, simulateErr := application.Simulate(ordinaryDynamicFloorTxBytes)
+		require.NoError(t, simulateErr)
+		assertUnchanged(simulateBefore, committedContext(t, application))
+
+		checkBefore := snapshot(application.GetContextForCheckTx(nil))
+		checkResponse, checkErr := application.CheckTx(&abci.RequestCheckTx{
+			Tx:   ordinaryDynamicFloorTxBytes,
+			Type: abci.CheckTxType_New,
+		})
+		require.NoError(t, checkErr)
+		require.Equal(t, sdkerrors.ErrInsufficientFee.ABCICode(), checkResponse.Code)
+		assertUnchanged(checkBefore, application.GetContextForCheckTx(nil))
+
+		recheckBefore := snapshot(application.GetContextForCheckTx(nil))
+		recheckResponse, recheckErr := application.CheckTx(&abci.RequestCheckTx{
+			Tx:   ordinaryDynamicFloorTxBytes,
+			Type: abci.CheckTxType_Recheck,
+		})
+		require.NoError(t, recheckErr)
+		require.Equal(t, sdkerrors.ErrInsufficientFee.ABCICode(), recheckResponse.Code)
+		assertUnchanged(recheckBefore, application.GetContextForCheckTx(nil))
+
+		proposalBefore := snapshot(committedContext(t, application))
+		proposalResponse, proposalErr := application.ProcessProposal(&abci.RequestProcessProposal{
+			Height: 2,
+			Time:   blockTime.Add(2 * time.Second),
+			Txs:    [][]byte{ordinaryDynamicFloorTxBytes},
+		})
+		require.NoError(t, proposalErr)
+		// Guru intentionally uses the SDK no-op proposal handler; execution safety
+		// is enforced when the same production ante handler runs in FinalizeBlock.
+		require.Equal(t, abci.ResponseProcessProposal_ACCEPT, proposalResponse.Status)
+		assertUnchanged(proposalBefore, committedContext(t, application))
+	})
 	t.Run("oracle fee production wiring", func(t *testing.T) {
 		assertOracleFeeMarketProductionWiring(t, application, queryContext)
 	})
@@ -602,6 +715,56 @@ func TestApplicationStateMachine(t *testing.T) {
 			))
 		})
 	}
+	t.Run("ordinary SDK dynamic fee accepts exact floor through production ante", func(t *testing.T) {
+		minGasPrice := feeMarketParams.MinGasPrice
+		nominalFee := minGasPrice.
+			MulInt(sdkmath.NewIntFromUint64(ordinaryDynamicFloorGas)).
+			Ceil().
+			RoundInt()
+		feeCap := sdkmath.LegacyNewDecFromInt(nominalFee).
+			QuoInt(sdkmath.NewIntFromUint64(ordinaryDynamicFloorGas))
+		effectivePrice := sdkmath.LegacyMinDec(
+			feeMarketParams.BaseFee.Add(minGasPrice),
+			feeCap,
+		)
+		require.True(t, effectivePrice.Equal(minGasPrice))
+
+		exactFloorExtension, extensionErr := codectypes.NewAnyWithValue(
+			&antetypes.ExtensionOptionDynamicFeeTx{MaxPriorityPrice: minGasPrice},
+		)
+		require.NoError(t, extensionErr)
+		checkContext := application.GetContextForCheckTx(nil)
+		checkAccount := application.AccountKeeper.GetAccount(checkContext, cosmosSender)
+		require.NotNil(t, checkAccount)
+		exactFloorTxBytes := signAndEncodeCosmosTx(
+			t,
+			application,
+			cosmosPrivateKey,
+			checkAccount.GetAccountNumber(),
+			checkAccount.GetSequence(),
+			&banktypes.MsgMultiSend{
+				Inputs: []banktypes.Input{{
+					Address: cosmosSender.String(),
+					Coins:   sdk.NewCoins(sdk.NewInt64Coin(config.BaseDenom, 1)),
+				}},
+				Outputs: []banktypes.Output{{
+					Address: sdk.AccAddress(cosmosRecipient.Bytes()).String(),
+					Coins:   sdk.NewCoins(sdk.NewInt64Coin(config.BaseDenom, 1)),
+				}},
+			},
+			sdk.NewCoins(sdk.NewCoin(config.BaseDenom, nominalFee)),
+			ordinaryDynamicFloorGas,
+			exactFloorExtension,
+		)
+
+		exactFloorResult, checkErr := application.CheckTx(&abci.RequestCheckTx{
+			Tx:   exactFloorTxBytes,
+			Type: abci.CheckTxType_New,
+		})
+		require.NoError(t, checkErr)
+		require.Equal(t, abci.CodeTypeOK, exactFloorResult.Code, exactFloorResult.Log)
+		require.Equal(t, int64(ordinaryDynamicFloorGas), exactFloorResult.GasWanted)
+	})
 
 	prepareResult, err := application.PrepareProposal(&abci.RequestPrepareProposal{
 		Height:     2,
@@ -619,15 +782,22 @@ func TestApplicationStateMachine(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, processResult.Status)
 
+	finalizeTxs := make([][]byte, 0, len(prepareResult.Txs)+1)
+	finalizeTxs = append(finalizeTxs, ordinaryDynamicFloorTxBytes)
+	finalizeTxs = append(finalizeTxs, prepareResult.Txs...)
 	finalized, err := application.FinalizeBlock(&abci.RequestFinalizeBlock{
 		Height:          2,
 		Time:            blockTime.Add(2 * time.Second),
 		ProposerAddress: proposerAddress,
-		Txs:             prepareResult.Txs,
+		Txs:             finalizeTxs,
 	})
 	require.NoError(t, err)
-	require.Len(t, finalized.TxResults, 2)
-	for index, result := range finalized.TxResults {
+	require.Len(t, finalized.TxResults, 3)
+	rejectedDynamicResult := finalized.TxResults[0]
+	require.Equal(t, sdkerrors.ErrInsufficientFee.ABCICode(), rejectedDynamicResult.Code)
+	require.Equal(t, int64(ordinaryDynamicFloorGas), rejectedDynamicResult.GasWanted)
+	require.Positive(t, rejectedDynamicResult.GasUsed)
+	for index, result := range finalized.TxResults[1:] {
 		require.True(t, result.IsOK(), result.Log)
 		require.Equal(t, int64(submittedGas), result.GasWanted)
 		require.Equal(t, int64(minimumGasUsed), result.GasUsed)
@@ -640,9 +810,10 @@ func TestApplicationStateMachine(t *testing.T) {
 	}
 	finalizeContext := application.GetContextForFinalizeBlock(nil)
 	require.Zero(t, application.FeeMarketKeeper.GetTransientGasWanted(finalizeContext))
+	expectedBlockGasWantedWithRejected := expectedBlockGasWanted + uint64(rejectedDynamicResult.GasUsed)
 	require.Equal(
 		t,
-		expectedBlockGasWanted,
+		expectedBlockGasWantedWithRejected,
 		application.FeeMarketKeeper.GetBlockGasWanted(finalizeContext),
 	)
 	_, err = application.Commit()
@@ -668,7 +839,7 @@ func TestApplicationStateMachine(t *testing.T) {
 	}
 	require.Equal(
 		t,
-		expectedBlockGasWanted,
+		expectedBlockGasWantedWithRejected,
 		application.FeeMarketKeeper.GetBlockGasWanted(queryContext),
 	)
 
@@ -872,9 +1043,15 @@ func signAndEncodeCosmosTx(
 	message sdk.Msg,
 	fees sdk.Coins,
 	gasLimit uint64,
+	extensionOptions ...*codectypes.Any,
 ) []byte {
 	t.Helper()
 	builder := application.GetTxConfig().NewTxBuilder()
+	if len(extensionOptions) > 0 {
+		extensionBuilder, ok := builder.(authtx.ExtensionOptionsTxBuilder)
+		require.True(t, ok)
+		extensionBuilder.SetExtensionOptions(extensionOptions...)
+	}
 	require.NoError(t, builder.SetMsgs(message))
 	builder.SetFeeAmount(fees)
 	builder.SetGasLimit(gasLimit)


### PR DESCRIPTION
# Description

This PR fixes a global minimum gas-price enforcement gap for ordinary Cosmos
SDK transactions that use `ExtensionOptionDynamicFeeTx`.

The existing Cosmos minimum-gas-price decorator validates the submitted fee
cap or total fee against the global floor. The Cosmos EVM v0.6.2 dynamic-fee
checker then calculates the price that is actually charged using EIP-1559
semantics:

- `F = submitted fee / declared gas`
- `P = min(B + T, F)`

where:

- `F` is the submitted fee cap per gas;
- `B` is the FeeMarket base fee;
- `T` is `MaxPriorityPrice`;
- `P` is the effective gas price; and
- `M` is the global `MinGasPrice`.

Previously, a transaction could satisfy `F >= M` while still producing
`P < M`. The submitted fee therefore passed the global floor check, but the
upstream dynamic-fee checker returned a lower effective fee for deduction.
Under Guru's zero-base-fee policy, a nil or zero priority price could make the
effective price zero even when the submitted fee cap satisfied the global
minimum.

This change:

- introduces an application-wide Cosmos dynamic-fee checker that wraps the
  upstream Cosmos EVM v0.6.2 checker;
- runs the upstream checker first so its fee calculation, priority, fallback
  behavior, and error ordering remain unchanged;
- reconstructs the exact `LegacyDec` effective gas price and rejects an
  ordinary dynamic-fee transaction with `ErrInsufficientFee` when `P < M`;
- compares exact decimal prices before converting them into rounded integer fee
  totals, preventing rounding collisions from admitting a below-floor price;
- preserves the upstream behavior for genesis transactions, pre-London heights,
  zero `MinGasPrice`, transactions without the dynamic-fee extension, and
  upstream validation errors;
- keeps eligible standard `MsgSend` transactions on their existing
  `FixedSendGas` admission and execution-gas settlement policy;
- applies the ordinary dynamic-fee floor to standard-`MsgSend` fallback cases,
  including multi-message transactions, fee grants, and classifier fallbacks;
  and
- rejects an affected transaction before fee deduction, sequence increment, or
  message execution.

The execution boundary for an affected below-floor transaction is:

| Phase | Result |
|---|---|
| `Simulate` | Preserves the existing simulation behavior and does not commit state |
| `CheckTx` | Returns `ErrInsufficientFee` without changing balances or sequence |
| `ReCheckTx` | Returns `ErrInsufficientFee` without changing balances or sequence |
| `ProcessProposal` | Remains accepted by Guru's existing SDK no-op proposal handler |
| `FinalizeBlock` | The transaction fails ante validation before fee deduction or message execution; block processing continues and consumed ante gas remains accounted |

An ordinary dynamic-fee transaction whose exact effective price equals
`MinGasPrice` remains accepted by the production `CheckTx` path.

## Critical files to review

- `app/ante/handler.go`
  - application-wide Cosmos dynamic-fee dispatch;
  - upstream compatibility boundary; and
  - exact effective gas-price floor validation.
- `app/ante/standard_msgsend_fee.go`
  - separation of the standard `MsgSend` fee and settlement policy from the
    ordinary Cosmos dynamic-fee policy; and
  - shared dynamic-fee extension extraction.
- `app/ante/standard_msgsend_test.go`
  - below-, exact-, and above-floor boundaries;
  - decimal-price versus rounded-total behavior;
  - upstream fallback and error compatibility;
  - rejection before deduction and downstream decorators; and
  - standard `MsgSend` fallback routing.
- `app/app_test.go`
  - production ante wiring across simulation, `CheckTx`, `ReCheckTx`,
    `ProcessProposal`, `FinalizeBlock`, and committed state.

## Review instructions

1. Trace an ordinary Cosmos SDK transaction carrying
   `ExtensionOptionDynamicFeeTx` through `app/ante/handler.go`.
2. Confirm that the upstream Cosmos EVM checker runs before the application
   floor check, preserving upstream errors and fee/priority results.
3. Confirm that the application compares the exact decimal value of
   `min(BaseFee + MaxPriorityPrice, feeCap)` against `MinGasPrice`, rather than
   comparing rounded integer fee totals.
4. Confirm that genesis, pre-London, zero-minimum-price, missing-extension, and
   invalid dynamic-fee inputs retain the upstream behavior and error ordering.
5. Confirm that eligible standard `MsgSend` transactions retain their declared
   gas admission and execution-gas settlement semantics, while ineligible or
   fallback transactions use the ordinary dynamic-fee floor.
6. Confirm that an under-floor transaction is rejected before fee deduction,
   sequence increment, or message execution.
7. Review the ABCI lifecycle boundary carefully: `ProcessProposal`
   intentionally remains no-op and accepts the transaction, while
   `FinalizeBlock` returns a failed transaction result through the production
   ante handler.
8. For a live network deployment, confirm that validator activation is
   coordinated at the same upgrade height.

## Validation

The following checks passed on the dedicated IDC remote test runner using the
repository-required Go 1.23.8 toolchain:

- `env GOTOOLCHAIN=go1.23.8 go test -mod=readonly -count=1 ./app/ante ./app`
- `env GOTOOLCHAIN=go1.23.8 go test -race -mod=readonly -count=1 ./app/ante ./app`

Additional formatting and diff checks passed:

- `gofmt -d` on all four changed Go files produced no diff.
- `git diff --check HEAD^ HEAD` reported no whitespace errors.

The full repository test suite, a real CometBFT multi-validator E2E test, and
GitHub CI were not run as part of this PR-description pass.

## Compatibility and consensus impact

This PR does not change protobuf definitions, persistent stores, genesis
schemas, or node configuration. It does change production ante and state
transition behavior.

Clients that previously supplied a sufficient fee cap but a nil, zero, or low
`MaxPriorityPrice` must now ensure that:

`min(BaseFee + MaxPriorityPrice, feeCap) >= MinGasPrice`

On an already-running network, this binary must be activated consistently by
validators at a coordinated upgrade height. An old binary can execute an
under-floor transaction that the new binary rejects, which can produce
different transaction results, balances, sequences, and application hashes
across mixed validator versions.

Guru's current `ProcessProposal` handler remains the SDK no-op handler. This PR
therefore does not add proposal filtering: a proposer can include an affected
transaction directly in a block, after which `FinalizeBlock` deterministically
returns an insufficient-fee transaction result without committing its fee,
transfer, or sequence changes.

Closes: N/A

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member — TODO: add the relevant issue or team discussion reference
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch — N/A: this v2.1 change targets `dev-v2.1` as required by `CONTRIBUTING.md`

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md` — N/A: `CHANGELOG.md` is not present in the `dev-v2.1` base
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code — N/A: this PR intentionally changes production ante fee validation
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed