### PR TITLE
Fix/cosmos msgsend gas accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,12 @@ Guru installs Cosmos SDK modules, Cosmos EVM VM/FeeMarket/ERC20 modules, IBC
 core, and ICS-20. It also installs the Guru Constitution and Oracle modules and
 wraps upstream staking so the chain-wide minimum validator self-bond is applied
 at genesis and during validator-set updates. The ante handler preserves the
-upstream Ethereum transaction path while applying Guru's standard `MsgSend`
-gas and fee rules to eligible Cosmos transactions.
+upstream Ethereum transaction path while applying Guru's FixedSendGas policy to
+bounded, single-key Cosmos `MsgSend` transactions. Eligible transactions retain
+their signed gas limit and raw bytes, but use exactly `21,000` gas for public
+accounting, proposal budgeting, FeeMarket contribution, and fee settlement. The
+eligibility ceiling is 2,048 raw bytes; a larger decode-valid transaction follows
+the ordinary upstream Cosmos path instead of being rejected for size alone.
 
 The generated default genesis:
 
@@ -82,14 +86,28 @@ The generated default genesis:
 
 These are bootstrap values. Operators may edit a new network's genesis subject
 to both upstream module validation and Guru's cross-module checks. Guru validates
-the Constitution self-bond denomination and amount and the required FeeMarket
-policy before accepting genesis.
+the Constitution self-bond denomination and amount, the required FeeMarket
+policy, and that both EVM denomination fields remain equal to the immutable
+`config.BaseDenom` before accepting genesis.
+
+Runtime EVM parameter updates are a trusted-governance boundary. Under that
+trust model, Guru accepts the operational risk that the upstream
+`MsgUpdateParams` path does not revalidate `EvmDenom` or
+`ExtendedDenomOptions`. Operators MUST NOT use that message to change either
+field: both denominations are operationally immutable after genesis, and
+denomination changes are upgrade-only. Any such change requires a coordinated
+binary upgrade and an explicit state migration covering bank metadata and
+balances, stored and global EVM coin information, FeeMarket and FixedSendGas
+policy, transaction and RPC clients, and export/import validation. Other EVM
+parameters remain governable subject to their normal validation.
 
 ## Mempool and proposal behavior
 
 Guru deliberately uses the SDK `NoOpMempool` because CometBFT owns transaction
-storage and gossip. The normal transaction selection path delegates to the SDK
-default proposal handler for a no-op application mempool.
+storage and gossip. Its application proposal handler preserves FIFO order and
+the original raw bytes while applying mixed gas budgeting: eligible
+FixedSendGas transactions count as `21,000`, and ordinary transactions count by
+their signed gas limit.
 
 Guru wraps that default path with Oracle proposal handling. When an Oracle
 payload is expected, `PrepareProposal` validates the extended commit, builds a
@@ -99,9 +117,21 @@ a missing, malformed, or mismatched Oracle payload.
 
 Broadcast transactions normally pass `CheckTx` before entering the CometBFT
 mempool. Ante verification runs again during `FinalizeBlock`; an invalid or
-stale normal transaction therefore produces a deterministic failed transaction
-result without committing its state. Oracle consensus records are stricter: the
-proposal is rejected when their canonical content or position is invalid.
+stale ordinary transaction therefore produces a deterministic failed
+transaction result without committing its state. FixedSendGas proposal
+admission uses an ante-only snapshot: the height `H-1` committed state, the
+projected target-height BaseFee, the minimum gas price already effective for
+height `H`, and successful ante writes from preceding proposal transactions.
+It does not apply `PreBlock`, `BeginBlock`, or preceding transaction message
+state transitions. `ProcessProposal` rejects the whole proposal when a normal
+raw transaction cannot be decoded, a FixedSendGas transaction violates
+consensus/admission rules under that snapshot, or the mixed gas budget is
+exceeded. Decode-valid ordinary ante failures retain the existing `NoOp`
+behavior. Failures that arise only in `FinalizeBlock` because of the excluded
+lifecycle or preceding message effects follow the normal per-transaction
+ante/message semantics and do not retroactively reject the proposal. Oracle
+consensus records remain stricter: the proposal is rejected when their canonical
+content or position is invalid.
 
 Each validator may run the standalone `oracled` process and configure its Unix
 socket in the node's `[oracle]` section. Oracle participation is enabled by

--- a/app/ante/handler.go
+++ b/app/ante/handler.go
@@ -7,6 +7,7 @@ import (
 	evmante "github.com/cosmos/evm/ante"
 	cosmosante "github.com/cosmos/evm/ante/cosmos"
 	evmanteevm "github.com/cosmos/evm/ante/evm"
+	anteinterfaces "github.com/cosmos/evm/ante/interfaces"
 	antetypes "github.com/cosmos/evm/ante/types"
 	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
@@ -23,15 +24,59 @@ var (
 	dynamicFeeExtensionURL   = sdk.MsgTypeURL(&antetypes.ExtensionOptionDynamicFeeTx{})
 )
 
+// ProspectiveFeeMarketKeeper extends the upstream ante keeper contract with
+// the deterministic EIP-1559 calculation used by the fee market BeginBlocker.
+type ProspectiveFeeMarketKeeper interface {
+	anteinterfaces.FeeMarketKeeper
+	CalculateBaseFee(ctx sdk.Context) sdkmath.LegacyDec
+}
+
+// prospectiveFeeMarketParamsAdapter makes proposal-time ante verification use
+// the same target-height BaseFee that FinalizeBlock will install in BeginBlock.
+// CheckTx, ReCheckTx, Simulate, and FinalizeBlock retain the keeper's stored
+// parameters exactly.
+type prospectiveFeeMarketParamsAdapter struct {
+	ProspectiveFeeMarketKeeper
+}
+
+// NewProspectiveFeeMarketParamsAdapter adapts the application fee market
+// keeper without changing the upstream HandlerOptions contract.
+func NewProspectiveFeeMarketParamsAdapter(
+	keeper ProspectiveFeeMarketKeeper,
+) anteinterfaces.FeeMarketKeeper {
+	return prospectiveFeeMarketParamsAdapter{ProspectiveFeeMarketKeeper: keeper}
+}
+
+func (a prospectiveFeeMarketParamsAdapter) GetParams(ctx sdk.Context) feemarkettypes.Params {
+	params := a.ProspectiveFeeMarketKeeper.GetParams(ctx)
+	switch ctx.ExecMode() {
+	case sdk.ExecModePrepareProposal, sdk.ExecModeProcessProposal:
+		prospectiveBaseFee := a.ProspectiveFeeMarketKeeper.CalculateBaseFee(ctx)
+		// FeeMarket BeginBlock only stores a newly calculated BaseFee when the
+		// calculation is non-nil. Mirror that lifecycle boundary so proposal ante
+		// never replaces the stored value with an uninitialized decimal.
+		if !prospectiveBaseFee.IsNil() {
+			params.BaseFee = prospectiveBaseFee
+		}
+	}
+	return params
+}
+
 // NewAnteHandler preserves the upstream Cosmos EVM v0.6.2 Ethereum path and
 // routes Cosmos transactions through the application-local fee policy and
 // standard MsgSend gas extension.
 func NewAnteHandler(options evmante.HandlerOptions) sdk.AnteHandler {
 	upstreamHandler := evmante.NewAnteHandler(options)
+	classifier := NewStandardMsgSendClassifier(options.AccountKeeper)
 
 	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
-		if tx == nil {
-			return upstreamHandler(ctx, tx, simulate)
+		classification, fixed, err := classifier.classify(ctx, tx, simulate)
+		if err != nil {
+			return ctx, err
+		}
+		if fixed {
+			fixedCtx := ctx.WithValue(standardMsgSendContextKey{}, &classification)
+			return newCosmosAnteHandler(fixedCtx, options)(fixedCtx, tx, simulate)
 		}
 
 		if extensionTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
@@ -60,9 +105,13 @@ func newCosmosAnteHandler(ctx sdk.Context, options evmante.HandlerOptions) sdk.A
 	var txFeeChecker authante.TxFeeChecker
 	if options.DynamicFeeChecker {
 		txFeeChecker = newCosmosDynamicFeeChecker(&feemarketParams)
-	} else {
-		txFeeChecker = newStandardMsgSendValidatorFeeChecker()
 	}
+	spendableBankKeeper, _ := options.BankKeeper.(standardMsgSendSpendableBankKeeper)
+	ordinaryGasWanted := evmanteevm.NewGasWantedDecorator(
+		options.EvmKeeper,
+		options.FeeMarketKeeper,
+		&feemarketParams,
+	)
 
 	return sdk.ChainAnteDecorators(
 		cosmosante.NewRejectMessagesDecorator(),
@@ -70,19 +119,18 @@ func newCosmosAnteHandler(ctx sdk.Context, options evmante.HandlerOptions) sdk.A
 			sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
 			sdk.MsgTypeURL(&sdkvesting.MsgCreateVestingAccount{}),
 		),
-		authante.NewSetUpContextDecorator(),
-		NewStandardMsgSendGasDecorator(
-			options.AccountKeeper,
-			feemarketParams.MinGasMultiplier,
-			options.MaxTxGasWanted,
-		),
+		NewStandardMsgSendGasDecorator(options.AccountKeeper),
 		authante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		authante.NewValidateBasicDecorator(),
 		authante.NewTxTimeoutHeightDecorator(),
 		authante.NewValidateMemoDecorator(options.AccountKeeper),
-		newStandardMsgSendMinGasPriceDecorator(&feemarketParams),
+		newStandardMsgSendFeePlanDecorator(
+			&feemarketParams,
+			options.AccountKeeper,
+			spendableBankKeeper,
+		),
 		authante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
-		authante.NewDeductFeeDecorator(
+		newStandardMsgSendDeductFeeDecorator(
 			options.AccountKeeper,
 			options.BankKeeper,
 			options.FeegrantKeeper,
@@ -94,8 +142,8 @@ func newCosmosAnteHandler(ctx sdk.Context, options evmante.HandlerOptions) sdk.A
 		authante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		authante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
-		evmanteevm.NewGasWantedDecorator(
-			options.EvmKeeper,
+		newStandardMsgSendGasWantedDecorator(
+			ordinaryGasWanted,
 			options.FeeMarketKeeper,
 			&feemarketParams,
 		),
@@ -105,18 +153,14 @@ func newCosmosAnteHandler(ctx sdk.Context, options evmante.HandlerOptions) sdk.A
 // newCosmosDynamicFeeChecker owns the application-wide Cosmos dynamic-fee
 // policy. Ordinary transactions preserve the upstream Cosmos EVM v0.6.2 fee,
 // priority, fallback, and error ordering, then enforce the global floor against
-// the exact dynamic effective price. Eligible MsgSend transactions delegate to
-// the separate FixedSendGas fee and settlement policy.
+// the exact dynamic effective price. FixedSendGas transactions use their
+// context fee plan instead of this checker.
 func newCosmosDynamicFeeChecker(
 	feemarketParams *feemarkettypes.Params,
 ) authante.TxFeeChecker {
 	upstream := evmanteevm.NewDynamicFeeChecker(feemarketParams)
 
 	return func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
-		if isStandardMsgSendGasContext(ctx) {
-			return checkStandardMsgSendDynamicFee(ctx, tx, feemarketParams, upstream)
-		}
-
 		feeTx, ok := tx.(sdk.FeeTx)
 		if !ok {
 			return upstream(ctx, tx)

--- a/app/ante/standard_msgsend_fee.go
+++ b/app/ante/standard_msgsend_fee.go
@@ -1,272 +1,182 @@
 package ante
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/big"
-	"slices"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 
 	cosmosante "github.com/cosmos/evm/ante/cosmos"
+	evmanteevm "github.com/cosmos/evm/ante/evm"
 	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	chainconfig "github.com/gurufinglobal/guru/v2/config"
 )
 
-// checkStandardMsgSendDynamicFee applies the FixedSendGas fee and settlement
-// policy after the application-wide Cosmos checker selects an eligible MsgSend.
-// It uses the Ethereum transaction price model against declared gas D, then
-// settles that price against execution gas E.
-//
-// This application's native EVM denom has 18 decimals. Consequently, the EVM
-// path's ConvertAmountTo18DecimalsLegacy step is a no-op, while converting the
-// LegacyDec base fee to *big.Int still truncates its fractional component.
-func checkStandardMsgSendDynamicFee(
-	ctx sdk.Context,
-	tx sdk.Tx,
-	feemarketParams *feemarkettypes.Params,
-	upstream authante.TxFeeChecker,
-) (sdk.Coins, int64, error) {
-	feeTx, ok := tx.(sdk.FeeTx)
-	if !ok {
-		return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
-	}
-	settlementGas, ok := standardMsgSendSettlementGas(ctx)
-	if !ok {
-		return nil, 0, errorsmod.Wrap(sdkerrors.ErrLogic, "standard MsgSend execution gas is unavailable")
-	}
-	if ctx.BlockHeight() == 0 ||
-		!evmtypes.IsLondon(evmtypes.GetEthChainConfig(), ctx.BlockHeight()) {
-		fees, priority, err := upstream(ctx, tx)
-		if err != nil || isStandardMsgSendAdmissionContext(ctx) {
-			return fees, priority, err
-		}
-		settled, settleErr := settleStandardMsgSendFees(
-			fees,
-			feeTx.GetGas(),
-			settlementGas,
-		)
-		return settled, priority, settleErr
-	}
+const (
+	EventTypeFixedSendGas           = "fixed_send_gas"
+	AttributeKeyDeclaredGas         = "declared_gas"
+	AttributeKeyAccountingGas       = "accounting_gas"
+	AttributeKeySubmittedFee        = "submitted_fee"
+	AttributeKeyEffectiveGasPrice   = "effective_gas_price"
+	AttributeKeyActualFee           = "actual_fee"
+	standardMsgSendDecimalPrecision = 18
+)
 
-	if isStandardMsgSendAdmissionContext(ctx) {
-		return checkAndSettleStandardMsgSendFee(
-			ctx,
-			feeTx,
-			feemarketParams,
-			feeTx.GetGas(),
-		)
-	}
-	return checkAndSettleStandardMsgSendFee(
-		ctx,
-		feeTx,
-		feemarketParams,
-		settlementGas,
+type standardMsgSendFeePlanContextKey struct{}
+
+type standardMsgSendSpendableBankKeeper interface {
+	SpendableCoin(context.Context, sdk.AccAddress, string) sdk.Coin
+}
+
+type standardMsgSendPrice struct {
+	numerator   *big.Int
+	denominator *big.Int
+}
+
+type standardMsgSendFeePlan struct {
+	declaredGas    uint64
+	submittedFee   sdk.Coin
+	effectivePrice standardMsgSendPrice
+	actualFee      sdk.Coins
+	priority       int64
+}
+
+func standardMsgSendDecimalScale() *big.Int {
+	return new(big.Int).Exp(
+		big.NewInt(10),
+		big.NewInt(standardMsgSendDecimalPrecision),
+		nil,
 	)
 }
 
-// newStandardMsgSendValidatorFeeChecker mirrors the Cosmos SDK v0.53
-// validator-min-gas-price checker. Admission and priority use the declared gas;
-// eligible MsgSend settlement alone uses execution gas.
-func newStandardMsgSendValidatorFeeChecker() authante.TxFeeChecker {
-	return func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
-		fees, priority, err := checkStandardMsgSendValidatorFee(ctx, tx)
-		if err != nil || !isStandardMsgSendGasContext(ctx) {
-			return fees, priority, err
-		}
-		if isStandardMsgSendAdmissionContext(ctx) {
-			return fees, priority, nil
-		}
-
-		feeTx, ok := tx.(sdk.FeeTx)
-		if !ok {
-			return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
-		}
-
-		settlementGas, ok := standardMsgSendSettlementGas(ctx)
-		if !ok {
-			return fees, priority, nil
-		}
-
-		settled, settleErr := settleStandardMsgSendFees(
-			fees,
-			feeTx.GetGas(),
-			settlementGas,
-		)
-		return settled, priority, settleErr
+func standardMsgSendScaledDec(value sdkmath.LegacyDec) *big.Int {
+	if value.IsNil() {
+		return new(big.Int)
 	}
+	return value.BigInt()
 }
 
-func isStandardMsgSendAdmissionContext(ctx sdk.Context) bool {
-	return ctx.IsCheckTx() || ctx.IsReCheckTx()
+func compareStandardMsgSendPrices(left, right standardMsgSendPrice) int {
+	leftProduct := new(big.Int).Mul(left.numerator, right.denominator)
+	rightProduct := new(big.Int).Mul(right.numerator, left.denominator)
+	return leftProduct.Cmp(rightProduct)
 }
 
-func isStandardMsgSendGasContext(ctx sdk.Context) bool {
-	_, ok := ctx.GasMeter().(*standardMsgSendGasMeter)
-	return ok
-}
-
-func standardMsgSendSettlementGas(ctx sdk.Context) (uint64, bool) {
-	meter, ok := ctx.GasMeter().(*standardMsgSendGasMeter)
-	if !ok {
-		return 0, false
+func ceilStandardMsgSendQuotient(numerator, denominator *big.Int) *big.Int {
+	quotient := new(big.Int)
+	remainder := new(big.Int)
+	quotient.QuoRem(numerator, denominator, remainder)
+	if remainder.Sign() != 0 {
+		quotient.Add(quotient, big.NewInt(1))
 	}
-	return uint64(meter.executionGas), true
+	return quotient
 }
 
-// checkAndSettleStandardMsgSendFee applies the successful Ethereum plain
-// transfer price semantics:
-//
-//   - legacy/no extension: P = F = submittedFee / D
-//   - dynamic extension: P = min(B + tip, F)
-//   - admission and priority use D; deduction is ceil(P * E)
-//
-// B is the integer EVM base fee. NoBaseFee and pre-enable heights produce B=0.
-func checkAndSettleStandardMsgSendFee(
+func standardMsgSendPriceString(price standardMsgSendPrice) string {
+	quotient := new(big.Int)
+	remainder := new(big.Int)
+	quotient.QuoRem(price.numerator, price.denominator, remainder)
+	if remainder.Sign() == 0 {
+		return quotient.String()
+	}
+	return fmt.Sprintf("%s/%s", price.numerator, price.denominator)
+}
+
+// buildStandardMsgSendFeePlan is the only FixedSendGas fee formula. It uses
+// exact integer cross-products throughout: feeCap F/D is never rounded into a
+// LegacyDec before BaseFee, MGP, settlement, or priority is decided.
+func buildStandardMsgSendFeePlan(
 	ctx sdk.Context,
-	feeTx sdk.FeeTx,
+	classification *standardMsgSendClassification,
 	feemarketParams *feemarkettypes.Params,
-	executionGas uint64,
-) (sdk.Coins, int64, error) {
+	accountKeeper authante.AccountKeeper,
+	bankKeeper standardMsgSendSpendableBankKeeper,
+	checkSpendability bool,
+) (standardMsgSendFeePlan, error) {
+	if classification == nil || classification.feeTx == nil || classification.msg == nil {
+		return standardMsgSendFeePlan{}, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas classification is unavailable",
+		)
+	}
+	if feemarketParams == nil {
+		return standardMsgSendFeePlan{}, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas fee market params are not configured",
+		)
+	}
+	if feemarketParams.MinGasPrice.IsNil() || feemarketParams.MinGasPrice.IsNegative() {
+		return standardMsgSendFeePlan{}, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas minimum gas price must be configured and non-negative",
+		)
+	}
+
+	feeTx := classification.feeTx
 	declaredGas := feeTx.GetGas()
-	if declaredGas == 0 {
-		return nil, 0, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "gas cannot be zero")
+	if declaredGas < StandardMsgSendGas {
+		return standardMsgSendFeePlan{}, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidGasLimit,
+			"FixedSendGas requires at least %d declared gas",
+			StandardMsgSendGas,
+		)
 	}
-
-	denom := evmtypes.GetEVMCoinDenom()
-	declaredGasInt := sdkmath.NewIntFromUint64(declaredGas)
-	feeAmount := feeTx.GetFee().AmountOf(denom)
-	feeCap := sdkmath.LegacyNewDecFromInt(feeAmount).QuoInt(declaredGasInt)
-	baseFee := standardMsgSendEthereumBaseFee(ctx, feemarketParams)
-
-	dynamicFee, hasDynamicFee := dynamicFeeExtension(feeTx)
-	effectivePrice := feeCap
-	priorityPrice := feeCap.Sub(baseFee)
-	if hasDynamicFee {
-		tipCap := dynamicFee.MaxPriorityPrice
-		if tipCap.IsNil() {
-			tipCap = sdkmath.LegacyZeroDec()
-		}
-		if tipCap.IsNegative() {
-			return nil, 0, errorsmod.Wrap(sdkerrors.ErrInsufficientFee, "max priority price cannot be negative")
-		}
-		if tipCap.GT(feeCap) {
-			return nil, 0, errorsmod.Wrapf(
-				sdkerrors.ErrInsufficientFee,
-				"max priority price %s exceeds fee cap %s",
-				tipCap,
-				feeCap,
-			)
-		}
-		if feeCap.LT(baseFee) {
-			return nil, 0, errorsmod.Wrapf(
-				sdkerrors.ErrInsufficientFee,
-				"gas prices too low, got: %s%s required: %s%s. Please retry using a higher gas price or a higher fee",
-				feeCap,
-				denom,
-				baseFee,
-				denom,
-			)
-		}
-
-		effectivePrice = sdkmath.LegacyMinDec(baseFee.Add(tipCap), feeCap)
-		priorityPrice = effectivePrice.Sub(baseFee)
-	} else if feeCap.LT(baseFee) {
-		// Ethereum legacy transactions must cover the current base fee.
-		return nil, 0, errorsmod.Wrapf(
+	fees := feeTx.GetFee()
+	if len(fees) != 1 || fees[0].Denom != chainconfig.BaseDenom || !fees[0].IsPositive() {
+		return standardMsgSendFeePlan{}, errorsmod.Wrapf(
 			sdkerrors.ErrInsufficientFee,
-			"gas prices too low, got: %s%s required: %s%s. Please retry using a higher gas price or a higher fee",
-			feeCap,
-			denom,
-			baseFee,
-			denom,
+			"FixedSendGas requires one positive %s fee",
+			chainconfig.BaseDenom,
 		)
 	}
 
-	priorityInt := priorityPrice.QuoInt(evmtypes.DefaultPriorityReduction).TruncateInt()
-	priority := int64(math.MaxInt64)
-	if priorityInt.IsInt64() {
-		priority = priorityInt.Int64()
+	declaredGasInt := new(big.Int).SetUint64(declaredGas)
+	submittedFeeInt := fees[0].Amount.BigInt()
+	decimalScale := standardMsgSendDecimalScale()
+	feeCap := standardMsgSendPrice{
+		numerator:   new(big.Int).Set(submittedFeeInt),
+		denominator: declaredGasInt,
 	}
 
-	settledAmount := effectivePrice.
-		MulInt(sdkmath.NewIntFromUint64(executionGas)).
-		Ceil().
-		RoundInt()
-	return sdk.Coins{{Denom: denom, Amount: settledAmount}}, priority, nil
-}
-
-func standardMsgSendEthereumBaseFee(
-	ctx sdk.Context,
-	feemarketParams *feemarkettypes.Params,
-) sdkmath.LegacyDec {
-	if feemarketParams == nil || !feemarketParams.IsBaseFeeEnabled(ctx.BlockHeight()) {
-		return sdkmath.LegacyZeroDec()
+	if standardMsgSendBaseFeeEnabled(ctx, feemarketParams) && feemarketParams.BaseFee.IsNil() {
+		return standardMsgSendFeePlan{}, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas active base fee is not configured",
+		)
+	}
+	baseFee := standardMsgSendBaseFee(ctx, feemarketParams)
+	if baseFee.IsNegative() {
+		return standardMsgSendFeePlan{}, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas base fee cannot be negative",
+		)
+	}
+	baseFeeScaled := standardMsgSendScaledDec(baseFee)
+	baseFeePrice := standardMsgSendPrice{
+		numerator:   baseFeeScaled,
+		denominator: decimalScale,
+	}
+	if compareStandardMsgSendPrices(feeCap, baseFeePrice) < 0 {
+		return standardMsgSendFeePlan{}, errorsmod.Wrapf(
+			sdkerrors.ErrInsufficientFee,
+			"FixedSendGas fee cap below base fee (%s%s < %s%s)",
+			standardMsgSendPriceString(feeCap),
+			chainconfig.BaseDenom,
+			baseFee,
+			chainconfig.BaseDenom,
+		)
 	}
 
-	baseFee := feemarketParams.BaseFee
-	if baseFee.IsNil() || baseFee.IsZero() {
-		return sdkmath.LegacyZeroDec()
-	}
-
-	// The application config fixes the native EVM denom exponent to 18, so
-	// ConvertAmountTo18DecimalsLegacy is intentionally not needed here.
-	return sdkmath.LegacyNewDecFromInt(baseFee.TruncateInt())
-}
-
-// standardMsgSendMinGasPriceDecorator preserves the upstream Cosmos decorator
-// for ordinary transactions. For an eligible MsgSend it checks the Ethereum
-// effective price P against the global minimum price, both multiplied by D.
-type standardMsgSendMinGasPriceDecorator struct {
-	upstream        cosmosante.MinGasPriceDecorator
-	feemarketParams *feemarkettypes.Params
-}
-
-func newStandardMsgSendMinGasPriceDecorator(
-	feemarketParams *feemarkettypes.Params,
-) standardMsgSendMinGasPriceDecorator {
-	return standardMsgSendMinGasPriceDecorator{
-		upstream:        cosmosante.NewMinGasPriceDecorator(feemarketParams),
-		feemarketParams: feemarketParams,
-	}
-}
-
-func (d standardMsgSendMinGasPriceDecorator) AnteHandle(
-	ctx sdk.Context,
-	tx sdk.Tx,
-	simulate bool,
-	next sdk.AnteHandler,
-) (sdk.Context, error) {
-	if !isStandardMsgSendGasContext(ctx) {
-		return d.upstream.AnteHandle(ctx, tx, simulate, next)
-	}
-
-	feeTx, ok := tx.(sdk.FeeTx)
-	if !ok {
-		return ctx, errorsmod.Wrapf(sdkerrors.ErrInvalidType, "invalid transaction type %T, expected sdk.FeeTx", tx)
-	}
-
-	feeCoins := feeTx.GetFee()
-	denom := evmtypes.GetEVMCoinDenom()
-	validFees := len(feeCoins) == 0 ||
-		(len(feeCoins) == 1 && slices.Contains([]string{denom, sdk.DefaultBondDenom}, feeCoins.GetDenomByIndex(0)))
-	if !validFees && !simulate {
-		return ctx, fmt.Errorf("expected only native token %s for fee, but got %s", denom, feeCoins.String())
-	}
-	if d.feemarketParams.MinGasPrice.IsZero() || simulate {
-		return next(ctx, tx, simulate)
-	}
-	if feeTx.GetGas() == 0 {
-		return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "gas cannot be zero")
-	}
-
-	feeCap := sdkmath.LegacyNewDecFromInt(feeCoins.AmountOf(denom)).
-		QuoInt(sdkmath.NewIntFromUint64(feeTx.GetGas()))
 	effectivePrice := feeCap
 	if dynamicFee, ok := dynamicFeeExtension(feeTx); ok {
 		tipCap := dynamicFee.MaxPriorityPrice
@@ -274,112 +184,359 @@ func (d standardMsgSendMinGasPriceDecorator) AnteHandle(
 			tipCap = sdkmath.LegacyZeroDec()
 		}
 		if tipCap.IsNegative() {
-			return ctx, errorsmod.Wrap(sdkerrors.ErrInsufficientFee, "max priority price cannot be negative")
+			return standardMsgSendFeePlan{}, errorsmod.Wrap(
+				sdkerrors.ErrInsufficientFee,
+				"max priority price cannot be negative",
+			)
 		}
-		if tipCap.GT(feeCap) {
-			return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "max priority price %s exceeds fee cap %s", tipCap, feeCap)
+		basePlusTip := standardMsgSendPrice{
+			numerator: new(big.Int).Add(
+				baseFeeScaled,
+				standardMsgSendScaledDec(tipCap),
+			),
+			denominator: decimalScale,
 		}
-		baseFee := standardMsgSendEthereumBaseFee(ctx, d.feemarketParams)
-		if feeCap.LT(baseFee) {
-			return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "gas prices too low, got: %s%s required: %s%s", feeCap, denom, baseFee, denom)
+		if compareStandardMsgSendPrices(basePlusTip, feeCap) < 0 {
+			effectivePrice = basePlusTip
 		}
-		effectivePrice = sdkmath.LegacyMinDec(baseFee.Add(tipCap), feeCap)
 	}
 
-	gasLimit := sdkmath.LegacyNewDecFromBigInt(new(big.Int).SetUint64(feeTx.GetGas()))
-	providedFee := effectivePrice.Mul(gasLimit)
-	requiredFee := d.feemarketParams.MinGasPrice.Mul(gasLimit)
-	if providedFee.LT(requiredFee) {
-		return ctx, errorsmod.Wrapf(
+	minimumPrice := feemarketParams.MinGasPrice
+	minimumPriceRatio := standardMsgSendPrice{
+		numerator:   standardMsgSendScaledDec(minimumPrice),
+		denominator: decimalScale,
+	}
+	if compareStandardMsgSendPrices(effectivePrice, minimumPriceRatio) < 0 {
+		return standardMsgSendFeePlan{}, errorsmod.Wrapf(
 			sdkerrors.ErrInsufficientFee,
-			"provided fee < minimum global fee (%s < %s). Please increase the priority tip (for EIP-1559 txs) or the gas prices (for legacy txs)",
-			providedFee.TruncateInt(),
-			requiredFee.TruncateInt(),
+			"FixedSendGas effective gas price below minimum global gas price (%s%s < %s%s)",
+			standardMsgSendPriceString(effectivePrice),
+			chainconfig.BaseDenom,
+			minimumPrice,
+			chainconfig.BaseDenom,
 		)
 	}
 
-	return next(ctx, tx, simulate)
-}
-
-// settleStandardMsgSendFees preserves each submitted coin's gas price while
-// replacing the declared gas multiplier with executionGas.
-func settleStandardMsgSendFees(
-	fees sdk.Coins,
-	declaredGas uint64,
-	executionGas uint64,
-) (sdk.Coins, error) {
-	if declaredGas == 0 {
-		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "gas cannot be zero")
+	actualFeeInt := ceilStandardMsgSendQuotient(
+		new(big.Int).Mul(
+			new(big.Int).Set(effectivePrice.numerator),
+			new(big.Int).SetUint64(StandardMsgSendGas),
+		),
+		effectivePrice.denominator,
+	)
+	if actualFeeInt.Cmp(submittedFeeInt) > 0 {
+		return standardMsgSendFeePlan{}, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas actual fee exceeds submitted fee",
+		)
 	}
 
-	declaredGasInt := sdkmath.NewIntFromUint64(declaredGas)
-	settlementGas := sdkmath.NewIntFromUint64(executionGas)
-	settled := make(sdk.Coins, len(fees))
-	for i, fee := range fees {
-		amount := sdkmath.LegacyNewDecFromInt(fee.Amount).
-			QuoInt(declaredGasInt).
-			MulInt(settlementGas).
-			Ceil().
-			RoundInt()
-		settled[i] = sdk.NewCoin(fee.Denom, amount)
+	actualFee := sdk.NewCoins()
+	if actualFeeInt.Sign() > 0 {
+		actualFee = sdk.NewCoins(sdk.NewCoin(
+			chainconfig.BaseDenom,
+			sdkmath.NewIntFromBigInt(actualFeeInt),
+		))
 	}
 
-	return settled, nil
+	priorityNumerator := new(big.Int).Sub(
+		new(big.Int).Mul(
+			new(big.Int).Set(effectivePrice.numerator),
+			decimalScale,
+		),
+		new(big.Int).Mul(
+			baseFeeScaled,
+			effectivePrice.denominator,
+		),
+	)
+	if priorityNumerator.Sign() < 0 {
+		return standardMsgSendFeePlan{}, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas effective price is below base fee",
+		)
+	}
+	priorityReduction := evmtypes.DefaultPriorityReduction.BigInt()
+	if priorityReduction == nil || priorityReduction.Sign() <= 0 {
+		return standardMsgSendFeePlan{}, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas priority reduction must be positive",
+		)
+	}
+	priorityDenominator := new(big.Int).Mul(
+		new(big.Int).Mul(
+			new(big.Int).Set(effectivePrice.denominator),
+			decimalScale,
+		),
+		priorityReduction,
+	)
+	priorityInt := new(big.Int).Quo(priorityNumerator, priorityDenominator)
+	priority := int64(math.MaxInt64)
+	if priorityInt.IsInt64() {
+		priority = priorityInt.Int64()
+	}
+
+	if checkSpendability {
+		if accountKeeper == nil {
+			return standardMsgSendFeePlan{}, errorsmod.Wrap(
+				sdkerrors.ErrLogic,
+				"FixedSendGas account keeper is not configured",
+			)
+		}
+		if accountKeeper.GetAccount(ctx, classification.sender) == nil {
+			return standardMsgSendFeePlan{}, errorsmod.Wrapf(
+				sdkerrors.ErrUnknownAddress,
+				"fee payer address %s does not exist",
+				classification.sender,
+			)
+		}
+		if bankKeeper == nil {
+			return standardMsgSendFeePlan{}, errorsmod.Wrap(
+				sdkerrors.ErrLogic,
+				"FixedSendGas spendable bank keeper is not configured",
+			)
+		}
+		spendable := bankKeeper.SpendableCoin(
+			ctx,
+			classification.sender,
+			chainconfig.BaseDenom,
+		).Amount.BigInt()
+		required := new(big.Int).Add(
+			classification.msg.Amount[0].Amount.BigInt(),
+			submittedFeeInt,
+		)
+		if spendable.Cmp(required) < 0 {
+			return standardMsgSendFeePlan{}, errorsmod.Wrapf(
+				sdkerrors.ErrInsufficientFunds,
+				"FixedSendGas spendable balance %s%s is below transfer plus submitted fee %s%s",
+				spendable,
+				chainconfig.BaseDenom,
+				required,
+				chainconfig.BaseDenom,
+			)
+		}
+	}
+
+	return standardMsgSendFeePlan{
+		declaredGas:    declaredGas,
+		submittedFee:   fees[0],
+		effectivePrice: effectivePrice,
+		actualFee:      actualFee,
+		priority:       priority,
+	}, nil
 }
 
-// checkStandardMsgSendValidatorFee is the local equivalent of the unexported
-// Cosmos SDK v0.53 default checker. It intentionally evaluates the original
-// FeeTx and its declared gas before execution-gas settlement occurs.
-func checkStandardMsgSendValidatorFee(
+func standardMsgSendBaseFee(
+	ctx sdk.Context,
+	feemarketParams *feemarkettypes.Params,
+) sdkmath.LegacyDec {
+	if !standardMsgSendBaseFeeEnabled(ctx, feemarketParams) ||
+		feemarketParams.BaseFee.IsNil() {
+		return sdkmath.LegacyZeroDec()
+	}
+	return feemarketParams.BaseFee
+}
+
+func standardMsgSendBaseFeeEnabled(
+	ctx sdk.Context,
+	feemarketParams *feemarkettypes.Params,
+) bool {
+	return ctx.BlockHeight() != 0 &&
+		evmtypes.IsLondon(evmtypes.GetEthChainConfig(), ctx.BlockHeight()) &&
+		feemarketParams != nil &&
+		feemarketParams.IsBaseFeeEnabled(ctx.BlockHeight())
+}
+
+type standardMsgSendFeePlanDecorator struct {
+	upstream        cosmosante.MinGasPriceDecorator
+	feemarketParams *feemarkettypes.Params
+	accountKeeper   authante.AccountKeeper
+	bankKeeper      standardMsgSendSpendableBankKeeper
+}
+
+func newStandardMsgSendFeePlanDecorator(
+	feemarketParams *feemarkettypes.Params,
+	accountKeeper authante.AccountKeeper,
+	bankKeeper standardMsgSendSpendableBankKeeper,
+) standardMsgSendFeePlanDecorator {
+	return standardMsgSendFeePlanDecorator{
+		upstream:        cosmosante.NewMinGasPriceDecorator(feemarketParams),
+		feemarketParams: feemarketParams,
+		accountKeeper:   accountKeeper,
+		bankKeeper:      bankKeeper,
+	}
+}
+
+func (d standardMsgSendFeePlanDecorator) AnteHandle(
 	ctx sdk.Context,
 	tx sdk.Tx,
-) (sdk.Coins, int64, error) {
-	feeTx, ok := tx.(sdk.FeeTx)
-	if !ok {
-		return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	simulate bool,
+	next sdk.AnteHandler,
+) (sdk.Context, error) {
+	classification, fixed := standardMsgSendClassificationFromContext(ctx)
+	if !fixed {
+		return d.upstream.AnteHandle(ctx, tx, simulate, next)
+	}
+	if simulate && classification.feeTx.GetGas() == 0 {
+		return next(ctx.WithPriority(0), tx, simulate)
 	}
 
-	fees := feeTx.GetFee()
-	gas := feeTx.GetGas()
-	if ctx.IsCheckTx() && !ctx.MinGasPrices().IsZero() {
-		requiredFees := make(sdk.Coins, len(ctx.MinGasPrices()))
-		gasLimit := sdkmath.LegacyNewDec(int64(gas)) // #nosec G115 -- ValidateBasic bounds gas before fee deduction.
-		for i, gasPrice := range ctx.MinGasPrices() {
-			requiredFee := gasPrice.Amount.Mul(gasLimit)
-			requiredFees[i] = sdk.NewCoin(
-				gasPrice.Denom,
-				requiredFee.Ceil().RoundInt(),
-			)
-		}
-
-		if !fees.IsAnyGTE(requiredFees) {
-			return nil, 0, errorsmod.Wrapf(
-				sdkerrors.ErrInsufficientFee,
-				"insufficient fees; got: %s required: %s",
-				fees,
-				requiredFees,
-			)
-		}
+	plan, err := buildStandardMsgSendFeePlan(
+		ctx,
+		classification,
+		d.feemarketParams,
+		d.accountKeeper,
+		d.bankKeeper,
+		true,
+	)
+	if err != nil {
+		return ctx, err
 	}
-
-	return fees, standardMsgSendValidatorPriority(fees, int64(gas)), nil // #nosec G115 -- ValidateBasic bounds gas.
+	return next(
+		ctx.WithValue(standardMsgSendFeePlanContextKey{}, &plan),
+		tx,
+		simulate,
+	)
 }
 
-func standardMsgSendValidatorPriority(fees sdk.Coins, gas int64) int64 {
-	if gas <= 0 {
-		return 0
+func standardMsgSendFeePlanFromContext(ctx sdk.Context) (*standardMsgSendFeePlan, bool) {
+	plan, ok := ctx.Value(standardMsgSendFeePlanContextKey{}).(*standardMsgSendFeePlan)
+	return plan, ok && plan != nil
+}
+
+type standardMsgSendDeductFeeDecorator struct {
+	ordinary authante.DeductFeeDecorator
+	fixed    authante.DeductFeeDecorator
+}
+
+func newStandardMsgSendDeductFeeDecorator(
+	accountKeeper authante.AccountKeeper,
+	bankKeeper authtypes.BankKeeper,
+	feegrantKeeper authante.FeegrantKeeper,
+	ordinaryChecker authante.TxFeeChecker,
+) standardMsgSendDeductFeeDecorator {
+	fixedChecker := func(ctx sdk.Context, _ sdk.Tx) (sdk.Coins, int64, error) {
+		plan, ok := standardMsgSendFeePlanFromContext(ctx)
+		if !ok {
+			return nil, 0, errorsmod.Wrap(
+				sdkerrors.ErrLogic,
+				"FixedSendGas fee plan is unavailable",
+			)
+		}
+		return plan.actualFee, plan.priority, nil
 	}
 
-	var priority int64
-	for _, fee := range fees {
-		candidate := int64(math.MaxInt64)
-		gasPrice := fee.Amount.QuoRaw(gas)
-		if gasPrice.IsInt64() {
-			candidate = gasPrice.Int64()
-		}
-		if priority == 0 || candidate < priority {
-			priority = candidate
-		}
+	return standardMsgSendDeductFeeDecorator{
+		ordinary: authante.NewDeductFeeDecorator(
+			accountKeeper,
+			bankKeeper,
+			feegrantKeeper,
+			ordinaryChecker,
+		),
+		fixed: authante.NewDeductFeeDecorator(
+			accountKeeper,
+			bankKeeper,
+			feegrantKeeper,
+			fixedChecker,
+		),
 	}
-	return priority
+}
+
+func (d standardMsgSendDeductFeeDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (sdk.Context, error) {
+	classification, fixed := standardMsgSendClassificationFromContext(ctx)
+	if !fixed {
+		return d.ordinary.AnteHandle(ctx, tx, simulate, next)
+	}
+	if simulate && classification.feeTx.GetGas() == 0 {
+		return next(ctx.WithPriority(0), tx, simulate)
+	}
+
+	plan, ok := standardMsgSendFeePlanFromContext(ctx)
+	if !ok {
+		return ctx, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas fee plan is unavailable",
+		)
+	}
+	return d.fixed.AnteHandle(
+		ctx,
+		tx,
+		false,
+		func(nextCtx sdk.Context, nextTx sdk.Tx, _ bool) (sdk.Context, error) {
+			nextCtx.EventManager().EmitEvent(sdk.NewEvent(
+				EventTypeFixedSendGas,
+				sdk.NewAttribute(AttributeKeyDeclaredGas, fmt.Sprintf("%d", plan.declaredGas)),
+				sdk.NewAttribute(AttributeKeyAccountingGas, fmt.Sprintf("%d", StandardMsgSendGas)),
+				sdk.NewAttribute(AttributeKeySubmittedFee, plan.submittedFee.String()),
+				sdk.NewAttribute(AttributeKeyEffectiveGasPrice, standardMsgSendPriceString(plan.effectivePrice)),
+				sdk.NewAttribute(AttributeKeyActualFee, plan.actualFee.String()),
+			))
+			return next(nextCtx, nextTx, simulate)
+		},
+	)
+}
+
+type standardMsgSendGasWantedDecorator struct {
+	ordinary        evmanteevm.GasWantedDecorator
+	feeMarketKeeper interface {
+		AddTransientGasWanted(sdk.Context, uint64) (uint64, error)
+	}
+	feemarketParams *feemarkettypes.Params
+}
+
+func newStandardMsgSendGasWantedDecorator(
+	ordinary evmanteevm.GasWantedDecorator,
+	feeMarketKeeper interface {
+		AddTransientGasWanted(sdk.Context, uint64) (uint64, error)
+	},
+	feemarketParams *feemarkettypes.Params,
+) standardMsgSendGasWantedDecorator {
+	return standardMsgSendGasWantedDecorator{
+		ordinary:        ordinary,
+		feeMarketKeeper: feeMarketKeeper,
+		feemarketParams: feemarketParams,
+	}
+}
+
+func (d standardMsgSendGasWantedDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (sdk.Context, error) {
+	if !isStandardMsgSendGasContext(ctx) {
+		return d.ordinary.AnteHandle(ctx, tx, simulate, next)
+	}
+
+	newCtx, err := next(ctx, tx, simulate)
+	if err != nil {
+		return newCtx, err
+	}
+	if newCtx.ExecMode() != sdk.ExecModeFinalize ||
+		!evmtypes.IsLondon(evmtypes.GetEthChainConfig(), newCtx.BlockHeight()) {
+		return newCtx, nil
+	}
+	if d.feemarketParams == nil {
+		return newCtx, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas fee market params are not configured",
+		)
+	}
+	if !d.feemarketParams.IsBaseFeeEnabled(newCtx.BlockHeight()) {
+		return newCtx, nil
+	}
+	if d.feeMarketKeeper == nil {
+		return newCtx, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas fee market keeper is not configured",
+		)
+	}
+	if _, err := d.feeMarketKeeper.AddTransientGasWanted(newCtx, StandardMsgSendGas); err != nil {
+		return newCtx, errorsmod.Wrap(err, "add FixedSendGas transient gas wanted")
+	}
+	return newCtx, nil
 }

--- a/app/ante/standard_msgsend_gas.go
+++ b/app/ante/standard_msgsend_gas.go
@@ -6,281 +6,305 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
-	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 
 	antetypes "github.com/cosmos/evm/ante/types"
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
-	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	chainconfig "github.com/gurufinglobal/guru/v2/config"
 )
 
 const (
-	// StandardMsgSendGas is the intrinsic execution-gas floor for the bounded
-	// MsgSend class.
+	// StandardMsgSendGas is the consensus accounting gas for every eligible
+	// FixedSendGas transaction. The signed gas limit remains unchanged in the
+	// transaction bytes and is used only as the maximum fee-price denominator.
 	StandardMsgSendGas uint64 = 21_000
 
-	// StandardMsgSendMaxMemoBytes keeps the standard-send class bounded even if the
-	// chain's auth parameter is raised later.
-	StandardMsgSendMaxMemoBytes = 256
+	// StandardMsgSendMaxTxBytes is the FixedSendGas eligibility ceiling. It is
+	// intentionally not a chain-wide transaction-size limit: larger decode-valid
+	// transactions use the ordinary upstream path.
+	StandardMsgSendMaxTxBytes = 2_048
 )
 
-// StandardMsgSendGasDecorator assigns Ethereum-compatible minimum execution
-// gas, with a 21k floor, to a deliberately narrow MsgSend shape. The submitted
-// gas limit remains visible as the public meter limit, while internal ante and
-// message work is tracked by an unbounded meter. Transactions outside this
-// class continue through the ordinary Cosmos gas path.
-type StandardMsgSendGasDecorator struct {
-	accountKeeper    authante.AccountKeeper
-	minGasMultiplier sdkmath.LegacyDec
-	maxTxGasWanted   uint64
+type standardMsgSendContextKey struct{}
+
+type standardMsgSendClassification struct {
+	feeTx  sdk.FeeTx
+	msg    *banktypes.MsgSend
+	sender sdk.AccAddress
 }
 
-func NewStandardMsgSendGasDecorator(
-	accountKeeper authante.AccountKeeper,
-	minGasMultiplier sdkmath.LegacyDec,
-	maxTxGasWanted uint64,
-) StandardMsgSendGasDecorator {
-	return StandardMsgSendGasDecorator{
-		accountKeeper:    accountKeeper,
-		minGasMultiplier: minGasMultiplier,
-		maxTxGasWanted:   maxTxGasWanted,
-	}
+// StandardMsgSendClassifier is the single FixedSendGas classification source
+// shared by ante and proposal handling. A nil error with eligible=false means
+// ordinary upstream fallback; an error is a deterministic admission failure.
+type StandardMsgSendClassifier struct {
+	accountKeeper authante.AccountKeeper
 }
 
-func (d StandardMsgSendGasDecorator) AnteHandle(
+func NewStandardMsgSendClassifier(accountKeeper authante.AccountKeeper) StandardMsgSendClassifier {
+	return StandardMsgSendClassifier{accountKeeper: accountKeeper}
+}
+
+// ClassifyProposal applies the same classifier to original proposal bytes.
+// Callers must put those exact bytes in ctx.TxBytes before calling this method.
+func (c StandardMsgSendClassifier) ClassifyProposal(
+	ctx sdk.Context,
+	tx sdk.Tx,
+) (bool, error) {
+	_, eligible, err := c.classify(ctx, tx, false)
+	return eligible, err
+}
+
+// classify deliberately has a three-way result:
+//
+//   - eligible=false, err=nil: decode-valid ordinary upstream transaction;
+//   - eligible=true, err=nil: bounded FixedSendGas transaction;
+//   - err!=nil: deterministic FixedSendGas admission failure.
+//
+// Raw size is checked before decoded accessors. A decode-valid transaction over
+// the ceiling is always ordinary, even if its canonical re-encoding is smaller.
+func (c StandardMsgSendClassifier) classify(
 	ctx sdk.Context,
 	tx sdk.Tx,
 	simulate bool,
-	next sdk.AnteHandler,
-) (sdk.Context, error) {
-	eligible, publicGasLimit, insufficientGas, dependenciesMissing := d.classify(ctx, tx, simulate)
-	if insufficientGas {
-		return ctx, errorsmod.Wrapf(
-			sdkerrors.ErrInvalidGasLimit,
-			"standard MsgSend requires at least %d gas",
-			StandardMsgSendGas,
-		)
-	}
-	if dependenciesMissing {
-		return ctx, errorsmod.Wrap(
-			sdkerrors.ErrLogic,
-			"standard MsgSend gas dependencies are not configured",
-		)
-	}
-	if !eligible {
-		return next(ctx, tx, simulate)
-	}
-
-	executionGas, ok := standardMsgSendExecutionGas(publicGasLimit, d.minGasMultiplier)
-	if !ok {
-		return ctx, errorsmod.Wrap(
-			sdkerrors.ErrLogic,
-			"standard MsgSend minimum gas multiplier is invalid",
-		)
-	}
-
-	actualMeter := storetypes.NewInfiniteGasMeter()
-	if consumed := ctx.GasMeter().GasConsumed(); consumed > 0 {
-		actualMeter.ConsumeGas(consumed, "standard MsgSend pre-classification gas")
-	}
-	gasWanted := publicGasLimit
-	if (ctx.IsCheckTx() || ctx.IsReCheckTx()) &&
-		d.maxTxGasWanted > 0 && gasWanted > d.maxTxGasWanted {
-		gasWanted = d.maxTxGasWanted
-	}
-
-	return next(
-		ctx.
-			WithKVGasConfig(storetypes.GasConfig{}).
-			WithTransientKVGasConfig(storetypes.GasConfig{}).
-			WithGasMeter(newStandardMsgSendGasMeter(
-				actualMeter,
-				gasWanted,
-				executionGas,
-				simulate || (!ctx.IsCheckTx() && !ctx.IsReCheckTx()),
-			)),
-		tx,
-		simulate,
-	)
-}
-
-// standardMsgSendExecutionGas mirrors Cosmos EVM v0.6.2 minimum-gas
-// settlement and preserves the 21k intrinsic floor for a standard send.
-func standardMsgSendExecutionGas(
-	declaredGas uint64,
-	minGasMultiplier sdkmath.LegacyDec,
-) (uint64, bool) {
-	if declaredGas == 0 {
-		return StandardMsgSendGas, true
-	}
-	if minGasMultiplier.IsNil() {
-		minGasMultiplier = sdkmath.LegacyZeroDec()
-	}
-	if minGasMultiplier.IsNegative() || minGasMultiplier.GT(sdkmath.LegacyOneDec()) {
-		return 0, false
-	}
-
-	minimumGasUsed := sdkmath.LegacyNewDecFromInt(sdkmath.NewIntFromUint64(declaredGas)).
-		Mul(minGasMultiplier).
-		TruncateInt()
-	if !minimumGasUsed.IsUint64() {
-		return 0, false
-	}
-
-	executionGas := minimumGasUsed.Uint64()
-	if executionGas < StandardMsgSendGas {
-		executionGas = StandardMsgSendGas
-	}
-
-	return executionGas, true
-}
-
-// classify contains only standard-send classification. The recovery boundary is
-// intentionally narrower than the downstream ante call: malformed fee payer,
-// granter, signer, or message accessors fall back to the ordinary path, where
-// the normal decorators determine the canonical error without replaying work.
-func (d StandardMsgSendGasDecorator) classify(
-	ctx sdk.Context,
-	tx sdk.Tx,
-	simulate bool,
-) (eligible bool, publicGasLimit uint64, insufficientGas bool, dependenciesMissing bool) {
+) (classification standardMsgSendClassification, eligible bool, err error) {
 	defer func() {
 		if recover() != nil {
+			classification = standardMsgSendClassification{}
 			eligible = false
-			publicGasLimit = 0
-			insufficientGas = false
-			dependenciesMissing = false
+			err = errorsmod.Wrap(
+				sdkerrors.ErrTxDecode,
+				"panic while classifying FixedSendGas transaction",
+			)
 		}
 	}()
 
-	feeTx, msg, candidate := standardMsgSendShapeWithoutGasLimit(tx)
-	if !candidate {
-		return false, 0, false, false
-	}
-
-	declaredGas := feeTx.GetGas()
-	if simulate {
-		switch {
-		case declaredGas == 0:
-			publicGasLimit = StandardMsgSendGas
-		case declaredGas < StandardMsgSendGas:
-			return false, 0, false, false
-		default:
-			publicGasLimit = declaredGas
-		}
-	} else if declaredGas < StandardMsgSendGas {
-		return false, 0, true, false
-	} else {
-		publicGasLimit = declaredGas
-	}
-
-	if d.accountKeeper == nil {
-		return false, 0, false, true
-	}
-
-	feePayer := feeTx.FeePayer()
-	from, err := d.accountKeeper.AddressCodec().StringToBytes(msg.FromAddress)
-	if err != nil || !bytes.Equal(from, feePayer) {
-		return false, 0, false, false
-	}
-	if _, err = d.accountKeeper.AddressCodec().StringToBytes(msg.ToAddress); err != nil ||
-		!d.hasSingleSupportedSigner(ctx, tx, feePayer) {
-		return false, 0, false, false
-	}
-
-	return true, publicGasLimit, false, false
-}
-
-func standardMsgSendShapeWithoutGasLimit(tx sdk.Tx) (sdk.FeeTx, *banktypes.MsgSend, bool) {
 	if tx == nil {
-		return nil, nil, false
+		return standardMsgSendClassification{}, false, errorsmod.Wrap(
+			sdkerrors.ErrTxDecode,
+			"cannot classify a nil FixedSendGas transaction",
+		)
+	}
+	if len(ctx.TxBytes()) > StandardMsgSendMaxTxBytes {
+		return standardMsgSendClassification{}, false, nil
 	}
 
 	msgs := tx.GetMsgs()
 	if len(msgs) != 1 {
-		return nil, nil, false
+		return standardMsgSendClassification{}, false, nil
 	}
 	msg, ok := msgs[0].(*banktypes.MsgSend)
-	if !ok || msg == nil || len(msg.Amount) != 1 ||
-		!msg.Amount.IsValid() || !msg.Amount.IsAllPositive() {
-		return nil, nil, false
+	if !ok || msg == nil || len(msg.Amount) != 1 {
+		return standardMsgSendClassification{}, false, nil
+	}
+	if !msg.Amount.IsValid() || !msg.Amount.IsAllPositive() {
+		return standardMsgSendClassification{}, false, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidCoins,
+			"FixedSendGas requires one positive %s transfer amount",
+			chainconfig.BaseDenom,
+		)
+	}
+	if msg.Amount[0].Denom != chainconfig.BaseDenom {
+		return standardMsgSendClassification{}, false, nil
 	}
 
 	feeTx, ok := tx.(sdk.FeeTx)
-	if !ok || !feeTx.GetFee().IsValid() ||
-		len(feeTx.FeeGranter()) != 0 || len(feeTx.GetFee()) > 1 {
-		return nil, nil, false
+	if !ok {
+		return standardMsgSendClassification{}, false, errorsmod.Wrap(
+			sdkerrors.ErrTxDecode,
+			"FixedSendGas MsgSend must implement sdk.FeeTx",
+		)
 	}
-	if len(feeTx.GetFee()) == 1 && feeTx.GetFee()[0].Denom != evmtypes.GetEVMCoinDenom() {
-		return nil, nil, false
+	declaredGas := feeTx.GetGas()
+	fees := feeTx.GetFee()
+	if !fees.IsValid() {
+		return standardMsgSendClassification{}, false, errorsmod.Wrapf(
+			sdkerrors.ErrInsufficientFee,
+			"invalid FixedSendGas fee: %s",
+			fees,
+		)
+	}
+	if len(feeTx.FeeGranter()) != 0 {
+		return standardMsgSendClassification{}, false, nil
 	}
 
-	if memoTx, ok := tx.(sdk.TxWithMemo); ok && len(memoTx.GetMemo()) > StandardMsgSendMaxMemoBytes {
-		return nil, nil, false
-	}
-	if unorderedTx, ok := tx.(sdk.TxWithUnordered); ok && unorderedTx.GetUnordered() {
-		return nil, nil, false
+	if simulate && declaredGas == 0 {
+		if len(fees) > 1 || (len(fees) == 1 && fees[0].Denom != chainconfig.BaseDenom) {
+			return standardMsgSendClassification{}, false, nil
+		}
+	} else if len(fees) != 1 || fees[0].Denom != chainconfig.BaseDenom {
+		return standardMsgSendClassification{}, false, nil
 	}
 
-	if extensionTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
-		if len(extensionTx.GetNonCriticalExtensionOptions()) != 0 {
-			return nil, nil, false
+	if c.accountKeeper == nil {
+		return standardMsgSendClassification{}, false, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas account keeper is not configured",
+		)
+	}
+	memoTx, ok := tx.(sdk.TxWithMemo)
+	if !ok {
+		return standardMsgSendClassification{}, false, errorsmod.Wrap(
+			sdkerrors.ErrTxDecode,
+			"FixedSendGas transaction must implement sdk.TxWithMemo",
+		)
+	}
+	memoLength := len(memoTx.GetMemo())
+	if maxMemo := c.accountKeeper.GetParams(ctx).MaxMemoCharacters; uint64(memoLength) > maxMemo {
+		return standardMsgSendClassification{}, false, errorsmod.Wrapf(
+			sdkerrors.ErrMemoTooLarge,
+			"maximum number of characters is %d but received %d characters",
+			maxMemo,
+			memoLength,
+		)
+	}
+
+	from, err := c.accountKeeper.AddressCodec().StringToBytes(msg.FromAddress)
+	if err != nil {
+		return standardMsgSendClassification{}, false, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidAddress,
+			"invalid FixedSendGas sender: %s",
+			err,
+		)
+	}
+	if _, err := c.accountKeeper.AddressCodec().StringToBytes(msg.ToAddress); err != nil {
+		return standardMsgSendClassification{}, false, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidAddress,
+			"invalid FixedSendGas recipient: %s",
+			err,
+		)
+	}
+
+	feePayer := sdk.AccAddress(feeTx.FeePayer())
+	if !bytes.Equal(from, feePayer) {
+		return standardMsgSendClassification{}, false, nil
+	}
+	singleKey, err := c.hasSingleSupportedSigner(ctx, tx, feePayer)
+	if err != nil {
+		return standardMsgSendClassification{}, false, err
+	}
+	if !singleKey {
+		return standardMsgSendClassification{}, false, nil
+	}
+
+	extensionTx, ok := tx.(authante.HasExtensionOptionsTx)
+	if !ok {
+		return standardMsgSendClassification{}, false, errorsmod.Wrap(
+			sdkerrors.ErrTxDecode,
+			"FixedSendGas transaction must implement extension options",
+		)
+	}
+	extensions := extensionTx.GetExtensionOptions()
+	if len(extensions) > 1 {
+		return standardMsgSendClassification{}, false, errorsmod.Wrap(
+			sdkerrors.ErrUnknownExtensionOptions,
+			"FixedSendGas permits at most one dynamic-fee extension",
+		)
+	}
+	if len(extensions) == 1 {
+		option := extensions[0]
+		if option == nil || option.GetTypeUrl() != dynamicFeeExtensionURL {
+			return standardMsgSendClassification{}, false, errorsmod.Wrap(
+				sdkerrors.ErrUnknownExtensionOptions,
+				"FixedSendGas has an unsupported critical extension",
+			)
 		}
-		extensions := extensionTx.GetExtensionOptions()
-		if len(extensions) > 1 {
-			return nil, nil, false
+		if _, ok := option.GetCachedValue().(*antetypes.ExtensionOptionDynamicFeeTx); !ok {
+			return standardMsgSendClassification{}, false, errorsmod.Wrap(
+				sdkerrors.ErrUnknownExtensionOptions,
+				"FixedSendGas dynamic-fee extension is malformed",
+			)
 		}
-		if len(extensions) == 1 {
-			if _, ok := extensions[0].GetCachedValue().(*antetypes.ExtensionOptionDynamicFeeTx); !ok {
-				return nil, nil, false
+	}
+	if len(extensionTx.GetNonCriticalExtensionOptions()) != 0 {
+		return standardMsgSendClassification{}, false, nil
+	}
+
+	if declaredGas < StandardMsgSendGas {
+		if simulate {
+			if declaredGas == 0 {
+				// D=0 is the explicit gas-only estimation exception.
+				return standardMsgSendClassification{
+					feeTx:  feeTx,
+					msg:    msg,
+					sender: sdk.AccAddress(from),
+				}, true, nil
 			}
+
+			// A non-zero simulation below G keeps ordinary SDK semantics.
+			return standardMsgSendClassification{}, false, nil
 		}
+		return standardMsgSendClassification{}, false, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidGasLimit,
+			"FixedSendGas requires at least %d declared gas",
+			StandardMsgSendGas,
+		)
 	}
 
-	return feeTx, msg, true
+	return standardMsgSendClassification{
+		feeTx:  feeTx,
+		msg:    msg,
+		sender: sdk.AccAddress(from),
+	}, true, nil
 }
 
-func (d StandardMsgSendGasDecorator) hasSingleSupportedSigner(
+func (c StandardMsgSendClassifier) hasSingleSupportedSigner(
 	ctx context.Context,
 	tx sdk.Tx,
 	feePayer sdk.AccAddress,
-) bool {
+) (bool, error) {
 	sigTx, ok := tx.(authsigning.SigVerifiableTx)
 	if !ok {
-		return false
+		return false, errorsmod.Wrap(
+			sdkerrors.ErrTxDecode,
+			"FixedSendGas transaction must implement signature verification",
+		)
 	}
 
 	signers, err := sigTx.GetSigners()
-	if err != nil || len(signers) != 1 || !bytes.Equal(signers[0], feePayer) {
-		return false
+	if err != nil {
+		return false, errorsmod.Wrap(sdkerrors.ErrTxDecode, "get FixedSendGas signers")
+	}
+	if len(signers) != 1 || !bytes.Equal(signers[0], feePayer) {
+		return false, nil
 	}
 	signatures, err := sigTx.GetSignaturesV2()
-	if err != nil || len(signatures) != 1 {
-		return false
+	if err != nil {
+		return false, errorsmod.Wrap(sdkerrors.ErrTxDecode, "get FixedSendGas signatures")
+	}
+	if len(signatures) != 1 {
+		return false, nil
+	}
+	if _, ok := signatures[0].Data.(*signing.SingleSignatureData); !ok {
+		return false, nil
 	}
 	pubKeys, err := sigTx.GetPubKeys()
-	if err != nil || len(pubKeys) != 1 {
-		return false
+	if err != nil {
+		return false, errorsmod.Wrap(sdkerrors.ErrTxDecode, "get FixedSendGas public keys")
+	}
+	if len(pubKeys) != 1 {
+		return false, nil
 	}
 
 	pubKey := pubKeys[0]
 	if pubKey == nil {
-		account := d.accountKeeper.GetAccount(ctx, feePayer)
+		account := c.accountKeeper.GetAccount(ctx, feePayer)
 		if account == nil {
-			return false
+			return false, nil
 		}
 		pubKey = account.GetPubKey()
 	}
 
-	return hasStandardMsgSendPubKey(pubKey)
+	return hasStandardMsgSendPubKey(pubKey), nil
 }
 
 func hasStandardMsgSendPubKey(pubKey cryptotypes.PubKey) bool {
@@ -292,50 +316,141 @@ func hasStandardMsgSendPubKey(pubKey cryptotypes.PubKey) bool {
 	}
 }
 
-type standardMsgSendGasMeter struct {
-	actual       storetypes.GasMeter
-	limit        storetypes.Gas
-	reportedGas  storetypes.Gas
-	executionGas storetypes.Gas
+// StandardMsgSendGasDecorator is the first setup router in the local Cosmos
+// ante chain. Eligible FixedSendGas transactions get a staged accounting meter;
+// ordinary Cosmos transactions retain the SDK SetUpContextDecorator.
+type StandardMsgSendGasDecorator struct {
+	classifier StandardMsgSendClassifier
+	upstream   authante.SetUpContextDecorator
 }
 
-func newStandardMsgSendGasMeter(
-	actual storetypes.GasMeter,
-	limit uint64,
-	executionGas uint64,
-	reportExecutionGas bool,
-) storetypes.GasMeter {
-	reportedGas := uint64(0)
-	if reportExecutionGas {
-		reportedGas = executionGas
+func NewStandardMsgSendGasDecorator(
+	accountKeeper authante.AccountKeeper,
+) StandardMsgSendGasDecorator {
+	return StandardMsgSendGasDecorator{
+		classifier: NewStandardMsgSendClassifier(accountKeeper),
+		upstream:   authante.NewSetUpContextDecorator(),
+	}
+}
+
+func (d StandardMsgSendGasDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (newCtx sdk.Context, err error) {
+	classification, eligible := standardMsgSendClassificationFromContext(ctx)
+	if !eligible {
+		classified, classifiedEligible, classifyErr := d.classifier.classify(ctx, tx, simulate)
+		if classifyErr != nil {
+			return ctx, classifyErr
+		}
+		if !classifiedEligible {
+			return d.upstream.AnteHandle(ctx, tx, simulate, next)
+		}
+		classification = &classified
 	}
 
-	return &standardMsgSendGasMeter{
-		actual:       actual,
-		limit:        storetypes.Gas(limit),
-		reportedGas:  storetypes.Gas(reportedGas),
-		executionGas: storetypes.Gas(executionGas),
+	actualMeter := storetypes.NewInfiniteGasMeter()
+	if ctx.GasMeter() != nil {
+		if consumed := ctx.GasMeter().GasConsumed(); consumed > 0 {
+			actualMeter.ConsumeGas(consumed, "FixedSendGas pre-setup gas")
+		}
 	}
+	meter := newStandardMsgSendGasMeter(actualMeter)
+	fixedCtx := ctx.
+		WithGasMeter(meter).
+		WithValue(standardMsgSendContextKey{}, classification)
+	if block := ctx.ConsensusParams().Block; block != nil &&
+		block.MaxGas > 0 && StandardMsgSendGas > uint64(block.MaxGas) {
+		return fixedCtx, errorsmod.Wrapf(
+			sdkerrors.ErrInvalidGasLimit,
+			"FixedSendGas accounting gas %d exceeds block max gas %d",
+			StandardMsgSendGas,
+			block.MaxGas,
+		)
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			switch outOfGas := recovered.(type) {
+			case storetypes.ErrorOutOfGas:
+				newCtx = fixedCtx
+				err = errorsmod.Wrapf(
+					sdkerrors.ErrOutOfGas,
+					"out of gas in location: %v; gasWanted: %d; gasUsed: %d",
+					outOfGas.Descriptor,
+					StandardMsgSendGas,
+					meter.GasConsumed(),
+				)
+			default:
+				panic(recovered)
+			}
+		}
+	}()
+
+	newCtx, err = next(fixedCtx, tx, simulate)
+	if newCtx.IsZero() {
+		newCtx = fixedCtx
+	}
+	returnedMeter, ok := newCtx.GasMeter().(*standardMsgSendGasMeter)
+	if !ok || returnedMeter != meter {
+		if err != nil {
+			// Preserve the canonical downstream error, but return the fixed
+			// context so failed ante accounting cannot escape the staged meter.
+			return fixedCtx, err
+		}
+		return fixedCtx, errorsmod.Wrap(
+			sdkerrors.ErrLogic,
+			"FixedSendGas meter was replaced during ante handling",
+		)
+	}
+	if err != nil {
+		return newCtx, err
+	}
+	meter.anteSucceeded = true
+	return newCtx, nil
+}
+
+func standardMsgSendClassificationFromContext(
+	ctx sdk.Context,
+) (*standardMsgSendClassification, bool) {
+	classification, ok := ctx.Value(standardMsgSendContextKey{}).(*standardMsgSendClassification)
+	return classification, ok && classification != nil
+}
+
+func isStandardMsgSendGasContext(ctx sdk.Context) bool {
+	_, classified := standardMsgSendClassificationFromContext(ctx)
+	_, metered := ctx.GasMeter().(*standardMsgSendGasMeter)
+	return classified && metered
+}
+
+type standardMsgSendGasMeter struct {
+	actual        storetypes.GasMeter
+	anteSucceeded bool
+}
+
+func newStandardMsgSendGasMeter(actual storetypes.GasMeter) *standardMsgSendGasMeter {
+	return &standardMsgSendGasMeter{actual: actual}
 }
 
 func (m *standardMsgSendGasMeter) GasConsumed() storetypes.Gas {
-	return m.reportedGas
+	return storetypes.Gas(StandardMsgSendGas)
 }
 
 func (m *standardMsgSendGasMeter) GasConsumedToLimit() storetypes.Gas {
-	return m.reportedGas
+	if !m.anteSucceeded {
+		return 0
+	}
+	return storetypes.Gas(StandardMsgSendGas)
 }
 
 func (m *standardMsgSendGasMeter) GasRemaining() storetypes.Gas {
-	if m.reportedGas >= m.limit {
-		return 0
-	}
-
-	return m.limit - m.reportedGas
+	return 0
 }
 
 func (m *standardMsgSendGasMeter) Limit() storetypes.Gas {
-	return m.limit
+	return storetypes.Gas(StandardMsgSendGas)
 }
 
 func (m *standardMsgSendGasMeter) ConsumeGas(amount storetypes.Gas, descriptor string) {
@@ -356,10 +471,9 @@ func (m *standardMsgSendGasMeter) IsOutOfGas() bool {
 
 func (m *standardMsgSendGasMeter) String() string {
 	return fmt.Sprintf(
-		"StandardMsgSendGasMeter{limit: %d, execution: %d, reported: %d, actual: %s}",
-		m.limit,
-		m.executionGas,
-		m.reportedGas,
+		"FixedSendGasMeter{accounting: %d, ante_succeeded: %t, actual: %s}",
+		StandardMsgSendGas,
+		m.anteSucceeded,
 		m.actual.String(),
 	)
 }

--- a/app/ante/standard_msgsend_test.go
+++ b/app/ante/standard_msgsend_test.go
@@ -3,7 +3,7 @@ package ante
 import (
 	"bytes"
 	"context"
-	"errors"
+	"math/big"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +15,7 @@ import (
 	evmante "github.com/cosmos/evm/ante"
 	evmanteevm "github.com/cosmos/evm/ante/evm"
 	antetypes "github.com/cosmos/evm/ante/types"
+	"github.com/cosmos/evm/crypto/ethsecp256k1"
 	evmaddress "github.com/cosmos/evm/encoding/address"
 	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
@@ -32,148 +33,133 @@ import (
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	chainconfig "github.com/gurufinglobal/guru/v2/config"
 )
 
-func TestStandardMsgSendGasDecoratorEligibility(t *testing.T) {
+func TestStandardMsgSendClassifierRawTxBytesBoundary(t *testing.T) {
 	configureStandardMsgSendTestDenom()
 
 	addressCodec := evmaddress.NewEvmCodec("guru")
 	payer := sdk.AccAddress(bytes.Repeat([]byte{0x11}, 20))
-	other := sdk.AccAddress(bytes.Repeat([]byte{0x22}, 20))
-	dynamicExtension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{})
-	require.NoError(t, err)
+	classifier := NewStandardMsgSendClassifier(&standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+	})
+	tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+
+	for _, test := range []struct {
+		name         string
+		rawSize      int
+		wantEligible bool
+	}{
+		{name: "2047 bytes", rawSize: StandardMsgSendMaxTxBytes - 1, wantEligible: true},
+		{name: "2048 bytes", rawSize: StandardMsgSendMaxTxBytes, wantEligible: true},
+		{name: "2049 bytes", rawSize: StandardMsgSendMaxTxBytes + 1, wantEligible: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := sdk.Context{}.
+				WithContext(context.Background()).
+				WithTxBytes(bytes.Repeat([]byte{0x01}, test.rawSize))
+			_, eligible, err := classifier.classify(ctx, tx, false)
+			require.NoError(t, err)
+			require.Equal(t, test.wantEligible, eligible)
+		})
+	}
+}
+
+func TestStandardMsgSendClassifierGasAndSignaturePolicy(t *testing.T) {
+	configureStandardMsgSendTestDenom()
+
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x22}, 20))
+	classifier := NewStandardMsgSendClassifier(&standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+	})
+	ethPrivateKey := &ethsecp256k1.PrivKey{Key: bytes.Repeat([]byte{0x01}, 32)}
+	ethPublicKey := ethPrivateKey.PubKey()
+	require.NotNil(t, ethPublicKey)
 
 	tests := []struct {
-		name             string
-		simulate         bool
-		mutate           func(*standardMsgSendTestTx)
-		wantStandard     bool
-		wantExecutionGas uint64
-		wantErr          error
+		name         string
+		simulate     bool
+		mutate       func(*standardMsgSendTestTx)
+		wantEligible bool
+		wantErr      error
 	}{
-		{name: "exact gas", wantStandard: true},
 		{
-			name: "declared gas at multiplier threshold",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.gas = 42_000
-			},
-			wantStandard:     true,
-			wantExecutionGas: StandardMsgSendGas,
+			name:         "secp256k1 single signature at G",
+			wantEligible: true,
 		},
 		{
-			name: "declared gas above standard",
+			name: "ethsecp256k1 single signature at G",
 			mutate: func(tx *standardMsgSendTestTx) {
-				tx.gas = 200_000
+				tx.pubKeys = []cryptotypes.PubKey{ethPublicKey}
+				tx.signatures[0].PubKey = ethPublicKey
 			},
-			wantStandard:     true,
-			wantExecutionGas: 100_000,
+			wantEligible: true,
 		},
 		{
-			name: "dynamic fee extension",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.extensions = []*codectypes.Any{dynamicExtension}
-			},
-			wantStandard: true,
-		},
-		{
-			name:     "simulation gas zero",
-			simulate: true,
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.gas = 0
-			},
-			wantStandard: true,
-		},
-		{
-			name: "execution below standard",
+			name: "actual transaction below G",
 			mutate: func(tx *standardMsgSendTestTx) {
 				tx.gas = StandardMsgSendGas - 1
 			},
 			wantErr: sdkerrors.ErrInvalidGasLimit,
 		},
 		{
-			name:     "simulation below standard falls back",
+			name: "negative fee is a deterministic admission error",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.fee = sdk.Coins{{
+					Denom:  chainconfig.BaseDenom,
+					Amount: sdkmath.NewInt(-1),
+				}}
+			},
+			wantErr: sdkerrors.ErrInsufficientFee,
+		},
+		{
+			name:     "simulation D zero is fixed gas-only",
+			simulate: true,
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.gas = 0
+				tx.fee = sdk.NewCoins()
+			},
+			wantEligible: true,
+		},
+		{
+			name:     "simulation non-zero D below G is ordinary",
 			simulate: true,
 			mutate: func(tx *standardMsgSendTestTx) {
 				tx.gas = StandardMsgSendGas - 1
 			},
 		},
 		{
-			name: "memo above bound",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.memo = strings.Repeat("m", StandardMsgSendMaxMemoBytes+1)
-			},
+			name:         "simulation D equal to G is fixed",
+			simulate:     true,
+			wantEligible: true,
 		},
 		{
-			name: "multiple send denoms",
+			name:     "simulation D above G is fixed",
+			simulate: true,
 			mutate: func(tx *standardMsgSendTestTx) {
-				tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.NewCoins(
-					sdk.NewInt64Coin("adenom", 1),
-					sdk.NewInt64Coin("bdenom", 1),
-				)
+				tx.gas = 200_000
 			},
+			wantEligible: true,
 		},
 		{
-			name: "invalid recipient",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.msgs[0].(*banktypes.MsgSend).ToAddress = "not-an-address"
-			},
-		},
-		{
-			name: "non-positive send amount",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.Coins{
-					sdk.NewInt64Coin("send-denom", 0),
-				}
-			},
-		},
-		{
-			name: "fee grant",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.granter = append(sdk.AccAddress(nil), payer...)
-			},
-		},
-		{
-			name: "fee payer differs from sender",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.payer = append(sdk.AccAddress(nil), other...)
-				tx.signers = [][]byte{append([]byte(nil), other...)}
-			},
-		},
-		{
-			name: "multiple signers",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.signers = append(tx.signers, append([]byte(nil), other...))
-			},
-		},
-		{
-			name: "unsupported public key",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.pubKeys = []cryptotypes.PubKey{ed25519.GenPrivKey().PubKey()}
-			},
-		},
-		{
-			name: "large single signature remains eligible",
-			mutate: func(tx *standardMsgSendTestTx) {
-				tx.signatures[0].Data = &signing.SingleSignatureData{
-					Signature: bytes.Repeat([]byte{0x01}, 1_024),
-				}
-			},
-			wantStandard: true,
-		},
-		{
-			name: "multi signature data remains eligible",
+			name: "multisig signature data is ordinary",
 			mutate: func(tx *standardMsgSendTestTx) {
 				tx.signatures[0].Data = &signing.MultiSignatureData{}
 			},
-			wantStandard: true,
+		},
+		{
+			name: "unsupported public key is ordinary",
+			mutate: func(tx *standardMsgSendTestTx) {
+				publicKey := ed25519.GenPrivKey().PubKey()
+				tx.pubKeys = []cryptotypes.PubKey{publicKey}
+				tx.signatures[0].PubKey = publicKey
+			},
 		},
 	}
 
-	decorator := NewStandardMsgSendGasDecorator(
-		&standardMsgSendAccountKeeper{addressCodec: addressCodec},
-		standardMsgSendTestMinGasMultiplier(),
-		0,
-	)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tx := newStandardMsgSendTestTx(t, addressCodec, payer)
@@ -181,61 +167,353 @@ func TestStandardMsgSendGasDecoratorEligibility(t *testing.T) {
 				test.mutate(&tx)
 			}
 
-			originalMeter := storetypes.NewInfiniteGasMeter()
-			ctx := sdk.Context{}.
-				WithGasMeter(originalMeter).
-				WithTxBytes(bytes.Repeat([]byte{0x01}, 4_096))
-			nextCalled := false
-			var nextTx sdk.Tx
-			newCtx, err := decorator.AnteHandle(
-				ctx,
-				&tx,
+			_, eligible, err := classifier.classify(
+				sdk.Context{}.
+					WithContext(context.Background()).
+					WithTxBytes(bytes.Repeat([]byte{0x02}, 512)),
+				tx,
 				test.simulate,
-				func(ctx sdk.Context, tx sdk.Tx, _ bool) (sdk.Context, error) {
-					nextCalled = true
-					nextTx = tx
-					return ctx, nil
-				},
 			)
-
 			if test.wantErr != nil {
 				require.ErrorIs(t, err, test.wantErr)
-				require.False(t, nextCalled)
+				require.False(t, eligible)
 				return
 			}
 
 			require.NoError(t, err)
-			require.True(t, nextCalled)
-			require.Same(t, &tx, nextTx)
-			_, standardized := newCtx.GasMeter().(*standardMsgSendGasMeter)
-			require.Equal(t, test.wantStandard, standardized)
-			if test.wantStandard {
-				wantLimit := tx.gas
-				if wantLimit == 0 {
-					wantLimit = StandardMsgSendGas
-				}
-				wantExecutionGas := test.wantExecutionGas
-				if wantExecutionGas == 0 {
-					wantExecutionGas = StandardMsgSendGas
-				}
-				require.Equal(t, wantExecutionGas, uint64(newCtx.GasMeter().GasConsumed()))
-				require.Equal(t, wantLimit, uint64(newCtx.GasMeter().Limit()))
-				require.Equal(
-					t,
-					wantLimit-wantExecutionGas,
-					uint64(newCtx.GasMeter().GasRemaining()),
-				)
-				standardMeter := newCtx.GasMeter().(*standardMsgSendGasMeter)
-				require.Equal(t, wantExecutionGas, uint64(standardMeter.executionGas))
-			} else {
-				require.Same(t, originalMeter, newCtx.GasMeter())
+			require.Equal(t, test.wantEligible, eligible)
+			if test.wantEligible {
+				_, single := tx.signatures[0].Data.(*signing.SingleSignatureData)
+				require.True(t, single)
 			}
 		})
 	}
 }
 
-func TestStandardMsgSendMalformedFeePayerFallsBackToCanonicalAnteValidation(t *testing.T) {
+func TestStandardMsgSendClassifierExtensionEnvelope(t *testing.T) {
 	configureStandardMsgSendTestDenom()
+
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x33}, 20))
+	classifier := NewStandardMsgSendClassifier(&standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+	})
+	validDynamic, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{})
+	require.NoError(t, err)
+	malformedDynamic := &codectypes.Any{TypeUrl: dynamicFeeExtensionURL}
+	unknownCritical := &codectypes.Any{TypeUrl: "/guru.test.UnknownCritical"}
+	nonCritical := &codectypes.Any{TypeUrl: "/guru.test.NonCritical"}
+
+	tests := []struct {
+		name         string
+		extensions   []*codectypes.Any
+		nonCritical  []*codectypes.Any
+		wantEligible bool
+		wantErr      error
+	}{
+		{
+			name:         "one approved dynamic extension",
+			extensions:   []*codectypes.Any{validDynamic},
+			wantEligible: true,
+		},
+		{
+			name:       "duplicate approved dynamic extensions",
+			extensions: []*codectypes.Any{validDynamic, validDynamic},
+			wantErr:    sdkerrors.ErrUnknownExtensionOptions,
+		},
+		{
+			name:       "unknown critical extension",
+			extensions: []*codectypes.Any{unknownCritical},
+			wantErr:    sdkerrors.ErrUnknownExtensionOptions,
+		},
+		{
+			name:       "malformed approved dynamic extension",
+			extensions: []*codectypes.Any{malformedDynamic},
+			wantErr:    sdkerrors.ErrUnknownExtensionOptions,
+		},
+		{
+			name:        "noncritical extension uses ordinary path",
+			nonCritical: []*codectypes.Any{nonCritical},
+		},
+		{
+			name:        "approved dynamic plus noncritical uses ordinary path",
+			extensions:  []*codectypes.Any{validDynamic},
+			nonCritical: []*codectypes.Any{nonCritical},
+		},
+		{
+			name:        "duplicate critical is not hidden by noncritical fallback",
+			extensions:  []*codectypes.Any{validDynamic, validDynamic},
+			nonCritical: []*codectypes.Any{nonCritical},
+			wantErr:     sdkerrors.ErrUnknownExtensionOptions,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+			tx.extensions = test.extensions
+			tx.nonCriticalExtensions = test.nonCritical
+			ctx := sdk.Context{}.
+				WithContext(context.Background()).
+				WithTxBytes(bytes.Repeat([]byte{0x03}, 512))
+
+			_, eligible, classifyErr := classifier.classify(ctx, tx, false)
+			if test.wantErr != nil {
+				require.ErrorIs(t, classifyErr, test.wantErr)
+				require.False(t, eligible)
+				return
+			}
+			require.NoError(t, classifyErr)
+			require.Equal(t, test.wantEligible, eligible)
+		})
+	}
+}
+
+func TestStandardMsgSendClassifierCanonicalShapeBoundary(t *testing.T) {
+	configureStandardMsgSendTestDenom()
+
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x34}, 20))
+	other := sdk.AccAddress(bytes.Repeat([]byte{0x35}, 20))
+	classifier := NewStandardMsgSendClassifier(&standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+	})
+
+	tests := []struct {
+		name         string
+		mutate       func(*standardMsgSendTestTx)
+		wantEligible bool
+		wantErr      error
+	}{
+		{name: "canonical shape", wantEligible: true},
+		{
+			name: "non-native transfer is ordinary",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.NewCoins(sdk.NewInt64Coin("uother", 1))
+			},
+		},
+		{
+			name: "multiple transfer amounts are ordinary",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.NewCoins(
+					sdk.NewInt64Coin(chainconfig.BaseDenom, 1),
+					sdk.NewInt64Coin("uother", 1),
+				)
+			},
+		},
+		{
+			name: "non-native fee is ordinary",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.fee = sdk.NewCoins(sdk.NewInt64Coin("uother", 1))
+			},
+		},
+		{
+			name: "empty actual fee is ordinary",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.fee = sdk.NewCoins()
+			},
+		},
+		{
+			name: "fee grant is ordinary",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.granter = append(sdk.AccAddress(nil), payer...)
+			},
+		},
+		{
+			name: "different fee payer is ordinary",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.payer = append(sdk.AccAddress(nil), other...)
+				tx.signers = [][]byte{append([]byte(nil), other...)}
+			},
+		},
+		{
+			name: "invalid native transfer is a standard coin error",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.Coins{{
+					Denom:  chainconfig.BaseDenom,
+					Amount: sdkmath.ZeroInt(),
+				}}
+			},
+			wantErr: sdkerrors.ErrInvalidCoins,
+		},
+		{
+			name: "invalid non-native fee is still a standard fee error",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.fee = sdk.Coins{{Denom: "uother", Amount: sdkmath.ZeroInt()}}
+			},
+			wantErr: sdkerrors.ErrInsufficientFee,
+		},
+		{
+			name: "memo above auth parameter is rejected",
+			mutate: func(tx *standardMsgSendTestTx) {
+				tx.memo = strings.Repeat("m", int(authtypes.DefaultParams().MaxMemoCharacters)+1)
+			},
+			wantErr: sdkerrors.ErrMemoTooLarge,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+			if test.mutate != nil {
+				test.mutate(&tx)
+			}
+			ctx := sdk.Context{}.
+				WithContext(context.Background()).
+				WithTxBytes(bytes.Repeat([]byte{0x04}, 512))
+
+			_, eligible, classifyErr := classifier.classify(ctx, tx, false)
+			if test.wantErr != nil {
+				require.ErrorIs(t, classifyErr, test.wantErr)
+				require.False(t, eligible)
+				return
+			}
+			require.NoError(t, classifyErr)
+			require.Equal(t, test.wantEligible, eligible)
+		})
+	}
+}
+
+func TestProspectiveFeeMarketParamsAdapterUsesTargetHeightBaseFee(t *testing.T) {
+	storedBaseFee := sdkmath.LegacyMustNewDecFromStr("11.25")
+	prospectiveBaseFee := sdkmath.LegacyMustNewDecFromStr("12.5")
+	params := feemarkettypes.DefaultParams()
+	params.BaseFee = storedBaseFee
+	keeper := &prospectiveFeeMarketKeeperStub{
+		params:         params,
+		prospectiveFee: prospectiveBaseFee,
+	}
+	adapter := NewProspectiveFeeMarketParamsAdapter(keeper)
+
+	tests := []struct {
+		name             string
+		mode             sdk.ExecMode
+		wantBaseFee      sdkmath.LegacyDec
+		wantCalculations int
+	}{
+		{name: "CheckTx keeps stored base fee", mode: sdk.ExecModeCheck, wantBaseFee: storedBaseFee},
+		{name: "ReCheckTx keeps stored base fee", mode: sdk.ExecModeReCheck, wantBaseFee: storedBaseFee},
+		{name: "Simulate keeps stored base fee", mode: sdk.ExecModeSimulate, wantBaseFee: storedBaseFee},
+		{
+			name:             "PrepareProposal uses prospective base fee",
+			mode:             sdk.ExecModePrepareProposal,
+			wantBaseFee:      prospectiveBaseFee,
+			wantCalculations: 1,
+		},
+		{
+			name:             "ProcessProposal uses prospective base fee",
+			mode:             sdk.ExecModeProcessProposal,
+			wantBaseFee:      prospectiveBaseFee,
+			wantCalculations: 1,
+		},
+		{name: "FinalizeBlock keeps stored base fee", mode: sdk.ExecModeFinalize, wantBaseFee: storedBaseFee},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keeper.calculateCalls = 0
+			got := adapter.GetParams(sdk.Context{}.
+				WithContext(context.Background()).
+				WithExecMode(test.mode))
+			require.True(t, got.BaseFee.Equal(test.wantBaseFee))
+			require.Equal(t, test.wantCalculations, keeper.calculateCalls)
+		})
+	}
+
+	t.Run("nil prospective base fee preserves the stored value", func(t *testing.T) {
+		keeper := &prospectiveFeeMarketKeeperStub{
+			params:         params,
+			prospectiveFee: sdkmath.LegacyDec{},
+		}
+		adapter := NewProspectiveFeeMarketParamsAdapter(keeper)
+		got := adapter.GetParams(sdk.Context{}.WithExecMode(sdk.ExecModeProcessProposal))
+		require.True(t, got.BaseFee.Equal(storedBaseFee))
+		require.Equal(t, 1, keeper.calculateCalls)
+	})
+}
+
+func TestStandardMsgSendGasWantedAddsExactlyGOnlyAfterFinalizeAnteSuccess(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	params := feemarkettypes.DefaultParams()
+	params.NoBaseFee = false
+	params.EnableHeight = 0
+	keeper := &standardMsgSendGasWantedKeeperStub{}
+	decorator := newStandardMsgSendGasWantedDecorator(
+		evmanteevm.GasWantedDecorator{},
+		keeper,
+		&params,
+	)
+	classification := &standardMsgSendClassification{}
+	newFixedContext := func(mode sdk.ExecMode) sdk.Context {
+		return sdk.Context{}.
+			WithContext(context.Background()).
+			WithBlockHeight(1).
+			WithExecMode(mode).
+			WithGasMeter(newStandardMsgSendGasMeter(storetypes.NewInfiniteGasMeter())).
+			WithValue(standardMsgSendContextKey{}, classification)
+	}
+
+	_, err := decorator.AnteHandle(
+		newFixedContext(sdk.ExecModeFinalize),
+		nil,
+		false,
+		func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			return nextCtx, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, keeper.calls)
+	require.Equal(t, StandardMsgSendGas, keeper.gasWanted)
+
+	keeper.calls = 0
+	keeper.gasWanted = 0
+	for _, mode := range []sdk.ExecMode{
+		sdk.ExecModeCheck,
+		sdk.ExecModeReCheck,
+		sdk.ExecModeSimulate,
+		sdk.ExecModePrepareProposal,
+		sdk.ExecModeProcessProposal,
+	} {
+		_, err = decorator.AnteHandle(
+			newFixedContext(mode),
+			nil,
+			mode == sdk.ExecModeSimulate,
+			func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+				return nextCtx, nil
+			},
+		)
+		require.NoError(t, err)
+	}
+	require.Zero(t, keeper.calls)
+
+	_, err = decorator.AnteHandle(
+		newFixedContext(sdk.ExecModeFinalize),
+		nil,
+		false,
+		func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			return nextCtx, sdkerrors.ErrUnauthorized
+		},
+	)
+	require.ErrorIs(t, err, sdkerrors.ErrUnauthorized)
+	require.Zero(t, keeper.calls)
+
+	params.NoBaseFee = true
+	_, err = decorator.AnteHandle(
+		newFixedContext(sdk.ExecModeFinalize),
+		nil,
+		false,
+		func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			return nextCtx, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Zero(t, keeper.calls)
+}
+
+func TestStandardMsgSendMalformedAccessorReturnsTxDecode(t *testing.T) {
+	configureStandardMsgSendTestDenom()
+
 	addressCodec := evmaddress.NewEvmCodec("guru")
 	payer := sdk.AccAddress(bytes.Repeat([]byte{0x44}, 20))
 	tx := panickingFeePayerTestTx{standardMsgSendTestTx: newStandardMsgSendTestTx(
@@ -243,13 +521,13 @@ func TestStandardMsgSendMalformedFeePayerFallsBackToCanonicalAnteValidation(t *t
 		addressCodec,
 		payer,
 	)}
-	decorator := NewStandardMsgSendGasDecorator(
-		&standardMsgSendAccountKeeper{addressCodec: addressCodec},
-		standardMsgSendTestMinGasMultiplier(),
-		0,
-	)
-	ctx := sdk.Context{}.WithGasMeter(storetypes.NewInfiniteGasMeter())
-	wantErr := errors.New("downstream canonical validation error")
+	decorator := NewStandardMsgSendGasDecorator(&standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+	})
+	ctx := sdk.Context{}.
+		WithContext(context.Background()).
+		WithGasMeter(storetypes.NewInfiniteGasMeter()).
+		WithTxBytes(bytes.Repeat([]byte{0x03}, 512))
 	nextCalls := 0
 
 	newCtx, err := decorator.AnteHandle(
@@ -258,290 +536,442 @@ func TestStandardMsgSendMalformedFeePayerFallsBackToCanonicalAnteValidation(t *t
 		false,
 		func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
 			nextCalls++
-			return nextCtx, wantErr
+			return nextCtx, nil
 		},
 	)
 
-	require.ErrorIs(t, err, wantErr)
-	require.Equal(t, 1, nextCalls)
+	require.ErrorIs(t, err, sdkerrors.ErrTxDecode)
+	require.Zero(t, nextCalls)
 	require.Same(t, ctx.GasMeter(), newCtx.GasMeter())
 }
 
-func TestStandardMsgSendGasByExecutionPhase(t *testing.T) {
+func TestStandardMsgSendGasMeterIsStagedUntilAnteSuccess(t *testing.T) {
 	configureStandardMsgSendTestDenom()
+
 	addressCodec := evmaddress.NewEvmCodec("guru")
 	payer := sdk.AccAddress(bytes.Repeat([]byte{0x55}, 20))
+	decorator := NewStandardMsgSendGasDecorator(&standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+	})
 	const declaredGas = uint64(200_000)
 
-	tests := []struct {
-		name         string
-		context      sdk.Context
-		simulate     bool
-		maxCheckGas  uint64
-		wantLimit    uint64
-		wantConsumed uint64
+	for _, test := range []struct {
+		name                string
+		nextErr             error
+		wantConsumedToLimit uint64
 	}{
 		{
-			name:         "check tx",
-			context:      sdk.Context{}.WithIsCheckTx(true),
-			wantLimit:    declaredGas,
-			wantConsumed: 0,
+			name:                "successful ante commits G",
+			wantConsumedToLimit: StandardMsgSendGas,
 		},
 		{
-			name:         "capped recheck tx",
-			context:      sdk.Context{}.WithIsReCheckTx(true),
-			maxCheckGas:  80_000,
-			wantLimit:    80_000,
-			wantConsumed: 0,
+			name:    "failed ante leaves block gas at zero",
+			nextErr: sdkerrors.ErrUnauthorized,
 		},
-		{
-			name:         "simulate",
-			context:      sdk.Context{}.WithExecMode(sdk.ExecModeSimulate),
-			simulate:     true,
-			wantLimit:    declaredGas,
-			wantConsumed: 100_000,
-		},
-		{
-			name:         "finalize",
-			context:      sdk.Context{}.WithExecMode(sdk.ExecModeFinalize),
-			wantLimit:    declaredGas,
-			wantConsumed: 100_000,
-		},
-	}
-
-	for _, test := range tests {
+	} {
 		t.Run(test.name, func(t *testing.T) {
-			decorator := NewStandardMsgSendGasDecorator(
-				&standardMsgSendAccountKeeper{addressCodec: addressCodec},
-				standardMsgSendTestMinGasMultiplier(),
-				test.maxCheckGas,
-			)
 			tx := newStandardMsgSendTestTx(t, addressCodec, payer)
 			tx.gas = declaredGas
-			ctx := test.context.WithGasMeter(storetypes.NewGasMeter(tx.gas))
+			ctx := sdk.Context{}.
+				WithContext(context.Background()).
+				WithGasMeter(storetypes.NewInfiniteGasMeter()).
+				WithTxBytes(bytes.Repeat([]byte{0x04}, 512))
 
 			newCtx, err := decorator.AnteHandle(
 				ctx,
 				tx,
-				test.simulate,
+				false,
 				func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
-					nextCtx.GasMeter().ConsumeGas(tx.gas+1, "internal work above submitted limit")
-					return nextCtx, nil
+					nextCtx.GasMeter().ConsumeGas(declaredGas+1, "internal ante work")
+					return nextCtx, test.nextErr
 				},
 			)
 
-			require.NoError(t, err)
+			if test.nextErr != nil {
+				require.ErrorIs(t, err, test.nextErr)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, declaredGas, tx.GetGas())
-			require.Equal(t, test.wantLimit, uint64(newCtx.GasMeter().Limit()))
-			require.Equal(t, test.wantConsumed, uint64(newCtx.GasMeter().GasConsumed()))
-			standardMeter := newCtx.GasMeter().(*standardMsgSendGasMeter)
-			require.Equal(t, uint64(100_000), uint64(standardMeter.executionGas))
-			require.Equal(t, storetypes.GasConfig{}, newCtx.KVGasConfig())
-			require.Equal(t, storetypes.GasConfig{}, newCtx.TransientKVGasConfig())
-			require.False(t, newCtx.GasMeter().IsPastLimit())
-			require.False(t, newCtx.GasMeter().IsOutOfGas())
+			meter, ok := newCtx.GasMeter().(*standardMsgSendGasMeter)
+			require.True(t, ok)
+			require.Equal(t, StandardMsgSendGas, uint64(meter.Limit()))
+			require.Equal(t, StandardMsgSendGas, uint64(meter.GasConsumed()))
+			require.Equal(t, test.wantConsumedToLimit, uint64(meter.GasConsumedToLimit()))
+			require.Equal(t, declaredGas+1, uint64(meter.actualGasConsumed()))
+			require.False(t, meter.IsPastLimit())
+			require.False(t, meter.IsOutOfGas())
 		})
 	}
 }
 
-func TestStandardMsgSendFeeAccounting(t *testing.T) {
+func TestStandardMsgSendFeePlanExactArithmeticAndAffordability(t *testing.T) {
 	configureStandardMsgSendFeeTestChain(t, 0)
+
 	addressCodec := evmaddress.NewEvmCodec("guru")
 	payer := sdk.AccAddress(bytes.Repeat([]byte{0x66}, 20))
-	const (
-		declaredGas  = uint64(200_000)
-		executionGas = uint64(100_000)
-		gasPrice     = int64(10)
+	accountKeeper := &standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+		account:      authtypes.NewBaseAccountWithAddress(payer),
+	}
+	tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+	tx.gas = 42_000
+	tx.fee = sdk.NewCoins(sdk.NewInt64Coin(chainconfig.BaseDenom, 42_001))
+	const transferAmount = int64(100)
+	tx.msgs[0].(*banktypes.MsgSend).Amount = sdk.NewCoins(
+		sdk.NewInt64Coin(chainconfig.BaseDenom, transferAmount),
 	)
+	ctx := sdk.Context{}.
+		WithContext(context.Background()).
+		WithBlockHeight(1).
+		WithTxBytes(bytes.Repeat([]byte{0x05}, 512))
+	classification, eligible, err := NewStandardMsgSendClassifier(accountKeeper).classify(ctx, tx, false)
+	require.NoError(t, err)
+	require.True(t, eligible)
 
-	t.Run("London admission uses declared gas and settlement uses execution gas", func(t *testing.T) {
-		baseFee := sdkmath.LegacyNewDec(gasPrice)
-		tipCap := sdkmath.LegacyNewDec(2).MulInt(evmtypes.DefaultPriorityReduction)
-		feeCap := baseFee.Add(
-			sdkmath.LegacyNewDec(3).MulInt(evmtypes.DefaultPriorityReduction),
-		)
-		extension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{
-			MaxPriorityPrice: tipCap,
+	params := feemarkettypes.DefaultParams()
+	params.NoBaseFee = true
+	params.MinGasPrice = sdkmath.LegacyZeroDec()
+	plan, err := buildStandardMsgSendFeePlan(
+		ctx,
+		&classification,
+		&params,
+		accountKeeper,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42_000), plan.declaredGas)
+	require.Equal(t, sdkmath.NewInt(21_001), plan.actualFee.AmountOf(chainconfig.BaseDenom))
+	require.Equal(t, "42001", plan.effectivePrice.numerator.String())
+	require.Equal(t, "42000", plan.effectivePrice.denominator.String())
+
+	required := sdkmath.NewInt(transferAmount + 42_001)
+	for _, test := range []struct {
+		name      string
+		spendable sdkmath.Int
+		wantErr   bool
+	}{
+		{
+			name:      "transfer plus submitted fee exactly passes",
+			spendable: required,
+		},
+		{
+			name:      "one below transfer plus submitted fee fails",
+			spendable: required.SubRaw(1),
+			wantErr:   true,
+		},
+		{
+			name: "transfer plus actual fee is still insufficient",
+			spendable: sdkmath.NewInt(transferAmount).Add(
+				plan.actualFee.AmountOf(chainconfig.BaseDenom),
+			),
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bankKeeper := &standardMsgSendSpendableBankKeeperStub{
+				spendable: test.spendable,
+			}
+			_, err := buildStandardMsgSendFeePlan(
+				ctx,
+				&classification,
+				&params,
+				accountKeeper,
+				bankKeeper,
+				true,
+			)
+			if test.wantErr {
+				require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, chainconfig.BaseDenom, bankKeeper.requestedDenom)
 		})
-		require.NoError(t, err)
-
-		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
-		tx.gas = declaredGas
-		tx.fee = sdk.NewCoins(sdk.NewCoin(
-			"agxn",
-			feeCap.MulInt(sdkmath.NewIntFromUint64(declaredGas)).RoundInt(),
-		))
-		tx.extensions = []*codectypes.Any{extension}
-		params := feemarkettypes.DefaultParams()
-		params.BaseFee = baseFee
-		checker := newCosmosDynamicFeeChecker(&params)
-		effectivePrice := baseFee.Add(tipCap)
-
-		checkFees, priority, err := checker(
-			standardMsgSendFeeTestContext(1, declaredGas, executionGas, true),
-			tx,
-		)
-		require.NoError(t, err)
-		require.Equal(t, int64(2), priority)
-		require.Equal(
-			t,
-			effectivePrice.MulInt(sdkmath.NewIntFromUint64(declaredGas)).Ceil().RoundInt(),
-			checkFees.AmountOf("agxn"),
-		)
-
-		finalizeFees, _, err := checker(
-			standardMsgSendFeeTestContext(1, declaredGas, executionGas, false),
-			tx,
-		)
-		require.NoError(t, err)
-		require.Equal(
-			t,
-			effectivePrice.MulInt(sdkmath.NewIntFromUint64(executionGas)).Ceil().RoundInt(),
-			finalizeFees.AmountOf("agxn"),
-		)
-		require.Equal(t, declaredGas, tx.GetGas())
-	})
-
-	t.Run("fee covering only execution gas fails declared-gas admission", func(t *testing.T) {
-		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
-		tx.gas = declaredGas
-		tx.fee = sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(executionGas)*gasPrice))
-		params := feemarkettypes.DefaultParams()
-		params.BaseFee = sdkmath.LegacyNewDec(gasPrice)
-
-		_, _, err := newCosmosDynamicFeeChecker(&params)(
-			standardMsgSendFeeTestContext(1, declaredGas, executionGas, true),
-			tx,
-		)
-		require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
-	})
-
-	t.Run("standard dispatch does not apply upstream raw fractional base fee", func(t *testing.T) {
-		feeCap := sdkmath.LegacyMustNewDecFromStr("10.5")
-		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
-		tx.gas = declaredGas
-		tx.fee = sdk.NewCoins(sdk.NewCoin(
-			"agxn",
-			feeCap.MulInt(sdkmath.NewIntFromUint64(declaredGas)).RoundInt(),
-		))
-		params := feemarkettypes.DefaultParams()
-		params.BaseFee = sdkmath.LegacyMustNewDecFromStr("10.9")
-
-		fees, _, err := newCosmosDynamicFeeChecker(&params)(
-			standardMsgSendFeeTestContext(1, declaredGas, executionGas, true),
-			tx,
-		)
-		require.NoError(t, err)
-		require.Equal(t, tx.GetFee(), fees)
-	})
-
-	t.Run("validator minimum price reserves declared fee then settles execution fee", func(t *testing.T) {
-		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
-		tx.gas = declaredGas
-		tx.fee = sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(declaredGas)*gasPrice))
-		checker := newStandardMsgSendValidatorFeeChecker()
-		checkCtx := standardMsgSendFeeTestContext(1, declaredGas, executionGas, true).
-			WithMinGasPrices(sdk.DecCoins{
-				sdk.NewDecCoinFromDec("agxn", sdkmath.LegacyNewDec(gasPrice)),
-			})
-
-		checkFees, priority, err := checker(checkCtx, tx)
-		require.NoError(t, err)
-		require.Equal(t, tx.GetFee(), checkFees)
-		require.Equal(t, gasPrice, priority)
-
-		finalizeFees, _, err := checker(
-			standardMsgSendFeeTestContext(1, declaredGas, executionGas, false),
-			tx,
-		)
-		require.NoError(t, err)
-		require.Equal(
-			t,
-			sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(executionGas)*gasPrice)),
-			finalizeFees,
-		)
-	})
-
-	t.Run("ordinary transactions retain the upstream checker", func(t *testing.T) {
-		tx := newStandardMsgSendTestTx(t, addressCodec, payer)
-		tx.gas = declaredGas
-		tx.fee = sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(declaredGas)*gasPrice))
-		params := feemarkettypes.DefaultParams()
-		params.BaseFee = sdkmath.LegacyNewDec(gasPrice)
-		ctx := sdk.Context{}.
-			WithBlockHeight(1).
-			WithGasMeter(storetypes.NewInfiniteGasMeter())
-
-		wantFees, wantPriority, err := evmanteevm.NewDynamicFeeChecker(&params)(ctx, tx)
-		require.NoError(t, err)
-		gotFees, gotPriority, err := newCosmosDynamicFeeChecker(&params)(ctx, tx)
-		require.NoError(t, err)
-		require.Equal(t, wantFees, gotFees)
-		require.Equal(t, wantPriority, gotPriority)
-	})
+	}
 }
 
-func TestStandardMsgSendEthereumFeePolicyEdges(t *testing.T) {
+func TestStandardMsgSendFeePlanBoundedInvariants(t *testing.T) {
 	configureStandardMsgSendFeeTestChain(t, 0)
-	ctx := standardMsgSendFeeTestContext(1, 42_000, 21_000, true)
-	params := feemarkettypes.DefaultParams()
-	params.BaseFee = sdkmath.LegacyMustNewDecFromStr("10.9")
-	require.Equal(t, sdkmath.LegacyNewDec(10), standardMsgSendEthereumBaseFee(ctx, &params))
-	params.NoBaseFee = true
-	require.True(t, standardMsgSendEthereumBaseFee(ctx, &params).IsZero())
 
-	params = feemarkettypes.DefaultParams()
-	params.BaseFee = sdkmath.LegacyNewDec(10)
-	params.MinGasPrice = sdkmath.LegacyNewDec(15)
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x67}, 20))
+	accountKeeper := &standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+		account:      authtypes.NewBaseAccountWithAddress(payer),
+	}
+	ctx := sdk.Context{}.
+		WithContext(context.Background()).
+		WithBlockHeight(1).
+		WithTxBytes(bytes.Repeat([]byte{0x07}, 512))
+
+	declaredGasCases := []uint64{
+		StandardMsgSendGas,
+		StandardMsgSendGas + 1,
+		42_000,
+		200_000,
+		^uint64(0),
+	}
+	priceCases := []int64{1, 2, 17, 1_000_000}
+
+	for _, declaredGas := range declaredGasCases {
+		for _, minimumPrice := range priceCases {
+			for _, remainder := range []uint64{0, 1, declaredGas - 1} {
+				declaredGasInt := new(big.Int).SetUint64(declaredGas)
+				submittedFeeInt := new(big.Int).Mul(
+					new(big.Int).Set(declaredGasInt),
+					big.NewInt(minimumPrice),
+				)
+				submittedFeeInt.Add(submittedFeeInt, new(big.Int).SetUint64(remainder))
+
+				tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+				tx.gas = declaredGas
+				tx.fee = sdk.NewCoins(sdk.NewCoin(
+					chainconfig.BaseDenom,
+					sdkmath.NewIntFromBigInt(submittedFeeInt),
+				))
+				classification, eligible, err := NewStandardMsgSendClassifier(accountKeeper).classify(
+					ctx,
+					tx,
+					false,
+				)
+				require.NoError(t, err)
+				require.True(t, eligible)
+
+				params := feemarkettypes.DefaultParams()
+				params.NoBaseFee = true
+				params.MinGasPrice = sdkmath.LegacyNewDec(minimumPrice)
+				plan, err := buildStandardMsgSendFeePlan(
+					ctx,
+					&classification,
+					&params,
+					accountKeeper,
+					nil,
+					false,
+				)
+				require.NoError(t, err)
+
+				expectedActualFee := ceilStandardMsgSendQuotient(
+					new(big.Int).Mul(
+						new(big.Int).Set(submittedFeeInt),
+						new(big.Int).SetUint64(StandardMsgSendGas),
+					),
+					declaredGasInt,
+				)
+				actualFee := plan.actualFee.AmountOf(chainconfig.BaseDenom).BigInt()
+				minimumActualFee := new(big.Int).Mul(
+					big.NewInt(minimumPrice),
+					new(big.Int).SetUint64(StandardMsgSendGas),
+				)
+
+				require.Zero(t, actualFee.Cmp(expectedActualFee))
+				require.LessOrEqual(t, actualFee.Cmp(submittedFeeInt), 0)
+				require.GreaterOrEqual(t, actualFee.Cmp(minimumActualFee), 0)
+			}
+		}
+	}
+}
+
+func TestStandardMsgSendFeePlanDynamicTipCapAndNegativeTip(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x77}, 20))
+	accountKeeper := &standardMsgSendAccountKeeper{
+		addressCodec: addressCodec,
+		account:      authtypes.NewBaseAccountWithAddress(payer),
+	}
+	tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+	tx.gas = 42_000
+	tx.fee = sdk.NewCoins(sdk.NewInt64Coin(chainconfig.BaseDenom, 84_000))
 	extension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{
-		MaxPriorityPrice: sdkmath.LegacyNewDec(1),
+		MaxPriorityPrice: sdkmath.LegacyNewDec(10),
 	})
 	require.NoError(t, err)
-	addressCodec := evmaddress.NewEvmCodec("guru")
-	tx := newStandardMsgSendTestTx(
-		t,
-		addressCodec,
-		sdk.AccAddress(bytes.Repeat([]byte{0x77}, 20)),
-	)
-	tx.gas = 42_000
-	tx.fee = sdk.NewCoins(sdk.NewInt64Coin("agxn", int64(tx.gas)*20))
 	tx.extensions = []*codectypes.Any{extension}
 
-	_, err = newStandardMsgSendMinGasPriceDecorator(&params).AnteHandle(
+	ctx := sdk.Context{}.
+		WithContext(context.Background()).
+		WithBlockHeight(1).
+		WithTxBytes(bytes.Repeat([]byte{0x06}, 512))
+	classification, eligible, err := NewStandardMsgSendClassifier(accountKeeper).classify(ctx, tx, false)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	params := feemarkettypes.DefaultParams()
+	params.BaseFee = sdkmath.LegacyOneDec()
+	params.MinGasPrice = sdkmath.LegacyZeroDec()
+
+	plan, err := buildStandardMsgSendFeePlan(
+		ctx,
+		&classification,
+		&params,
+		accountKeeper,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "2", standardMsgSendPriceString(plan.effectivePrice))
+	require.Equal(t, sdkmath.NewInt(42_000), plan.actualFee.AmountOf(chainconfig.BaseDenom))
+
+	negativeTip, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{
+		MaxPriorityPrice: sdkmath.LegacyNewDec(-1),
+	})
+	require.NoError(t, err)
+	tx.extensions = []*codectypes.Any{negativeTip}
+	negativeClassification, eligible, err := NewStandardMsgSendClassifier(accountKeeper).classify(
 		ctx,
 		tx,
 		false,
-		func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
-			return nextCtx, nil
-		},
+	)
+	require.NoError(t, err)
+	require.True(t, eligible)
+	_, err = buildStandardMsgSendFeePlan(
+		ctx,
+		&negativeClassification,
+		&params,
+		accountKeeper,
+		nil,
+		false,
 	)
 	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
 }
 
+func TestStandardMsgSendDeductFeeUsesActualFeeAndEmitsObservabilityEvent(t *testing.T) {
+	configureStandardMsgSendFeeTestChain(t, 0)
+
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x78}, 20))
+	accountKeeper := &dynamicFeeFloorAccountKeeper{
+		addressCodec:  addressCodec,
+		account:       authtypes.NewBaseAccountWithAddress(payer),
+		moduleAddress: sdk.AccAddress(bytes.Repeat([]byte{0x79}, 20)),
+	}
+	bankKeeper := &dynamicFeeFloorBankKeeper{}
+	tx := newStandardMsgSendTestTx(t, addressCodec, payer)
+	tx.gas = 42_000
+	tx.fee = sdk.NewCoins(sdk.NewInt64Coin(chainconfig.BaseDenom, 42_001))
+	ctx := sdk.Context{}.
+		WithContext(context.Background()).
+		WithBlockHeight(1).
+		WithTxBytes(bytes.Repeat([]byte{0x08}, 512)).
+		WithEventManager(sdk.NewEventManager())
+	classification, eligible, err := NewStandardMsgSendClassifier(accountKeeper).classify(ctx, tx, false)
+	require.NoError(t, err)
+	require.True(t, eligible)
+
+	params := feemarkettypes.DefaultParams()
+	params.NoBaseFee = true
+	params.MinGasPrice = sdkmath.LegacyZeroDec()
+	plan, err := buildStandardMsgSendFeePlan(
+		ctx,
+		&classification,
+		&params,
+		accountKeeper,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, sdkmath.NewInt(21_001), plan.actualFee.AmountOf(chainconfig.BaseDenom))
+
+	fixedCtx := ctx.
+		WithValue(standardMsgSendContextKey{}, &classification).
+		WithValue(standardMsgSendFeePlanContextKey{}, &plan)
+	decorator := newStandardMsgSendDeductFeeDecorator(
+		accountKeeper,
+		bankKeeper,
+		nil,
+		nil,
+	)
+	nextCalls := 0
+	newCtx, err := decorator.AnteHandle(
+		fixedCtx,
+		tx,
+		false,
+		func(nextCtx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			nextCalls++
+			return nextCtx, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, nextCalls)
+	require.Equal(t, 1, bankKeeper.sendCalls)
+	require.Equal(t, payer, bankKeeper.from)
+	require.Equal(t, authtypes.FeeCollectorName, bankKeeper.module)
+	require.Equal(t, plan.actualFee, bankKeeper.amount)
+
+	var fixedEvent *sdk.Event
+	for _, event := range newCtx.EventManager().Events() {
+		if event.Type == EventTypeFixedSendGas {
+			eventCopy := event
+			fixedEvent = &eventCopy
+			break
+		}
+	}
+	require.NotNil(t, fixedEvent)
+	attributes := make(map[string]string, len(fixedEvent.Attributes))
+	for _, attribute := range fixedEvent.Attributes {
+		attributes[attribute.Key] = attribute.Value
+	}
+	require.Equal(t, map[string]string{
+		AttributeKeyDeclaredGas:       "42000",
+		AttributeKeyAccountingGas:     "21000",
+		AttributeKeySubmittedFee:      plan.submittedFee.String(),
+		AttributeKeyEffectiveGasPrice: "42001/42000",
+		AttributeKeyActualFee:         plan.actualFee.String(),
+	}, attributes)
+}
+
 func TestAnteRouterPreservesUpstreamErrors(t *testing.T) {
-	options := evmante.HandlerOptions{}
+	configureStandardMsgSendFeeTestChain(t, 0)
+	addressCodec := evmaddress.NewEvmCodec("guru")
+	payer := sdk.AccAddress(bytes.Repeat([]byte{0x7a}, 20))
+	rejectedEthereumTx := newStandardMsgSendTestTx(t, addressCodec, payer)
+	rejectedEthereumTx.msgs = []sdk.Msg{&evmtypes.MsgEthereumTx{}}
+	rejectedEthereumTx.gas = 123_456
+
+	params := feemarkettypes.DefaultParams()
+	options := evmante.HandlerOptions{
+		FeeMarketKeeper: &prospectiveFeeMarketKeeperStub{params: params},
+	}
 	localHandler := NewAnteHandler(options)
 	upstreamHandler := evmante.NewAnteHandler(options)
 	tests := []struct {
-		name string
-		tx   sdk.Tx
+		name               string
+		tx                 sdk.Tx
+		wantLocalErr       error
+		compareReturnedGas bool
 	}{
-		{name: "nil transaction"},
+		{name: "nil transaction", wantLocalErr: sdkerrors.ErrTxDecode},
 		{
 			name: "unknown extension",
 			tx: anteRouterTestTx{extensions: []*codectypes.Any{{
 				TypeUrl: "/test.unsupported.ExtensionOption",
 			}}},
 		},
+		{
+			name:               "rejected Ethereum message preserves pre-setup gas context",
+			tx:                 rejectedEthereumTx,
+			compareReturnedGas: true,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := sdk.Context{}
-			_, wantErr := upstreamHandler(ctx, test.tx, false)
-			_, gotErr := localHandler(ctx, test.tx, false)
+			ctx := sdk.Context{}.
+				WithContext(context.Background()).
+				WithGasMeter(storetypes.NewInfiniteGasMeter())
+			wantCtx, wantErr := upstreamHandler(ctx, test.tx, false)
+			gotCtx, gotErr := localHandler(ctx, test.tx, false)
 			require.Error(t, wantErr)
-			require.EqualError(t, gotErr, wantErr.Error())
+			if test.wantLocalErr != nil {
+				require.ErrorIs(t, gotErr, test.wantLocalErr)
+			} else {
+				require.EqualError(t, gotErr, wantErr.Error())
+			}
+			if test.compareReturnedGas {
+				require.Equal(t, wantCtx.GasMeter().Limit(), gotCtx.GasMeter().Limit())
+				require.Equal(t, wantCtx.GasMeter().GasConsumed(), gotCtx.GasMeter().GasConsumed())
+			}
 		})
 	}
 }
@@ -828,8 +1258,6 @@ func TestOrdinaryDynamicFeeFloorCoversStandardMsgSendFallbacks(t *testing.T) {
 	addressCodec := evmaddress.NewEvmCodec("guru")
 	decorator := NewStandardMsgSendGasDecorator(
 		&standardMsgSendAccountKeeper{addressCodec: addressCodec},
-		standardMsgSendTestMinGasMultiplier(),
-		0,
 	)
 	tests := []struct {
 		name   string
@@ -848,9 +1276,11 @@ func TestOrdinaryDynamicFeeFloorCoversStandardMsgSendFallbacks(t *testing.T) {
 			},
 		},
 		{
-			name: "classifier fallback MsgSend",
+			name: "unsupported key MsgSend",
 			mutate: func(tx *standardMsgSendTestTx) {
-				tx.memo = strings.Repeat("m", StandardMsgSendMaxMemoBytes+1)
+				publicKey := ed25519.GenPrivKey().PubKey()
+				tx.pubKeys = []cryptotypes.PubKey{publicKey}
+				tx.signatures[0].PubKey = publicKey
 			},
 		},
 	}
@@ -932,6 +1362,7 @@ func newOrdinaryDynamicFeeTestTx(
 
 func ordinaryDynamicFeeTestContext(height int64) sdk.Context {
 	return sdk.Context{}.
+		WithContext(context.Background()).
 		WithBlockHeight(height).
 		WithGasMeter(storetypes.NewInfiniteGasMeter())
 }
@@ -977,6 +1408,10 @@ func (keeper *dynamicFeeFloorAccountKeeper) GetAccount(context.Context, sdk.AccA
 	return keeper.account
 }
 
+func (*dynamicFeeFloorAccountKeeper) GetParams(context.Context) authtypes.Params {
+	return authtypes.DefaultParams()
+}
+
 func (keeper *dynamicFeeFloorAccountKeeper) GetModuleAddress(string) sdk.AccAddress {
 	return keeper.moduleAddress
 }
@@ -984,15 +1419,21 @@ func (keeper *dynamicFeeFloorAccountKeeper) GetModuleAddress(string) sdk.AccAddr
 type dynamicFeeFloorBankKeeper struct {
 	authtypes.BankKeeper
 	sendCalls int
+	from      sdk.AccAddress
+	module    string
+	amount    sdk.Coins
 }
 
 func (keeper *dynamicFeeFloorBankKeeper) SendCoinsFromAccountToModule(
-	context.Context,
-	sdk.AccAddress,
-	string,
-	sdk.Coins,
+	_ context.Context,
+	from sdk.AccAddress,
+	module string,
+	amount sdk.Coins,
 ) error {
 	keeper.sendCalls++
+	keeper.from = append(sdk.AccAddress(nil), from...)
+	keeper.module = module
+	keeper.amount = amount
 	return nil
 }
 
@@ -1010,27 +1451,6 @@ func configureStandardMsgSendFeeTestChain(t *testing.T, londonHeight int64) {
 	require.NoError(t, evmtypes.SetChainConfig(chainConfig))
 }
 
-func standardMsgSendFeeTestContext(
-	height int64,
-	declaredGas uint64,
-	executionGas uint64,
-	checkTx bool,
-) sdk.Context {
-	return sdk.Context{}.
-		WithBlockHeight(height).
-		WithIsCheckTx(checkTx).
-		WithGasMeter(&standardMsgSendGasMeter{
-			actual:       storetypes.NewInfiniteGasMeter(),
-			limit:        storetypes.Gas(declaredGas),
-			reportedGas:  storetypes.Gas(executionGas),
-			executionGas: storetypes.Gas(executionGas),
-		})
-}
-
-func standardMsgSendTestMinGasMultiplier() sdkmath.LegacyDec {
-	return sdkmath.LegacyNewDecWithPrec(5, 1)
-}
-
 type standardMsgSendAccountKeeper struct {
 	authante.AccountKeeper
 	addressCodec coreaddress.Codec
@@ -1041,8 +1461,62 @@ func (keeper *standardMsgSendAccountKeeper) AddressCodec() coreaddress.Codec {
 	return keeper.addressCodec
 }
 
+func (*standardMsgSendAccountKeeper) GetParams(context.Context) authtypes.Params {
+	return authtypes.DefaultParams()
+}
+
 func (keeper *standardMsgSendAccountKeeper) GetAccount(context.Context, sdk.AccAddress) sdk.AccountI {
 	return keeper.account
+}
+
+type standardMsgSendSpendableBankKeeperStub struct {
+	spendable      sdkmath.Int
+	requestedDenom string
+}
+
+func (keeper *standardMsgSendSpendableBankKeeperStub) SpendableCoin(
+	_ context.Context,
+	_ sdk.AccAddress,
+	denom string,
+) sdk.Coin {
+	keeper.requestedDenom = denom
+	return sdk.NewCoin(denom, keeper.spendable)
+}
+
+type prospectiveFeeMarketKeeperStub struct {
+	params         feemarkettypes.Params
+	prospectiveFee sdkmath.LegacyDec
+	calculateCalls int
+}
+
+func (keeper *prospectiveFeeMarketKeeperStub) GetParams(sdk.Context) feemarkettypes.Params {
+	return keeper.params
+}
+
+func (*prospectiveFeeMarketKeeperStub) AddTransientGasWanted(
+	sdk.Context,
+	uint64,
+) (uint64, error) {
+	return 0, nil
+}
+
+func (keeper *prospectiveFeeMarketKeeperStub) CalculateBaseFee(sdk.Context) sdkmath.LegacyDec {
+	keeper.calculateCalls++
+	return keeper.prospectiveFee
+}
+
+type standardMsgSendGasWantedKeeperStub struct {
+	calls     int
+	gasWanted uint64
+}
+
+func (keeper *standardMsgSendGasWantedKeeperStub) AddTransientGasWanted(
+	_ sdk.Context,
+	gasWanted uint64,
+) (uint64, error) {
+	keeper.calls++
+	keeper.gasWanted += gasWanted
+	return keeper.gasWanted, nil
 }
 
 type standardMsgSendTestTx struct {
@@ -1140,22 +1614,28 @@ func newStandardMsgSendTestTx(
 		msgs: []sdk.Msg{&banktypes.MsgSend{
 			FromAddress: from,
 			ToAddress:   to,
-			Amount:      sdk.NewCoins(sdk.NewInt64Coin("send-denom", 1)),
+			Amount:      sdk.NewCoins(sdk.NewInt64Coin(chainconfig.BaseDenom, 1)),
 		}},
-		fee:        sdk.NewCoins(sdk.NewInt64Coin(evmtypes.GetEVMCoinDenom(), 1)),
-		gas:        StandardMsgSendGas,
-		payer:      append(sdk.AccAddress(nil), payer...),
-		signers:    [][]byte{append([]byte(nil), payer...)},
-		pubKeys:    []cryptotypes.PubKey{pubKey},
-		signatures: []signing.SignatureV2{{PubKey: pubKey}},
+		fee:     sdk.NewCoins(sdk.NewInt64Coin(chainconfig.BaseDenom, 1)),
+		gas:     StandardMsgSendGas,
+		payer:   append(sdk.AccAddress(nil), payer...),
+		signers: [][]byte{append([]byte(nil), payer...)},
+		pubKeys: []cryptotypes.PubKey{pubKey},
+		signatures: []signing.SignatureV2{{
+			PubKey: pubKey,
+			Data: &signing.SingleSignatureData{
+				SignMode:  signing.SignMode_SIGN_MODE_DIRECT,
+				Signature: []byte{0x01},
+			},
+		}},
 	}
 }
 
 func configureStandardMsgSendTestDenom() {
 	evmtypes.SetDefaultEvmCoinInfo(evmtypes.EvmCoinInfo{
-		Denom:         "agxn",
-		ExtendedDenom: "agxn",
-		DisplayDenom:  "gxn",
+		Denom:         chainconfig.BaseDenom,
+		ExtendedDenom: chainconfig.BaseDenom,
+		DisplayDenom:  chainconfig.DisplayDenom,
 		Decimals:      18,
 	})
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -47,6 +47,7 @@ import (
 	ethparams "github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 
+	appante "github.com/gurufinglobal/guru/v2/app/ante"
 	"github.com/gurufinglobal/guru/v2/config"
 	constitutiontypes "github.com/gurufinglobal/guru/v2/x/constitution/types"
 	oracletypes "github.com/gurufinglobal/guru/v2/x/oracle/types"
@@ -309,13 +310,39 @@ func TestApplicationStateMachine(t *testing.T) {
 	require.Empty(t, vmGenesis.Params.ActiveStaticPrecompiles)
 	require.Equal(t, []evmtypes.Preinstall{mustHistoryStoragePreinstall()}, vmGenesis.Preinstalls)
 
-	governanceDenomGenesis := cloneGenesisState(genesis)
-	governanceDenomVM := new(evmtypes.GenesisState)
-	application.AppCodec().MustUnmarshalJSON(governanceDenomGenesis[evmtypes.ModuleName], governanceDenomVM)
-	governanceDenomVM.Params.EvmDenom = "uother"
-	governanceDenomVM.Params.ExtendedDenomOptions.ExtendedDenom = "uother"
-	governanceDenomGenesis[evmtypes.ModuleName] = application.AppCodec().MustMarshalJSON(governanceDenomVM)
-	require.NoError(t, application.ValidateGenesis(governanceDenomGenesis))
+	for _, tc := range []struct {
+		name        string
+		mutate      func(*evmtypes.GenesisState)
+		errorString string
+	}{
+		{
+			name: "EVM denom",
+			mutate: func(genesis *evmtypes.GenesisState) {
+				genesis.Params.EvmDenom = "uother"
+			},
+			errorString: "evm evm_denom must be immutable config base denom",
+		},
+		{
+			name: "extended denom",
+			mutate: func(genesis *evmtypes.GenesisState) {
+				genesis.Params.ExtendedDenomOptions.ExtendedDenom = "uother"
+			},
+			errorString: "evm extended_denom must be immutable config base denom",
+		},
+	} {
+		t.Run("rejects mutable "+tc.name, func(t *testing.T) {
+			invalidGenesis := cloneGenesisState(genesis)
+			invalidEVMGenesis := new(evmtypes.GenesisState)
+			application.AppCodec().MustUnmarshalJSON(
+				invalidGenesis[evmtypes.ModuleName],
+				invalidEVMGenesis,
+			)
+			tc.mutate(invalidEVMGenesis)
+			invalidGenesis[evmtypes.ModuleName] = application.AppCodec().MustMarshalJSON(invalidEVMGenesis)
+
+			require.ErrorContains(t, application.ValidateGenesis(invalidGenesis), tc.errorString)
+		})
+	}
 
 	erc20Genesis := new(erc20types.GenesisState)
 	application.AppCodec().MustUnmarshalJSON(genesis[erc20types.ModuleName], erc20Genesis)
@@ -450,8 +477,8 @@ func TestApplicationStateMachine(t *testing.T) {
 			Txs:    [][]byte{ordinaryDynamicFloorTxBytes},
 		})
 		require.NoError(t, proposalErr)
-		// Guru intentionally uses the SDK no-op proposal handler; execution safety
-		// is enforced when the same production ante handler runs in FinalizeBlock.
+		// The FixedSendGas proposal verifier preserves the SDK NoOp semantics for
+		// decode-valid ordinary transactions, including ordinary ante failures.
 		require.Equal(t, abci.ResponseProcessProposal_ACCEPT, proposalResponse.Status)
 		assertUnchanged(proposalBefore, committedContext(t, application))
 	})
@@ -600,13 +627,14 @@ func TestApplicationStateMachine(t *testing.T) {
 	transferValue := big.NewInt(12_345)
 	minGasMultiplier := application.FeeMarketKeeper.GetParams(queryContext).MinGasMultiplier
 	require.True(t, minGasMultiplier.Equal(feemarkettypes.DefaultMinGasMultiplier))
-	minimumGasUsed := minGasMultiplier.
+	ethereumGasUsed := minGasMultiplier.
 		MulInt64(int64(submittedGas)).
 		TruncateInt().Uint64()
-	expectedBlockGasWanted := minGasMultiplier.
-		MulInt64(int64(2 * submittedGas)).
-		TruncateInt().Uint64()
-	protocolFee := sdkmath.NewIntFromUint64(minimumGasUsed).Mul(sdkmath.NewIntFromBigInt(gasPrice))
+	expectedBlockGasWanted := ethereumGasUsed + appante.StandardMsgSendGas
+	ethereumProtocolFee := sdkmath.NewIntFromUint64(ethereumGasUsed).
+		Mul(sdkmath.NewIntFromBigInt(gasPrice))
+	fixedSendActualFee := sdkmath.NewIntFromUint64(appante.StandardMsgSendGas).
+		Mul(sdkmath.NewIntFromBigInt(gasPrice))
 	submittedFee := sdkmath.NewIntFromUint64(submittedGas).
 		Mul(sdkmath.NewIntFromBigInt(gasPrice))
 
@@ -639,6 +667,58 @@ func TestApplicationStateMachine(t *testing.T) {
 		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, submittedFee)),
 		submittedGas,
 	)
+	cosmosGasOnlySimulationBytes := signAndEncodeCosmosTx(
+		t,
+		application,
+		cosmosPrivateKey,
+		cosmosSenderAccount.GetAccountNumber(),
+		cosmosSenderAccount.GetSequence(),
+		banktypes.NewMsgSend(
+			cosmosSender,
+			sdk.AccAddress(cosmosRecipient.Bytes()),
+			sdk.NewCoins(sdk.NewCoin(
+				config.BaseDenom,
+				sdkmath.NewIntFromBigInt(transferValue),
+			)),
+		),
+		nil,
+		0,
+	)
+	t.Run("FixedSendGas D zero simulation is gas-only", func(t *testing.T) {
+		beforeSender := application.BankKeeper.GetBalance(
+			queryContext,
+			cosmosSender,
+			config.BaseDenom,
+		)
+		beforeRecipient := application.BankKeeper.GetBalance(
+			queryContext,
+			sdk.AccAddress(cosmosRecipient.Bytes()),
+			config.BaseDenom,
+		)
+		beforeSequence := application.AccountKeeper.GetAccount(queryContext, cosmosSender).GetSequence()
+
+		gasInfo, _, simulateErr := application.Simulate(cosmosGasOnlySimulationBytes)
+		require.NoError(t, simulateErr)
+		require.Equal(t, appante.StandardMsgSendGas, gasInfo.GasWanted)
+		require.Equal(t, appante.StandardMsgSendGas, gasInfo.GasUsed)
+
+		afterContext := committedContext(t, application)
+		require.Equal(t, beforeSender, application.BankKeeper.GetBalance(
+			afterContext,
+			cosmosSender,
+			config.BaseDenom,
+		))
+		require.Equal(t, beforeRecipient, application.BankKeeper.GetBalance(
+			afterContext,
+			sdk.AccAddress(cosmosRecipient.Bytes()),
+			config.BaseDenom,
+		))
+		require.Equal(
+			t,
+			beforeSequence,
+			application.AccountKeeper.GetAccount(afterContext, cosmosSender).GetSequence(),
+		)
+	})
 
 	const proposalGas uint64 = 60_000_000
 	proposalFee := sdkmath.NewIntFromUint64(proposalGas).
@@ -653,6 +733,17 @@ func TestApplicationStateMachine(t *testing.T) {
 			Value:    transferValue,
 			Gas:      proposalGas,
 			GasPrice: gasPrice,
+		}),
+	)
+	overflowEthereumBytes, _ := signAndEncodeEthereumTx(
+		t,
+		application,
+		ethereumPrivateKey,
+		ethtypes.NewTx(&ethtypes.LegacyTx{
+			Nonce:    0,
+			To:       &ethereumRecipient,
+			Gas:      ^uint64(0),
+			GasPrice: big.NewInt(1),
 		}),
 	)
 	proposalCosmosBytes := signAndEncodeCosmosTx(
@@ -672,6 +763,269 @@ func TestApplicationStateMachine(t *testing.T) {
 		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, proposalFee)),
 		proposalGas,
 	)
+	invalidFixedFee := feeMarketParams.MinGasPrice.
+		MulInt(sdkmath.NewIntFromUint64(appante.StandardMsgSendGas)).
+		Ceil().
+		RoundInt().
+		SubRaw(1)
+	invalidFixedBytes := signAndEncodeCosmosTx(
+		t,
+		application,
+		cosmosPrivateKey,
+		cosmosSenderAccount.GetAccountNumber(),
+		cosmosSenderAccount.GetSequence(),
+		banktypes.NewMsgSend(
+			cosmosSender,
+			sdk.AccAddress(cosmosRecipient.Bytes()),
+			sdk.NewCoins(sdk.NewCoin(
+				config.BaseDenom,
+				sdkmath.NewIntFromBigInt(transferValue),
+			)),
+		),
+		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, invalidFixedFee)),
+		appante.StandardMsgSendGas,
+	)
+	sequentialTransfer := senderFunds.AmountOf(config.BaseDenom).QuoRaw(2)
+	sequentialFixedBytes := make([][]byte, 2)
+	for sequence := range sequentialFixedBytes {
+		sequentialFixedBytes[sequence] = signAndEncodeCosmosTx(
+			t,
+			application,
+			cosmosPrivateKey,
+			cosmosSenderAccount.GetAccountNumber(),
+			uint64(sequence),
+			banktypes.NewMsgSend(
+				cosmosSender,
+				sdk.AccAddress(cosmosRecipient.Bytes()),
+				sdk.NewCoins(sdk.NewCoin(config.BaseDenom, sequentialTransfer)),
+			),
+			sdk.NewCoins(sdk.NewCoin(config.BaseDenom, submittedFee)),
+			submittedGas,
+		)
+	}
+	type proposalStateSnapshot struct {
+		senderBalance       sdkmath.Int
+		recipientBalance    sdkmath.Int
+		feeCollectorBalance sdkmath.Int
+		sequence            uint64
+		blockGasWanted      uint64
+		lastBlockHeight     int64
+	}
+	proposalSnapshot := func() proposalStateSnapshot {
+		state := committedContext(t, application)
+		account := application.AccountKeeper.GetAccount(state, cosmosSender)
+		require.NotNil(t, account)
+		return proposalStateSnapshot{
+			senderBalance: application.BankKeeper.GetBalance(
+				state,
+				cosmosSender,
+				config.BaseDenom,
+			).Amount,
+			recipientBalance: application.BankKeeper.GetBalance(
+				state,
+				sdk.AccAddress(cosmosRecipient.Bytes()),
+				config.BaseDenom,
+			).Amount,
+			feeCollectorBalance: application.BankKeeper.GetBalance(
+				state,
+				authtypes.NewModuleAddress(authtypes.FeeCollectorName),
+				config.BaseDenom,
+			).Amount,
+			sequence:        account.GetSequence(),
+			blockGasWanted:  application.FeeMarketKeeper.GetBlockGasWanted(state),
+			lastBlockHeight: application.LastBlockHeight(),
+		}
+	}
+
+	t.Run("proposal rejects malformed raw transaction", func(t *testing.T) {
+		malformed := []byte{0xff}
+		prepared, prepareErr := application.PrepareProposal(&abci.RequestPrepareProposal{
+			Height:     2,
+			Time:       blockTime.Add(2 * time.Second),
+			MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+			Txs:        [][]byte{malformed},
+		})
+		require.NoError(t, prepareErr)
+		require.Empty(t, prepared.Txs)
+
+		processed, processErr := application.ProcessProposal(&abci.RequestProcessProposal{
+			Height: 2,
+			Time:   blockTime.Add(2 * time.Second),
+			Txs:    [][]byte{proposalCosmosBytes, malformed},
+		})
+		require.NoError(t, processErr)
+		require.Equal(t, abci.ResponseProcessProposal_REJECT, processed.Status)
+	})
+
+	t.Run("proposal rejects FixedSendGas fee admission failure", func(t *testing.T) {
+		prepared, prepareErr := application.PrepareProposal(&abci.RequestPrepareProposal{
+			Height:     2,
+			Time:       blockTime.Add(2 * time.Second),
+			MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+			Txs:        [][]byte{invalidFixedBytes},
+		})
+		require.NoError(t, prepareErr)
+		require.Empty(t, prepared.Txs)
+
+		processed, processErr := application.ProcessProposal(&abci.RequestProcessProposal{
+			Height: 2,
+			Time:   blockTime.Add(2 * time.Second),
+			Txs:    [][]byte{invalidFixedBytes},
+		})
+		require.NoError(t, processErr)
+		require.Equal(t, abci.ResponseProcessProposal_REJECT, processed.Status)
+	})
+
+	t.Run("proposal snapshots ante sequence without applying message transfers", func(t *testing.T) {
+		// Both transactions transfer half the committed balance. The second sequence
+		// is valid only after the first ante succeeds, while applying the first
+		// MsgSend would make the second A+F check fail.
+		before := proposalSnapshot()
+		prepared, prepareErr := application.PrepareProposal(&abci.RequestPrepareProposal{
+			Height:     2,
+			Time:       blockTime.Add(2 * time.Second),
+			MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+			Txs:        sequentialFixedBytes,
+		})
+		require.NoError(t, prepareErr)
+		require.Equal(t, sequentialFixedBytes, prepared.Txs)
+		require.Equal(t, before, proposalSnapshot())
+
+		processed, processErr := application.ProcessProposal(&abci.RequestProcessProposal{
+			Height: 2,
+			Time:   blockTime.Add(2 * time.Second),
+			Txs:    sequentialFixedBytes,
+		})
+		require.NoError(t, processErr)
+		require.Equal(t, abci.ResponseProcessProposal_ACCEPT, processed.Status)
+		require.Equal(t, before, proposalSnapshot())
+	})
+
+	t.Run("proposal snapshots successful ante fee deductions", func(t *testing.T) {
+		// The first message is a self-send, so its message execution has zero net
+		// balance effect. The second requires the complete starting balance as A+F
+		// and therefore fails only because the first successful ante deducted its fee.
+		feeBoundaryTransfer := senderFunds.AmountOf(config.BaseDenom).Sub(submittedFee)
+		require.True(t, feeBoundaryTransfer.IsPositive())
+		feeBoundaryBytes := [][]byte{
+			signAndEncodeCosmosTx(
+				t,
+				application,
+				cosmosPrivateKey,
+				cosmosSenderAccount.GetAccountNumber(),
+				0,
+				banktypes.NewMsgSend(
+					cosmosSender,
+					cosmosSender,
+					sdk.NewCoins(sdk.NewInt64Coin(config.BaseDenom, 1)),
+				),
+				sdk.NewCoins(sdk.NewCoin(config.BaseDenom, submittedFee)),
+				submittedGas,
+			),
+			signAndEncodeCosmosTx(
+				t,
+				application,
+				cosmosPrivateKey,
+				cosmosSenderAccount.GetAccountNumber(),
+				1,
+				banktypes.NewMsgSend(
+					cosmosSender,
+					sdk.AccAddress(cosmosRecipient.Bytes()),
+					sdk.NewCoins(sdk.NewCoin(config.BaseDenom, feeBoundaryTransfer)),
+				),
+				sdk.NewCoins(sdk.NewCoin(config.BaseDenom, submittedFee)),
+				submittedGas,
+			),
+		}
+
+		before := proposalSnapshot()
+		prepared, prepareErr := application.PrepareProposal(&abci.RequestPrepareProposal{
+			Height:     2,
+			Time:       blockTime.Add(2 * time.Second),
+			MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+			Txs:        feeBoundaryBytes,
+		})
+		require.NoError(t, prepareErr)
+		require.Equal(t, feeBoundaryBytes[:1], prepared.Txs)
+		require.Equal(t, before, proposalSnapshot())
+
+		processed, processErr := application.ProcessProposal(&abci.RequestProcessProposal{
+			Height: 2,
+			Time:   blockTime.Add(2 * time.Second),
+			Txs:    feeBoundaryBytes,
+		})
+		require.NoError(t, processErr)
+		require.Equal(t, abci.ResponseProcessProposal_REJECT, processed.Status)
+		require.Equal(t, before, proposalSnapshot())
+	})
+
+	t.Run("proposal enforces the consensus block gas budget", func(t *testing.T) {
+		overBudget := [][]byte{proposalEthereumBytes, proposalEthereumBytes}
+		prepared, prepareErr := application.PrepareProposal(&abci.RequestPrepareProposal{
+			Height:     2,
+			Time:       blockTime.Add(2 * time.Second),
+			MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+			Txs:        overBudget,
+		})
+		require.NoError(t, prepareErr)
+		require.Equal(t, overBudget[:1], prepared.Txs)
+
+		processed, processErr := application.ProcessProposal(&abci.RequestProcessProposal{
+			Height: 2,
+			Time:   blockTime.Add(2 * time.Second),
+			Txs:    overBudget,
+		})
+		require.NoError(t, processErr)
+		require.Equal(t, abci.ResponseProcessProposal_REJECT, processed.Status)
+	})
+
+	t.Run("proposal rejects uint64 gas overflow when block gas is unlimited", func(t *testing.T) {
+		unlimitedConsensusParams := *simtestutil.DefaultConsensusParams
+		unlimitedBlockParams := *simtestutil.DefaultConsensusParams.Block
+		unlimitedBlockParams.MaxGas = -1
+		unlimitedConsensusParams.Block = &unlimitedBlockParams
+		handler := newStandardMsgSendProposalHandler(application)
+		baseProposalContext := committedContext(t, application).
+			WithBlockHeight(2).
+			WithBlockTime(blockTime.Add(2 * time.Second)).
+			WithConsensusParams(unlimitedConsensusParams)
+		overflowTxs := [][]byte{overflowEthereumBytes, overflowEthereumBytes}
+
+		prepared, prepareErr := handler.PrepareProposal(
+			baseProposalContext.WithExecMode(sdk.ExecModePrepareProposal),
+			&abci.RequestPrepareProposal{
+				Height:     2,
+				Time:       blockTime.Add(2 * time.Second),
+				MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+				Txs:        overflowTxs,
+			},
+		)
+		require.NoError(t, prepareErr)
+		require.Equal(t, overflowTxs[:1], prepared.Txs)
+
+		processedPrepared, processErr := handler.ProcessProposal(
+			baseProposalContext.WithExecMode(sdk.ExecModeProcessProposal),
+			&abci.RequestProcessProposal{
+				Height: 2,
+				Time:   blockTime.Add(2 * time.Second),
+				Txs:    prepared.Txs,
+			},
+		)
+		require.NoError(t, processErr)
+		require.Equal(t, abci.ResponseProcessProposal_ACCEPT, processedPrepared.Status)
+
+		processedOverflow, processErr := handler.ProcessProposal(
+			baseProposalContext.WithExecMode(sdk.ExecModeProcessProposal),
+			&abci.RequestProcessProposal{
+				Height: 2,
+				Time:   blockTime.Add(2 * time.Second),
+				Txs:    overflowTxs,
+			},
+		)
+		require.NoError(t, processErr)
+		require.Equal(t, abci.ResponseProcessProposal_REJECT, processedOverflow.Status)
+	})
+
 	for _, proposalTxs := range [][][]byte{
 		{proposalEthereumBytes, proposalCosmosBytes},
 		{proposalCosmosBytes, proposalEthereumBytes},
@@ -683,24 +1037,46 @@ func TestApplicationStateMachine(t *testing.T) {
 			Txs:        proposalTxs,
 		})
 		require.NoError(t, prepareErr)
-		require.Equal(t, proposalTxs[:1], proposalGasResult.Txs)
+		require.Equal(t, proposalTxs, proposalGasResult.Txs)
+
+		processed, processErr := application.ProcessProposal(&abci.RequestProcessProposal{
+			Height: 2,
+			Time:   blockTime.Add(2 * time.Second),
+			Txs:    proposalGasResult.Txs,
+		})
+		require.NoError(t, processErr)
+		require.Equal(t, abci.ResponseProcessProposal_ACCEPT, processed.Status)
 	}
 
 	require.Zero(t, application.FeeMarketKeeper.GetTransientGasWanted(
 		application.GetContextForCheckTx(nil),
 	))
 	for _, test := range []struct {
-		name    string
-		txBytes []byte
+		name            string
+		txBytes         []byte
+		gasWanted       uint64
+		simulateGasUsed uint64
+		checkGasUsed    int64
 	}{
-		{name: "ethereum", txBytes: ethereumBytes},
-		{name: "msgsend", txBytes: cosmosBytes},
+		{
+			name:            "ethereum",
+			txBytes:         ethereumBytes,
+			gasWanted:       submittedGas,
+			simulateGasUsed: ethereumGasUsed,
+		},
+		{
+			name:            "FixedSendGas MsgSend",
+			txBytes:         cosmosBytes,
+			gasWanted:       appante.StandardMsgSendGas,
+			simulateGasUsed: appante.StandardMsgSendGas,
+			checkGasUsed:    int64(appante.StandardMsgSendGas),
+		},
 	} {
 		t.Run(test.name+" gas queries", func(t *testing.T) {
 			gasInfo, _, simulateErr := application.Simulate(test.txBytes)
 			require.NoError(t, simulateErr)
-			require.Equal(t, submittedGas, gasInfo.GasWanted)
-			require.Equal(t, minimumGasUsed, gasInfo.GasUsed)
+			require.Equal(t, test.gasWanted, gasInfo.GasWanted)
+			require.Equal(t, test.simulateGasUsed, gasInfo.GasUsed)
 
 			checkResult, checkErr := application.CheckTx(&abci.RequestCheckTx{
 				Tx:   test.txBytes,
@@ -708,8 +1084,8 @@ func TestApplicationStateMachine(t *testing.T) {
 			})
 			require.NoError(t, checkErr)
 			require.Equal(t, abci.CodeTypeOK, checkResult.Code, checkResult.Log)
-			require.Equal(t, int64(submittedGas), checkResult.GasWanted)
-			require.Zero(t, checkResult.GasUsed)
+			require.Equal(t, int64(test.gasWanted), checkResult.GasWanted)
+			require.Equal(t, test.checkGasUsed, checkResult.GasUsed)
 			require.Zero(t, application.FeeMarketKeeper.GetTransientGasWanted(
 				application.GetContextForCheckTx(nil),
 			))
@@ -797,17 +1173,27 @@ func TestApplicationStateMachine(t *testing.T) {
 	require.Equal(t, sdkerrors.ErrInsufficientFee.ABCICode(), rejectedDynamicResult.Code)
 	require.Equal(t, int64(ordinaryDynamicFloorGas), rejectedDynamicResult.GasWanted)
 	require.Positive(t, rejectedDynamicResult.GasUsed)
-	for index, result := range finalized.TxResults[1:] {
-		require.True(t, result.IsOK(), result.Log)
-		require.Equal(t, int64(submittedGas), result.GasWanted)
-		require.Equal(t, int64(minimumGasUsed), result.GasUsed)
-		if index == 0 {
-			ethereumResult, decodeErr := evmtypes.DecodeTxResponse(result.Data)
-			require.NoError(t, decodeErr)
-			require.False(t, ethereumResult.Failed(), ethereumResult.VmError)
-			require.Equal(t, ethereumTx.Hash().Hex(), ethereumResult.Hash)
-		}
-	}
+	ethereumFinalizeResult := finalized.TxResults[1]
+	require.True(t, ethereumFinalizeResult.IsOK(), ethereumFinalizeResult.Log)
+	require.Equal(t, int64(submittedGas), ethereumFinalizeResult.GasWanted)
+	require.Equal(t, int64(ethereumGasUsed), ethereumFinalizeResult.GasUsed)
+	ethereumResult, decodeErr := evmtypes.DecodeTxResponse(ethereumFinalizeResult.Data)
+	require.NoError(t, decodeErr)
+	require.False(t, ethereumResult.Failed(), ethereumResult.VmError)
+	require.Equal(t, ethereumTx.Hash().Hex(), ethereumResult.Hash)
+
+	fixedSendFinalizeResult := finalized.TxResults[2]
+	require.True(t, fixedSendFinalizeResult.IsOK(), fixedSendFinalizeResult.Log)
+	require.Equal(t, int64(appante.StandardMsgSendGas), fixedSendFinalizeResult.GasWanted)
+	require.Equal(t, int64(appante.StandardMsgSendGas), fixedSendFinalizeResult.GasUsed)
+	requireFixedSendGasEvent(
+		t,
+		fixedSendFinalizeResult.Events,
+		submittedGas,
+		sdk.NewCoin(config.BaseDenom, submittedFee),
+		gasPrice.String(),
+		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, fixedSendActualFee)),
+	)
 	finalizeContext := application.GetContextForFinalizeBlock(nil)
 	require.Zero(t, application.FeeMarketKeeper.GetTransientGasWanted(finalizeContext))
 	expectedBlockGasWantedWithRejected := expectedBlockGasWanted + uint64(rejectedDynamicResult.GasUsed)
@@ -820,16 +1206,22 @@ func TestApplicationStateMachine(t *testing.T) {
 	require.NoError(t, err)
 
 	queryContext = committedContext(t, application)
-	expectedSenderBalance := senderFunds.AmountOf(config.BaseDenom).
+	expectedEthereumSenderBalance := senderFunds.AmountOf(config.BaseDenom).
 		Sub(sdkmath.NewIntFromBigInt(transferValue)).
-		Sub(protocolFee)
-	for _, sender := range []sdk.AccAddress{ethereumSender, cosmosSender} {
-		require.True(t, application.BankKeeper.GetBalance(
-			queryContext,
-			sender,
-			config.BaseDenom,
-		).Amount.Equal(expectedSenderBalance))
-	}
+		Sub(ethereumProtocolFee)
+	expectedCosmosSenderBalance := senderFunds.AmountOf(config.BaseDenom).
+		Sub(sdkmath.NewIntFromBigInt(transferValue)).
+		Sub(fixedSendActualFee)
+	require.True(t, application.BankKeeper.GetBalance(
+		queryContext,
+		ethereumSender,
+		config.BaseDenom,
+	).Amount.Equal(expectedEthereumSenderBalance))
+	require.True(t, application.BankKeeper.GetBalance(
+		queryContext,
+		cosmosSender,
+		config.BaseDenom,
+	).Amount.Equal(expectedCosmosSenderBalance))
 	for _, recipient := range []common.Address{ethereumRecipient, cosmosRecipient} {
 		require.True(t, application.BankKeeper.GetBalance(
 			queryContext,
@@ -862,9 +1254,42 @@ func TestApplicationStateMachine(t *testing.T) {
 			Data:     common.FromHex("0x60006000fd"),
 		}),
 	)
+	const blockedTransferAmount int64 = 9_876
+	blockedFixedBytes := signAndEncodeCosmosTx(
+		t,
+		application,
+		cosmosPrivateKey,
+		cosmosSenderAccount.GetAccountNumber(),
+		1,
+		banktypes.NewMsgSend(
+			cosmosSender,
+			erc20ModuleAccount.GetAddress(),
+			sdk.NewCoins(sdk.NewInt64Coin(config.BaseDenom, blockedTransferAmount)),
+		),
+		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, submittedFee)),
+		submittedGas,
+	)
+	blockedProcessResult, err := application.ProcessProposal(&abci.RequestProcessProposal{
+		Height: 3,
+		Time:   blockTime.Add(3 * time.Second),
+		Txs:    [][]byte{revertBytes, blockedFixedBytes},
+	})
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, blockedProcessResult.Status)
+
 	senderBalanceBeforeRevert := application.BankKeeper.GetBalance(
 		queryContext,
 		ethereumSender,
+		config.BaseDenom,
+	)
+	senderBalanceBeforeBlocked := application.BankKeeper.GetBalance(
+		queryContext,
+		cosmosSender,
+		config.BaseDenom,
+	)
+	blockedBalanceBefore := application.BankKeeper.GetBalance(
+		queryContext,
+		erc20ModuleAccount.GetAddress(),
 		config.BaseDenom,
 	)
 	finalized = finalizeAndCommit(
@@ -873,14 +1298,27 @@ func TestApplicationStateMachine(t *testing.T) {
 		3,
 		blockTime.Add(3*time.Second),
 		proposerAddress,
-		[][]byte{revertBytes},
+		[][]byte{revertBytes, blockedFixedBytes},
 	)
-	require.Len(t, finalized.TxResults, 1)
+	require.Len(t, finalized.TxResults, 2)
 	require.True(t, finalized.TxResults[0].IsOK(), finalized.TxResults[0].Log)
 	revertResult, err := evmtypes.DecodeTxResponse(finalized.TxResults[0].Data)
 	require.NoError(t, err)
 	require.True(t, revertResult.Failed())
 	require.Equal(t, ethvm.ErrExecutionReverted.Error(), revertResult.VmError)
+	blockedFixedResult := finalized.TxResults[1]
+	require.False(t, blockedFixedResult.IsOK(), blockedFixedResult.Log)
+	require.Contains(t, blockedFixedResult.Log, "not allowed to receive funds")
+	require.Equal(t, int64(appante.StandardMsgSendGas), blockedFixedResult.GasWanted)
+	require.Equal(t, int64(appante.StandardMsgSendGas), blockedFixedResult.GasUsed)
+	requireFixedSendGasEvent(
+		t,
+		blockedFixedResult.Events,
+		submittedGas,
+		sdk.NewCoin(config.BaseDenom, submittedFee),
+		gasPrice.String(),
+		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, fixedSendActualFee)),
+	)
 
 	queryContext = committedContext(t, application)
 	createdContract := ethcrypto.CreateAddress(senderEVMAddress, 1)
@@ -904,14 +1342,193 @@ func TestApplicationStateMachine(t *testing.T) {
 	expectedRevertFee := sdkmath.NewIntFromUint64(revertResult.GasUsed).
 		Mul(sdkmath.NewIntFromBigInt(revertGasPrice))
 	require.True(t, revertCharge.Equal(expectedRevertFee))
+	senderBalanceAfterBlocked := application.BankKeeper.GetBalance(
+		queryContext,
+		cosmosSender,
+		config.BaseDenom,
+	)
+	require.True(t, senderBalanceBeforeBlocked.Amount.Sub(senderBalanceAfterBlocked.Amount).Equal(
+		fixedSendActualFee,
+	))
+	require.Equal(t, blockedBalanceBefore, application.BankKeeper.GetBalance(
+		queryContext,
+		erc20ModuleAccount.GetAddress(),
+		config.BaseDenom,
+	))
+	require.Equal(t, uint64(2), application.AccountKeeper.GetAccount(
+		queryContext,
+		cosmosSender,
+	).GetSequence())
+	require.Equal(
+		t,
+		uint64(revertResult.GasUsed)+appante.StandardMsgSendGas,
+		application.FeeMarketKeeper.GetBlockGasWanted(queryContext),
+	)
 	require.Equal(t, int64(3), application.LastBlockHeight())
+
+	messageEffectContext := committedContext(t, application)
+	messageEffectSenderBefore := application.BankKeeper.GetBalance(
+		messageEffectContext,
+		cosmosSender,
+		config.BaseDenom,
+	)
+	messageEffectRecipientBefore := application.BankKeeper.GetBalance(
+		messageEffectContext,
+		sdk.AccAddress(cosmosRecipient.Bytes()),
+		config.BaseDenom,
+	)
+	messageEffectSequence := application.AccountKeeper.GetAccount(
+		messageEffectContext,
+		cosmosSender,
+	).GetSequence()
+	depletingTransfer := messageEffectSenderBefore.Amount.Sub(submittedFee)
+	require.True(t, depletingTransfer.IsPositive())
+	depletingFixedBytes := signAndEncodeCosmosTx(
+		t,
+		application,
+		cosmosPrivateKey,
+		cosmosSenderAccount.GetAccountNumber(),
+		messageEffectSequence,
+		banktypes.NewMsgSend(
+			cosmosSender,
+			sdk.AccAddress(cosmosRecipient.Bytes()),
+			sdk.NewCoins(sdk.NewCoin(config.BaseDenom, depletingTransfer)),
+		),
+		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, submittedFee)),
+		submittedGas,
+	)
+	dependentFixedBytes := signAndEncodeCosmosTx(
+		t,
+		application,
+		cosmosPrivateKey,
+		cosmosSenderAccount.GetAccountNumber(),
+		messageEffectSequence+1,
+		banktypes.NewMsgSend(
+			cosmosSender,
+			sdk.AccAddress(cosmosRecipient.Bytes()),
+			sdk.NewCoins(sdk.NewInt64Coin(config.BaseDenom, 1)),
+		),
+		sdk.NewCoins(sdk.NewCoin(config.BaseDenom, submittedFee)),
+		submittedGas,
+	)
+	// Proposal admission ignores the first MsgSend and admits both transactions.
+	// Finalize executes it, leaving submittedFee-actualFee and causing the second
+	// transaction's transfer-plus-submitted-fee check to fail per transaction.
+	messageEffectProposal := [][]byte{depletingFixedBytes, dependentFixedBytes}
+	messageEffectSnapshot := proposalSnapshot()
+	preparedMessageEffect, err := application.PrepareProposal(&abci.RequestPrepareProposal{
+		Height:     4,
+		Time:       blockTime.Add(4 * time.Second),
+		MaxTxBytes: simtestutil.DefaultConsensusParams.Block.MaxBytes,
+		Txs:        messageEffectProposal,
+	})
+	require.NoError(t, err)
+	require.Equal(t, messageEffectProposal, preparedMessageEffect.Txs)
+	require.Equal(t, messageEffectSnapshot, proposalSnapshot())
+	processedMessageEffect, err := application.ProcessProposal(&abci.RequestProcessProposal{
+		Height: 4,
+		Time:   blockTime.Add(4 * time.Second),
+		Txs:    messageEffectProposal,
+	})
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, processedMessageEffect.Status)
+	require.Equal(t, messageEffectSnapshot, proposalSnapshot())
+
+	finalized = finalizeAndCommit(
+		t,
+		application,
+		4,
+		blockTime.Add(4*time.Second),
+		proposerAddress,
+		messageEffectProposal,
+	)
+	require.Len(t, finalized.TxResults, 2)
+	require.True(t, finalized.TxResults[0].IsOK(), finalized.TxResults[0].Log)
+	require.Equal(t, int64(appante.StandardMsgSendGas), finalized.TxResults[0].GasWanted)
+	require.Equal(t, int64(appante.StandardMsgSendGas), finalized.TxResults[0].GasUsed)
+	dependentFixedResult := finalized.TxResults[1]
+	require.False(t, dependentFixedResult.IsOK(), dependentFixedResult.Log)
+	require.Equal(
+		t,
+		sdkerrors.ErrInsufficientFunds.ABCICode(),
+		dependentFixedResult.Code,
+	)
+	require.Contains(t, dependentFixedResult.Log, "FixedSendGas spendable balance")
+	require.Equal(t, int64(appante.StandardMsgSendGas), dependentFixedResult.GasWanted)
+	require.Equal(t, int64(appante.StandardMsgSendGas), dependentFixedResult.GasUsed)
+	requireNoFixedSendGasEvent(t, dependentFixedResult.Events)
+
+	queryContext = committedContext(t, application)
+	require.True(t, application.BankKeeper.GetBalance(
+		queryContext,
+		cosmosSender,
+		config.BaseDenom,
+	).Amount.Equal(
+		messageEffectSenderBefore.Amount.
+			Sub(fixedSendActualFee).
+			Sub(depletingTransfer),
+	))
+	require.True(t, application.BankKeeper.GetBalance(
+		queryContext,
+		sdk.AccAddress(cosmosRecipient.Bytes()),
+		config.BaseDenom,
+	).Amount.Equal(messageEffectRecipientBefore.Amount.Add(depletingTransfer)))
+	require.Equal(t, messageEffectSequence+1, application.AccountKeeper.GetAccount(
+		queryContext,
+		cosmosSender,
+	).GetSequence())
+	require.Equal(
+		t,
+		appante.StandardMsgSendGas,
+		application.FeeMarketKeeper.GetBlockGasWanted(queryContext),
+	)
+	require.Equal(t, int64(4), application.LastBlockHeight())
 
 	exported, err := application.ExportAppStateAndValidators(false, nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, int64(4), exported.Height)
+	require.Equal(t, int64(5), exported.Height)
 	var exportedGenesis GenesisState
 	require.NoError(t, json.Unmarshal(exported.AppState, &exportedGenesis))
 	require.NoError(t, application.ValidateGenesis(exportedGenesis))
+}
+
+func requireFixedSendGasEvent(
+	t *testing.T,
+	events []abci.Event,
+	declaredGas uint64,
+	submittedFee sdk.Coin,
+	effectiveGasPrice string,
+	actualFee sdk.Coins,
+) {
+	t.Helper()
+
+	var fixedEvent *abci.Event
+	for index := range events {
+		if events[index].Type == appante.EventTypeFixedSendGas {
+			fixedEvent = &events[index]
+			break
+		}
+	}
+	require.NotNil(t, fixedEvent)
+
+	attributes := make(map[string]string, len(fixedEvent.Attributes))
+	for _, attribute := range fixedEvent.Attributes {
+		attributes[attribute.Key] = attribute.Value
+	}
+	require.Equal(t, map[string]string{
+		appante.AttributeKeyDeclaredGas:       new(big.Int).SetUint64(declaredGas).String(),
+		appante.AttributeKeyAccountingGas:     new(big.Int).SetUint64(appante.StandardMsgSendGas).String(),
+		appante.AttributeKeySubmittedFee:      submittedFee.String(),
+		appante.AttributeKeyEffectiveGasPrice: effectiveGasPrice,
+		appante.AttributeKeyActualFee:         actualFee.String(),
+	}, attributes)
+}
+
+func requireNoFixedSendGasEvent(t *testing.T, events []abci.Event) {
+	t.Helper()
+	for _, event := range events {
+		require.NotEqual(t, appante.EventTypeFixedSendGas, event.Type)
+	}
 }
 
 func assertOracleFeeMarketProductionWiring(

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -131,7 +131,7 @@ func (app *App) unmarshalGenesis(
 }
 
 // ValidateGenesis delegates structural validation to the wired modules and
-// then enforces Guru's cross-module self-bond and FeeMarket policies.
+// then enforces Guru's consensus-critical cross-module policies.
 func (app *App) ValidateGenesis(genesis GenesisState) error {
 	if err := app.BasicModuleManager.ValidateGenesis(
 		app.AppCodec(),
@@ -144,6 +144,9 @@ func (app *App) ValidateGenesis(genesis GenesisState) error {
 		return err
 	}
 	if err := app.validateFeeMarketGenesisPolicy(genesis); err != nil {
+		return err
+	}
+	if err := app.validateEVMGenesisDenomPolicy(genesis); err != nil {
 		return err
 	}
 	return nil
@@ -303,6 +306,36 @@ func (app *App) validateFeeMarketGenesisPolicy(genesis GenesisState) error {
 	}
 	if !params.MinGasPrice.IsPositive() {
 		return fmt.Errorf("feemarket min_gas_price must be positive, got %s", params.MinGasPrice.String())
+	}
+
+	return nil
+}
+
+func (app *App) validateEVMGenesisDenomPolicy(genesis GenesisState) error {
+	evmGenesis := evmtypes.DefaultGenesisState()
+	if raw, ok := genesis[evmtypes.ModuleName]; ok {
+		if err := app.AppCodec().UnmarshalJSON(raw, evmGenesis); err != nil {
+			return fmt.Errorf("decode evm genesis: %w", err)
+		}
+	}
+
+	if evmGenesis.Params.EvmDenom != config.BaseDenom {
+		return fmt.Errorf(
+			"evm evm_denom must be immutable config base denom %q, got %q",
+			config.BaseDenom,
+			evmGenesis.Params.EvmDenom,
+		)
+	}
+	extendedDenomOptions := evmGenesis.Params.ExtendedDenomOptions
+	if extendedDenomOptions == nil {
+		return fmt.Errorf("evm extended_denom_options cannot be nil")
+	}
+	if extendedDenomOptions.ExtendedDenom != config.BaseDenom {
+		return fmt.Errorf(
+			"evm extended_denom must be immutable config base denom %q, got %q",
+			config.BaseDenom,
+			extendedDenomOptions.ExtendedDenom,
+		)
 	}
 
 	return nil

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -11,12 +11,13 @@ import (
 )
 
 func (app *App) configureAnteHandler(maxTxGasWanted uint64) error {
+	feeMarketKeeper := appante.NewProspectiveFeeMarketParamsAdapter(app.FeeMarketKeeper)
 	options := evmante.HandlerOptions{
 		Cdc:                    app.AppCodec(),
 		AccountKeeper:          app.AccountKeeper,
 		BankKeeper:             app.BankKeeper,
 		IBCKeeper:              app.IBCKeeper,
-		FeeMarketKeeper:        app.FeeMarketKeeper,
+		FeeMarketKeeper:        feeMarketKeeper,
 		EvmKeeper:              app.EVMKeeper,
 		FeegrantKeeper:         app.FeeGrantKeeper,
 		ExtensionOptionChecker: anteevmtypes.HasDynamicFeeExtensionOption,

--- a/app/oracle_consensus.go
+++ b/app/oracle_consensus.go
@@ -4,22 +4,17 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 	oracleabci "github.com/gurufinglobal/guru/v2/x/oracle/abci"
 	"github.com/spf13/cast"
 )
 
 func (app *App) configureOracleConsensus(appOptions AppOptions) error {
-	proposalHandler := baseapp.NewDefaultProposalHandler(
-		sdkmempool.NoOpMempool{},
-		app.BaseApp,
-	)
+	proposalHandler := newStandardMsgSendProposalHandler(app)
 	aggregator := oracleabci.NewAggregator(app.OracleKeeper, app.StakingKeeper)
 	oracleProposalHandler := oracleabci.NewProposalHandler(
 		aggregator,
-		proposalHandler.PrepareProposalHandler(),
-		proposalHandler.ProcessProposalHandler(),
+		proposalHandler.PrepareProposal,
+		proposalHandler.ProcessProposal,
 	)
 	app.SetPrepareProposal(oracleProposalHandler.PrepareProposal)
 	app.SetProcessProposal(oracleProposalHandler.ProcessProposal)

--- a/app/standard_msgsend_proposal.go
+++ b/app/standard_msgsend_proposal.go
@@ -1,0 +1,246 @@
+package app
+
+import (
+	"fmt"
+	"math"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	appante "github.com/gurufinglobal/guru/v2/app/ante"
+)
+
+// standardMsgSendProposalHandler preserves the SDK NoOp proposal semantics for
+// ordinary transactions while enforcing consensus admission and G-based block
+// accounting for bounded FixedSendGas transactions. Proposal admission uses the
+// H-1 committed state, the target-height MGP already committed by H-1 EndBlock,
+// the proposal-time projected BaseFee, and prior successful ante writes only.
+// Target-height PreBlock, BeginBlock, and message effects are deliberately
+// excluded. Oracle proposal records are handled by the outer Oracle proposal
+// handler and never reach this handler.
+type standardMsgSendProposalHandler struct {
+	app        *App
+	classifier appante.StandardMsgSendClassifier
+}
+
+func newStandardMsgSendProposalHandler(app *App) *standardMsgSendProposalHandler {
+	return &standardMsgSendProposalHandler{
+		app:        app,
+		classifier: appante.NewStandardMsgSendClassifier(app.AccountKeeper),
+	}
+}
+
+// PrepareProposal keeps CometBFT's input order and original transaction bytes.
+// A proposer drops malformed or invalid FixedSendGas candidates locally. It
+// never returns a per-transaction error because BaseApp falls back to the
+// unfiltered request when a PrepareProposal handler returns an error.
+func (h *standardMsgSendProposalHandler) PrepareProposal(
+	ctx sdk.Context,
+	req *abci.RequestPrepareProposal,
+) (*abci.ResponsePrepareProposal, error) {
+	if req == nil || req.MaxTxBytes <= 0 {
+		return &abci.ResponsePrepareProposal{}, nil
+	}
+
+	maxBlockGas := proposalMaxBlockGas(ctx)
+	selected := make([][]byte, 0, len(req.Txs))
+	var totalBytes int64
+	var totalGas uint64
+
+	for _, txBytes := range req.Txs {
+		tx, err := h.decodeTx(txBytes)
+		if err != nil {
+			continue
+		}
+
+		txCtx := ctx.WithTxBytes(txBytes)
+		fixed, err := h.classifier.ClassifyProposal(txCtx, tx)
+		if err != nil {
+			continue
+		}
+
+		txSize := cmttypes.ComputeProtoSizeForTxs([]cmttypes.Tx{txBytes})
+		if !proposalBytesFit(totalBytes, txSize, req.MaxTxBytes) {
+			continue
+		}
+
+		txGas, err := proposalAccountingGas(tx, fixed)
+		if err != nil || !proposalGasFits(totalGas, txGas, maxBlockGas) {
+			continue
+		}
+
+		// Run the exact production ante handler against the original bytes. An
+		// ordinary ante error does not change NoOp inclusion semantics, while a
+		// FixedSendGas admission error removes the candidate. Successful ante state
+		// alone advances the ephemeral PrepareProposal snapshot.
+		anteErr := h.runAnte(txCtx, tx)
+		if fixed && anteErr != nil {
+			continue
+		}
+
+		selected = append(selected, txBytes)
+		totalBytes += txSize
+		totalGas += txGas
+
+		if totalBytes >= req.MaxTxBytes ||
+			(maxBlockGas > 0 && totalGas >= maxBlockGas) {
+			break
+		}
+	}
+
+	return &abci.ResponsePrepareProposal{Txs: selected}, nil
+}
+
+// ProcessProposal rejects the complete proposal when any normal transaction is
+// malformed, any FixedSendGas candidate fails classification or admission, or
+// the mixed ordinary/FSG accounting gas exceeds the consensus block budget.
+// Decode-valid ordinary ante errors retain the configured NoOp semantics.
+func (h *standardMsgSendProposalHandler) ProcessProposal(
+	ctx sdk.Context,
+	req *abci.RequestProcessProposal,
+) (*abci.ResponseProcessProposal, error) {
+	if req == nil {
+		return rejectStandardMsgSendProposal(), nil
+	}
+
+	maxBlockGas := proposalMaxBlockGas(ctx)
+	var totalGas uint64
+
+	for _, txBytes := range req.Txs {
+		tx, err := h.decodeTx(txBytes)
+		if err != nil {
+			return rejectStandardMsgSendProposal(), nil
+		}
+
+		txCtx := ctx.WithTxBytes(txBytes)
+		fixed, err := h.classifier.ClassifyProposal(txCtx, tx)
+		if err != nil {
+			return rejectStandardMsgSendProposal(), nil
+		}
+
+		txGas, err := proposalAccountingGas(tx, fixed)
+		if err != nil || !proposalGasFits(totalGas, txGas, maxBlockGas) {
+			return rejectStandardMsgSendProposal(), nil
+		}
+		totalGas += txGas
+
+		// Successful ante writes advance the ephemeral proposal snapshot in tx
+		// order. PreBlock, BeginBlock, and message effects are intentionally absent;
+		// ordinary ante errors remain acceptable, while FixedSendGas ante errors
+		// invalidate the proposal.
+		anteErr := h.runAnte(txCtx, tx)
+		if fixed && anteErr != nil {
+			return rejectStandardMsgSendProposal(), nil
+		}
+	}
+
+	return &abci.ResponseProcessProposal{
+		Status: abci.ResponseProcessProposal_ACCEPT,
+	}, nil
+}
+
+func (h *standardMsgSendProposalHandler) decodeTx(txBytes []byte) (tx sdk.Tx, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			tx = nil
+			err = fmt.Errorf("panic while decoding proposal transaction: %v", recovered)
+		}
+	}()
+	tx, err = h.app.TxDecode(txBytes)
+	if err != nil {
+		return nil, err
+	}
+	if tx == nil {
+		return nil, fmt.Errorf("proposal transaction decoder returned nil")
+	}
+	return tx, nil
+}
+
+// runAnte advances only successful ante writes in the non-persistent proposal
+// snapshot. It intentionally does not execute messages or the target-height
+// PreBlock/BeginBlock lifecycle; those effects belong exclusively to
+// FinalizeBlock and any resulting message failure remains per-transaction.
+func (h *standardMsgSendProposalHandler) runAnte(
+	ctx sdk.Context,
+	tx sdk.Tx,
+) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic while validating proposal transaction: %v", recovered)
+		}
+	}()
+
+	if h.app.anteHandler == nil {
+		return fmt.Errorf("proposal ante handler is not configured")
+	}
+	msgs := tx.GetMsgs()
+	if len(msgs) == 0 {
+		return fmt.Errorf("proposal transaction must contain at least one message")
+	}
+	for _, msg := range msgs {
+		if msg == nil {
+			return fmt.Errorf("proposal transaction contains a nil message")
+		}
+		if basic, ok := msg.(sdk.HasValidateBasic); ok {
+			if err := basic.ValidateBasic(); err != nil {
+				return err
+			}
+		}
+		if h.app.MsgServiceRouter().Handler(msg) == nil {
+			return fmt.Errorf("no proposal message handler found for %T", msg)
+		}
+	}
+
+	anteCtx, write := ctx.CacheContext()
+	anteCtx = anteCtx.WithEventManager(sdk.NewEventManager())
+	_, err = h.app.anteHandler(anteCtx, tx, false)
+	if err != nil {
+		return err
+	}
+	write()
+	return nil
+}
+
+func proposalAccountingGas(tx sdk.Tx, fixed bool) (gas uint64, err error) {
+	if fixed {
+		return appante.StandardMsgSendGas, nil
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			gas = 0
+			err = fmt.Errorf("panic while reading proposal transaction gas: %v", recovered)
+		}
+	}()
+	if gasTx, ok := tx.(baseapp.GasTx); ok {
+		return gasTx.GetGas(), nil
+	}
+	return 0, nil
+}
+
+func proposalMaxBlockGas(ctx sdk.Context) uint64 {
+	block := ctx.ConsensusParams().Block
+	if block == nil || block.MaxGas <= 0 {
+		return 0
+	}
+	return uint64(block.MaxGas)
+}
+
+func proposalBytesFit(total, txSize, max int64) bool {
+	return txSize >= 0 && total >= 0 && total <= max && txSize <= max-total
+}
+
+func proposalGasFits(total, txGas, max uint64) bool {
+	if total > math.MaxUint64-txGas {
+		return false
+	}
+	return max == 0 || (total <= max && txGas <= max-total)
+}
+
+func rejectStandardMsgSendProposal() *abci.ResponseProcessProposal {
+	return &abci.ResponseProcessProposal{
+		Status: abci.ResponseProcessProposal_REJECT,
+	}
+}


### PR DESCRIPTION
# Description

This PR introduces a deterministic FixedSendGas policy for eligible Cosmos SDK `MsgSend` transactions.

Eligible transactions retain their original signed gas limit `D` and raw transaction bytes, while using a fixed accounting gas value of `G = 21,000` for:

- transaction gas reporting;
- block gas consumption;
- proposal gas budgeting;
- FeeMarket gas contribution; and
- actual fee settlement.

The submitted gas limit remains part of the signed transaction and is used as the fee-cap denominator. Given submitted fee `F`, the implementation computes the effective gas price without intermediate decimal rounding and deducts:

`actualFee = ceil(effectivePrice × 21,000)`

The FixedSendGas classifier is intentionally narrow. It applies only to transactions that contain a single positive native-denom `MsgSend`, use a supported single-signature key, do not use fee grants, fit within the 2,048-byte raw transaction limit, and satisfy the declared gas and extension-option requirements. Transactions outside this class continue through the ordinary Cosmos or Ethereum ante path.

This PR also:

- introduces proposal-time accounting that budgets FixedSendGas transactions at exactly `21,000` gas and ordinary transactions at their signed gas limit;
- evaluates FixedSendGas proposal admission against the projected target-height BaseFee;
- preserves the Oracle proposal payload wrapper and reserves its byte budget before selecting normal transactions;
- applies successful ante writes to an ephemeral proposal snapshot without executing messages, `PreBlock`, or `BeginBlock`;
- rejects malformed transactions, invalid FixedSendGas admission, gas overflow, and block gas budget violations during `ProcessProposal`;
- validates the configured EVM denom fields during genesis validation;
- adds FixedSendGas observability events; and
- documents the resulting fee, gas, mempool, and proposal behavior.

## Critical files to review

- `app/ante/standard_msgsend_gas.go`
  - FixedSendGas classification and staged `21,000` gas meter.
- `app/ante/standard_msgsend_fee.go`
  - Exact effective-price calculation, affordability checks, fee deduction, and FeeMarket gas contribution.
- `app/ante/handler.go`
  - FixedSendGas routing, ordinary Cosmos fallback, and prospective BaseFee adapter.
- `app/standard_msgsend_proposal.go`
  - Mixed FixedSendGas/ordinary proposal selection, admission, and block gas accounting.
- `app/oracle_consensus.go`
  - Integration of the proposal handler with the Oracle proposal wrapper.
- `app/genesis.go`
  - EVM denom genesis policy.
- `app/app_test.go` and `app/ante/standard_msgsend_test.go`
  - Production wiring, proposal lifecycle, exact arithmetic, gas accounting, and regression coverage.

## How to review

1. Confirm that only the bounded single-native-`MsgSend` class enters the FixedSendGas path.
2. Confirm that ordinary Cosmos transactions and Ethereum transactions preserve their existing ante semantics.
3. Verify the distinction between signed declared gas `D` and consensus accounting gas `G = 21,000`.
4. Verify that fee-cap admission uses `F / D`, while actual fee settlement uses `ceil(effectivePrice × G)`.
5. Check that failed FixedSendGas ante execution does not consume block gas, while successful ante execution consumes exactly `21,000`, including when message execution later fails.
6. Check that proposal handling uses the original transaction bytes, prevents gas overflow, and applies only successful ante writes to its ephemeral state.
7. Confirm that the Oracle payload remains outside normal transaction classification and gas accounting.

## Validation

The following checks passed:

- `GOWORK=off go test -mod=readonly ./app/ante -count=1`
- `GOWORK=off go test -mod=readonly ./app -run '^TestApplicationStateMachine$' -count=1`
- `GOWORK=off go test -mod=readonly ./... -count=1`
- `GOWORK=off go test -race -mod=readonly ./app/ante ./app -count=1`
- `GOWORK=off go vet -mod=readonly ./...`
- `GOWORK=off go -C oracle test -mod=readonly ./... -count=1`
- `git diff --check`
- `gofmt -d` on all changed Go files

## Current review blocker

This PR currently enforces the EVM denom invariant during genesis validation only. Before marking the PR ready for review, the runtime `MsgUpdateParams` path must also reject changes to `EvmDenom`, nil `ExtendedDenomOptions`, and changes to `ExtendedDenom`.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member — Add the relevant issue or discussion link.
- [x] left instructions on how to review the changes
- [ ] targeted the `main` branch — Not applicable: this PR targets `dev-v2.1`.

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md` — Not yet added.
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code — Not applicable: this PR intentionally changes consensus-critical production code.
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed