### PR TITLE
feat: support zero-height genesis export

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -195,6 +195,13 @@ func (app *App) InitChainer(
 	if err := app.ValidateGenesisAtHeight(genesis, initialHeight); err != nil {
 		return nil, err
 	}
+	if err := app.ValidateGenesisConsensusAtHeight(
+		genesis,
+		initialHeight,
+		req.ConsensusParams,
+	); err != nil {
+		return nil, fmt.Errorf("validate consensus-dependent genesis state: %w", err)
+	}
 	if err := app.UpgradeKeeper.SetModuleVersionMap(ctx, app.ModuleManager.GetVersionMap()); err != nil {
 		return nil, fmt.Errorf("set module version map: %w", err)
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -20,6 +20,7 @@ import (
 	evidencetypes "cosmossdk.io/x/evidence/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmttypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
@@ -36,6 +37,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	antetypes "github.com/cosmos/evm/ante/types"
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
@@ -138,8 +140,9 @@ func TestApplicationStateMachine(t *testing.T) {
 	cosmosSender := sdk.AccAddress(cosmosPrivateKey.PubKey().Address())
 	ethereumRecipient := common.HexToAddress("0x000000000000000000000000000000000000bEEF")
 	cosmosRecipient := common.HexToAddress("0x000000000000000000000000000000000000CAfE")
-	validatorSet, err := simtestutil.CreateRandomValidatorSet()
-	require.NoError(t, err)
+	validatorSet := cmttypes.NewValidatorSet([]*cmttypes.Validator{
+		cmttypes.NewValidator(exportRuntimeValidatorKey().PubKey(), 1),
+	})
 	proposerAddress := validatorSet.GetProposer().Address
 
 	genesis := application.DefaultGenesis()
@@ -359,6 +362,17 @@ func TestApplicationStateMachine(t *testing.T) {
 	require.Empty(t, erc20Genesis.NativePrecompiles)
 	require.Empty(t, erc20Genesis.DynamicPrecompiles)
 
+	// GenesisStateWithValSet supplies an already-bonded synthetic validator,
+	// so the bonding hook does not create its signing info. Include the state
+	// a real gentx-created validator has before testing CometBFT restarts.
+	slashingGenesis := new(slashingtypes.GenesisState)
+	application.AppCodec().MustUnmarshalJSON(genesis[slashingtypes.ModuleName], slashingGenesis)
+	consensusAddress := sdk.ConsAddress(proposerAddress)
+	slashingGenesis.SigningInfos = []slashingtypes.SigningInfo{{
+		Address:              consensusAddress.String(),
+		ValidatorSigningInfo: slashingtypes.NewValidatorSigningInfo(consensusAddress, 0, 0, time.Unix(0, 0), false, 0),
+	}}
+	genesis[slashingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(slashingGenesis)
 	genesisBytes, err := json.Marshal(genesis)
 	require.NoError(t, err)
 	blockTime := time.Unix(1_700_000_000, 0).UTC()
@@ -1497,12 +1511,7 @@ func TestApplicationStateMachine(t *testing.T) {
 	)
 	require.Equal(t, int64(4), application.LastBlockHeight())
 
-	exported, err := application.ExportAppStateAndValidators(false, nil, nil)
-	require.NoError(t, err)
-	require.Equal(t, int64(5), exported.Height)
-	var exportedGenesis GenesisState
-	require.NoError(t, json.Unmarshal(exported.AppState, &exportedGenesis))
-	require.NoError(t, application.ValidateGenesis(exportedGenesis))
+	testApplicationExport(t, application, blockTime, committedConsensusParams, &applicationLog, cosmosSender)
 
 	t.Run("missed minimum gas price schedule is discarded by the application end blocker", func(t *testing.T) {
 		committedHeight := application.LastBlockHeight()

--- a/app/export.go
+++ b/app/export.go
@@ -1,34 +1,142 @@
 package app
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"time"
 
+	sdkmath "cosmossdk.io/math"
+	"cosmossdk.io/store/rootmulti"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	connectiontypes "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	commitmenttypes "github.com/cosmos/ibc-go/v10/modules/core/23-commitment/types"
+	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
+	ibccoretypes "github.com/cosmos/ibc-go/v10/modules/core/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethparams "github.com/ethereum/go-ethereum/params"
+
+	constitutiontypes "github.com/gurufinglobal/guru/v2/x/constitution/types"
+	oracletypes "github.com/gurufinglobal/guru/v2/x/oracle/types"
 )
 
-// ExportAppStateAndValidators exports the currently loaded state at the next
-// genesis height. Zero-height state rewriting is deliberately not implicit;
-// it requires staking, distribution, and slashing transformations that are
-// outside Guru's supported export path.
+const zeroHeightEffectiveInitialHeight int64 = 1
+
+// ValidateExportRequest validates flag relationships before any application or
+// consensus database is opened.
+func ValidateExportRequest(
+	forZeroHeight bool,
+	jailAllowedAddrs []string,
+	modulesToExport []string,
+) error {
+	if !forZeroHeight && len(jailAllowedAddrs) != 0 {
+		return fmt.Errorf("jail allowlist requires zero-height export")
+	}
+	if forZeroHeight && len(modulesToExport) != 0 {
+		return fmt.Errorf("zero-height export requires a complete module export")
+	}
+	return nil
+}
+
+// zeroHeightExportReceipt is emitted through the structured application logger.
+// It contains only deterministic counts and committed heights so independently
+// generated receipts can be compared directly.
+type zeroHeightExportReceipt struct {
+	SourceHeight               int64
+	Validators                 int
+	Delegations                int
+	UnbondingEntriesReset      int
+	RedelegationEntriesReset   int
+	SigningInfosReset          int
+	MissedBlockWindowsReset    int
+	OracleTasksPreserved       int
+	OracleSchedulesRemoved     int
+	OracleLatestValuesRemoved  int
+	OracleHistoriesRemoved     int
+	ConstitutionPendingRemoved int
+	EVMHistorySlotsRemoved     int
+	RewardPayoutRecipients     int
+	AuthAccountsCreated        int
+	RewardPayoutTotal          string
+	CurrentMinGasPrice         string
+}
+
+// zeroHeightMutationWitness records the exact side effects returned by the
+// upstream keepers while the isolated transformation runs. It is deliberately
+// not serialized: it exists only to prove that the exported source-to-target
+// delta is the one the keepers actually produced.
+type zeroHeightMutationWitness struct {
+	RewardPayouts         map[string]sdk.Coins
+	NewRewardAccounts     []string
+	JailAllowlistApplied  bool
+	JailAllowedValidators map[string]struct{}
+	StakingValidators     map[string]stakingtypes.Validator
+}
+
+// ExportAppStateAndValidators exports the currently loaded state. A zero-height
+// export is built in a nested cache context and is never written back to the
+// source application's committed or check state.
 func (app *App) ExportAppStateAndValidators(
 	forZeroHeight bool,
 	jailAllowedAddrs []string,
 	modulesToExport []string,
-) (servertypes.ExportedApp, error) {
-	if forZeroHeight {
-		return servertypes.ExportedApp{}, fmt.Errorf("zero-height export is not supported")
-	}
-	if len(jailAllowedAddrs) != 0 {
-		return servertypes.ExportedApp{}, fmt.Errorf("jail allowlist requires zero-height export")
-	}
+) (exported servertypes.ExportedApp, err error) {
+	// Some upstream module exporters still panic on corrupt state. Convert those
+	// panics at the operator boundary so a failed transform cannot be mistaken
+	// for a completed genesis.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			exported = servertypes.ExportedApp{}
+			err = fmt.Errorf("export application state: %v", recovered)
+		}
+	}()
 
-	ctx := app.NewContextLegacy(true, cmtproto.Header{
-		Height:  app.LastBlockHeight(),
-		ChainID: app.ChainID(),
-	})
+	return app.exportAppStateAndValidators(
+		forZeroHeight,
+		jailAllowedAddrs,
+		modulesToExport,
+	)
+}
+
+func (app *App) exportAppStateAndValidators(
+	forZeroHeight bool,
+	jailAllowedAddrs []string,
+	modulesToExport []string,
+) (servertypes.ExportedApp, error) {
+	if err := ValidateExportRequest(forZeroHeight, jailAllowedAddrs, modulesToExport); err != nil {
+		return servertypes.ExportedApp{}, err
+	}
+	if app.LastBlockHeight() == math.MaxInt64 {
+		return servertypes.ExportedApp{}, fmt.Errorf("source height cannot be incremented")
+	}
+	nextHeight := app.LastBlockHeight() + 1
+
+	ctx, err := app.newExportContext(forZeroHeight)
+	if err != nil {
+		return servertypes.ExportedApp{}, err
+	}
+	consensusParams := app.GetConsensusParams(ctx)
+	if forZeroHeight {
+		return app.exportZeroHeightGenesis(ctx, jailAllowedAddrs, consensusParams)
+	}
 	genesis, err := app.ModuleManager.ExportGenesisForModules(ctx, app.AppCodec(), modulesToExport)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
@@ -40,19 +148,2064 @@ func (app *App) ExportAppStateAndValidators(
 			return servertypes.ExportedApp{}, fmt.Errorf("validate exported application state: %w", err)
 		}
 	}
-	appState, err := json.MarshalIndent(genesis, "", "  ")
+
+	return app.marshalExportedApp(
+		ctx,
+		GenesisState(genesis),
+		nextHeight,
+		consensusParams,
+	)
+}
+
+// newExportContext uses only the loaded application store. Zero-height validator
+// recalculation can begin unbonding, so it needs the committed block time rather
+// than wall-clock time or a zero timestamp. No CometBFT database is consulted.
+func (app *App) newExportContext(forZeroHeight bool) (sdk.Context, error) {
+	header := cmtproto.Header{Height: app.LastBlockHeight(), ChainID: app.ChainID()}
+	if forZeroHeight {
+		store, ok := app.CommitMultiStore().(*rootmulti.Store)
+		if !ok {
+			return sdk.Context{}, fmt.Errorf("application store does not expose commit metadata")
+		}
+		info, err := store.GetCommitInfo(header.Height)
+		if err != nil {
+			return sdk.Context{}, fmt.Errorf("load application commit metadata at height %d: %w", header.Height, err)
+		}
+		if info == nil || info.Version != header.Height || info.Timestamp.IsZero() {
+			return sdk.Context{}, fmt.Errorf("application commit time is unavailable at height %d", header.Height)
+		}
+		header.Time = info.Timestamp
+	}
+	return app.NewContextLegacy(true, header), nil
+}
+
+func (app *App) exportZeroHeightGenesis(
+	sourceCtx sdk.Context,
+	jailAllowedAddrs []string,
+	consensusParams cmtproto.ConsensusParams,
+) (servertypes.ExportedApp, error) {
+	if app.LastBlockHeight() == math.MaxInt64 {
+		return servertypes.ExportedApp{}, fmt.Errorf("source height cannot be incremented")
+	}
+
+	sourceGenesis, err := app.ModuleManager.ExportGenesisForModules(sourceCtx, app.AppCodec(), nil)
+	if err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("export source application state: %w", err)
+	}
+	sourceState := GenesisState(sourceGenesis)
+	if err := app.ValidateGenesisAtHeight(sourceState, app.LastBlockHeight()+1); err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("validate source application state: %w", err)
+	}
+	if err := app.validateExportInvariants(sourceState); err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("validate source export invariants: %w", err)
+	}
+	if err := app.validateZeroHeightPreflight(sourceCtx, sourceState); err != nil {
+		return servertypes.ExportedApp{}, err
+	}
+
+	// Never call writeCache: all reward settlement and staking/slashing rewrites
+	// remain isolated from the live DB and BaseApp's reusable check state.
+	targetCtx, _ := sourceCtx.CacheContext()
+	receipt, witness, err := app.prepareZeroHeightState(targetCtx, jailAllowedAddrs)
+	if err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("prepare zero-height state: %w", err)
+	}
+
+	targetGenesis, err := app.ModuleManager.ExportGenesisForModules(targetCtx, app.AppCodec(), nil)
+	if err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("export transformed application state: %w", err)
+	}
+	targetState := GenesisState(targetGenesis)
+	if err := app.transformZeroHeightGenesis(targetState, &receipt); err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("transform zero-height genesis: %w", err)
+	}
+	if err := app.ValidateGenesisAtHeight(targetState, zeroHeightEffectiveInitialHeight); err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("validate zero-height application state: %w", err)
+	}
+	// Oracle activation and initial schedules are validated after target launch configuration.
+	// ValidateGenesisAtHeight already checks the target export invariants.
+	if err := app.validateZeroHeightEconomicContinuity(sourceState, targetState, witness); err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("validate zero-height economic continuity: %w", err)
+	}
+
+	// Cosmos SDK writes initial_height=0 for --for-zero-height. CometBFT
+	// normalizes that sentinel to the effective first block height I=1.
+	exported, err := app.marshalExportedApp(targetCtx, targetState, 0, consensusParams)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
+	receipt.SourceHeight = app.LastBlockHeight()
+	feeMarket := new(feemarkettypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(targetState[feemarkettypes.ModuleName], feeMarket); err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("decode target feemarket receipt state: %w", err)
+	}
+	receipt.CurrentMinGasPrice = feeMarket.Params.MinGasPrice.String()
+	app.logZeroHeightExportReceipt(receipt)
+	return exported, nil
+}
+
+func (app *App) marshalExportedApp(
+	ctx sdk.Context,
+	genesis GenesisState,
+	height int64,
+	consensusParams cmtproto.ConsensusParams,
+) (servertypes.ExportedApp, error) {
+	appState, err := json.MarshalIndent(genesis, "", "  ")
+	if err != nil {
+		return servertypes.ExportedApp{}, fmt.Errorf("marshal application state: %w", err)
+	}
 	validators, err := staking.WriteValidators(ctx, app.StakingKeeper)
 	if err != nil {
-		return servertypes.ExportedApp{}, err
+		return servertypes.ExportedApp{}, fmt.Errorf("write genesis validators: %w", err)
 	}
 
 	return servertypes.ExportedApp{
 		AppState:        appState,
 		Validators:      validators,
-		Height:          app.LastBlockHeight() + 1,
-		ConsensusParams: app.GetConsensusParams(ctx),
+		Height:          height,
+		ConsensusParams: consensusParams,
 	}, nil
+}
+
+func (app *App) logZeroHeightExportReceipt(receipt zeroHeightExportReceipt) {
+	app.Logger().Info(
+		"zero-height application-state transformation completed",
+		"source_height", receipt.SourceHeight,
+		"effective_initial_height", zeroHeightEffectiveInitialHeight,
+		"validators", receipt.Validators,
+		"delegations", receipt.Delegations,
+		"unbonding_entries_reset", receipt.UnbondingEntriesReset,
+		"redelegation_entries_reset", receipt.RedelegationEntriesReset,
+		"signing_infos_reset", receipt.SigningInfosReset,
+		"missed_block_windows_reset", receipt.MissedBlockWindowsReset,
+		"oracle_tasks_preserved", receipt.OracleTasksPreserved,
+		"oracle_schedules_removed", receipt.OracleSchedulesRemoved,
+		"oracle_latest_values_removed", receipt.OracleLatestValuesRemoved,
+		"oracle_histories_removed", receipt.OracleHistoriesRemoved,
+		"evm_history_slots_removed", receipt.EVMHistorySlotsRemoved,
+		"constitution_pending_removed", receipt.ConstitutionPendingRemoved,
+		"reward_payout_recipients", receipt.RewardPayoutRecipients,
+		"auth_accounts_created", receipt.AuthAccountsCreated,
+		"reward_payout_total", receipt.RewardPayoutTotal,
+		"current_min_gas_price", receipt.CurrentMinGasPrice,
+		"chain_id", app.ChainID(),
+		"evm_chain_id", app.EVMChainID(),
+	)
+}
+
+// prepareZeroHeightState adapts Cosmos SDK v0.53.6 simapp/export.go to Guru's
+// keeper graph. Standard state changes use upstream keeper APIs. The approved
+// specification additionally requires errors instead of process exits, a
+// discarded cache, payout receipts, and a fresh slashing missed-block window.
+func (app *App) prepareZeroHeightState(
+	ctx sdk.Context,
+	jailAllowedAddrs []string,
+) (zeroHeightExportReceipt, zeroHeightMutationWitness, error) {
+	receipt := zeroHeightExportReceipt{}
+	witness := zeroHeightMutationWitness{RewardPayouts: make(map[string]sdk.Coins)}
+	witness.JailAllowlistApplied = len(jailAllowedAddrs) != 0
+	validators, err := app.StakingKeeper.GetAllValidators(ctx)
+	if err != nil {
+		return receipt, witness, fmt.Errorf("list validators: %w", err)
+	}
+	delegations, err := app.StakingKeeper.GetAllDelegations(ctx)
+	if err != nil {
+		return receipt, witness, fmt.Errorf("list delegations: %w", err)
+	}
+	receipt.Validators = len(validators)
+	receipt.Delegations = len(delegations)
+
+	allowed, err := app.validateJailAllowlist(ctx, validators, jailAllowedAddrs)
+	if err != nil {
+		return receipt, witness, err
+	}
+	witness.JailAllowedValidators = allowed
+	recordPayout := func(
+		recipient sdk.AccAddress,
+		amount sdk.Coins,
+		accountMissingBefore bool,
+	) error {
+		if amount.IsZero() {
+			return nil
+		}
+		address, err := app.AccountKeeper.AddressCodec().BytesToString(recipient)
+		if err != nil {
+			return fmt.Errorf("encode reward recipient: %w", err)
+		}
+		witness.RewardPayouts[address] = witness.RewardPayouts[address].Add(amount...)
+		if accountMissingBefore {
+			witness.NewRewardAccounts = append(witness.NewRewardAccounts, address)
+		}
+		return nil
+	}
+
+	// Settle all distributable integral rewards before rebuilding the reward
+	// periods. A missing commission is the only expected non-fatal condition.
+	for _, validator := range validators {
+		validatorAddr, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(
+			validator.GetOperator(),
+		)
+		if err != nil {
+			return receipt, witness, fmt.Errorf("decode validator %q: %w", validator.GetOperator(), err)
+		}
+		recipient, err := app.DistrKeeper.GetDelegatorWithdrawAddr(
+			ctx,
+			sdk.AccAddress(validatorAddr),
+		)
+		if err != nil {
+			return receipt, witness, fmt.Errorf(
+				"read validator %s commission withdrawal address: %w",
+				validator.GetOperator(),
+				err,
+			)
+		}
+		accountMissingBefore := app.AccountKeeper.GetAccount(ctx, recipient) == nil
+		amount, err := app.DistrKeeper.WithdrawValidatorCommission(ctx, validatorAddr)
+		if err != nil && !errors.Is(err, distrtypes.ErrNoValidatorCommission) {
+			return receipt, witness, fmt.Errorf(
+				"withdraw validator %s commission: %w",
+				validator.GetOperator(),
+				err,
+			)
+		}
+		if err == nil {
+			if err := recordPayout(recipient, amount, accountMissingBefore); err != nil {
+				return receipt, witness, err
+			}
+		}
+	}
+	for _, delegation := range delegations {
+		validatorAddr, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(
+			delegation.ValidatorAddress,
+		)
+		if err != nil {
+			return receipt, witness, fmt.Errorf(
+				"decode delegation validator %q: %w",
+				delegation.ValidatorAddress,
+				err,
+			)
+		}
+		delegatorAddr, err := app.AccountKeeper.AddressCodec().StringToBytes(
+			delegation.DelegatorAddress,
+		)
+		if err != nil {
+			return receipt, witness, fmt.Errorf("decode delegator %q: %w", delegation.DelegatorAddress, err)
+		}
+		recipient, err := app.DistrKeeper.GetDelegatorWithdrawAddr(ctx, delegatorAddr)
+		if err != nil {
+			return receipt, witness, fmt.Errorf(
+				"read delegation %s/%s withdrawal address: %w",
+				delegation.DelegatorAddress,
+				delegation.ValidatorAddress,
+				err,
+			)
+		}
+		accountMissingBefore := app.AccountKeeper.GetAccount(ctx, recipient) == nil
+		amount, err := app.DistrKeeper.WithdrawDelegationRewards(
+			ctx,
+			delegatorAddr,
+			validatorAddr,
+		)
+		if err != nil {
+			return receipt, witness, fmt.Errorf(
+				"withdraw delegation rewards for %s/%s: %w",
+				delegation.DelegatorAddress,
+				delegation.ValidatorAddress,
+				err,
+			)
+		}
+		if err := recordPayout(recipient, amount, accountMissingBefore); err != nil {
+			return receipt, witness, err
+		}
+	}
+	rewardPayoutTotal := sdk.NewCoins()
+	for _, payout := range witness.RewardPayouts {
+		rewardPayoutTotal = rewardPayoutTotal.Add(payout...)
+	}
+	receipt.RewardPayoutRecipients = len(witness.RewardPayouts)
+	receipt.AuthAccountsCreated = len(witness.NewRewardAccounts)
+	receipt.RewardPayoutTotal = rewardPayoutTotal.String()
+
+	app.DistrKeeper.DeleteAllValidatorSlashEvents(ctx)
+	app.DistrKeeper.DeleteAllValidatorHistoricalRewards(ctx)
+
+	zeroCtx := ctx.WithBlockHeight(0)
+	for _, validator := range validators {
+		validatorAddr, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(
+			validator.GetOperator(),
+		)
+		if err != nil {
+			return receipt, witness, fmt.Errorf("decode validator %q: %w", validator.GetOperator(), err)
+		}
+		scraps, err := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(zeroCtx, validatorAddr)
+		if err != nil {
+			return receipt, witness, fmt.Errorf(
+				"read validator %s outstanding rewards: %w",
+				validator.GetOperator(),
+				err,
+			)
+		}
+		feePool, err := app.DistrKeeper.FeePool.Get(zeroCtx)
+		if err != nil {
+			return receipt, witness, fmt.Errorf("read distribution fee pool: %w", err)
+		}
+		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
+		if err := app.DistrKeeper.FeePool.Set(zeroCtx, feePool); err != nil {
+			return receipt, witness, fmt.Errorf("write distribution fee pool: %w", err)
+		}
+		if err := app.DistrKeeper.Hooks().AfterValidatorCreated(zeroCtx, validatorAddr); err != nil {
+			return receipt, witness, fmt.Errorf(
+				"reinitialize validator %s rewards: %w",
+				validator.GetOperator(),
+				err,
+			)
+		}
+	}
+	for _, delegation := range delegations {
+		validatorAddr, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(
+			delegation.ValidatorAddress,
+		)
+		if err != nil {
+			return receipt, witness, fmt.Errorf(
+				"decode delegation validator %q: %w",
+				delegation.ValidatorAddress,
+				err,
+			)
+		}
+		delegatorAddr, err := app.AccountKeeper.AddressCodec().StringToBytes(
+			delegation.DelegatorAddress,
+		)
+		if err != nil {
+			return receipt, witness, fmt.Errorf("decode delegator %q: %w", delegation.DelegatorAddress, err)
+		}
+		if err := app.DistrKeeper.Hooks().BeforeDelegationCreated(
+			zeroCtx,
+			delegatorAddr,
+			validatorAddr,
+		); err != nil {
+			return receipt, witness, fmt.Errorf("reinitialize delegation period: %w", err)
+		}
+		if err := app.DistrKeeper.Hooks().AfterDelegationModified(
+			zeroCtx,
+			delegatorAddr,
+			validatorAddr,
+		); err != nil {
+			return receipt, witness, fmt.Errorf("reinitialize delegation rewards: %w", err)
+		}
+	}
+
+	if err := app.prepareZeroHeightStaking(ctx, validators, allowed, &receipt, &witness); err != nil {
+		return receipt, witness, err
+	}
+
+	var callbackErr error
+	if err := app.SlashingKeeper.IterateValidatorSigningInfos(
+		ctx,
+		func(address sdk.ConsAddress, info slashingtypes.ValidatorSigningInfo) bool {
+			info.StartHeight = 0
+			info.IndexOffset = 0
+			info.MissedBlocksCounter = 0
+			if err := app.SlashingKeeper.SetValidatorSigningInfo(ctx, address, info); err != nil {
+				callbackErr = err
+				return true
+			}
+			if err := app.SlashingKeeper.DeleteMissedBlockBitmap(ctx, address); err != nil {
+				callbackErr = err
+				return true
+			}
+			receipt.SigningInfosReset++
+			receipt.MissedBlockWindowsReset++
+			return false
+		},
+	); err != nil {
+		return receipt, witness, fmt.Errorf("iterate validator signing infos: %w", err)
+	}
+	if callbackErr != nil {
+		return receipt, witness, fmt.Errorf("reset validator signing state: %w", callbackErr)
+	}
+
+	return receipt, witness, nil
+}
+
+func (app *App) validateJailAllowlist(
+	ctx sdk.Context,
+	validators []stakingtypes.Validator,
+	jailAllowedAddrs []string,
+) (map[string]struct{}, error) {
+	if len(jailAllowedAddrs) == 0 {
+		return nil, nil
+	}
+	validatorsByOperator := make(map[string]stakingtypes.Validator, len(validators))
+	for _, validator := range validators {
+		validatorsByOperator[validator.GetOperator()] = validator
+	}
+
+	allowed := make(map[string]struct{}, len(jailAllowedAddrs))
+	for _, address := range jailAllowedAddrs {
+		addressBytes, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(address)
+		if err != nil {
+			return nil, fmt.Errorf("invalid jail-allowlist validator address %q: %w", address, err)
+		}
+		canonical, err := app.StakingKeeper.ValidatorAddressCodec().BytesToString(addressBytes)
+		if err != nil {
+			return nil, fmt.Errorf("encode jail-allowlist validator address %q: %w", address, err)
+		}
+		if _, duplicate := allowed[canonical]; duplicate {
+			return nil, fmt.Errorf("duplicate jail-allowlist validator address %q", canonical)
+		}
+		validator, found := validatorsByOperator[canonical]
+		if !found {
+			return nil, fmt.Errorf(
+				"jail-allowlist address %q does not identify an exported validator",
+				canonical,
+			)
+		}
+		consensusAddress, err := validator.GetConsAddr()
+		if err != nil {
+			return nil, fmt.Errorf("derive consensus address for validator %q: %w", canonical, err)
+		}
+		if app.SlashingKeeper.IsTombstoned(ctx, consensusAddress) {
+			return nil, fmt.Errorf("jail-allowlist cannot unjail tombstoned validator %q", canonical)
+		}
+		allowed[canonical] = struct{}{}
+	}
+	return allowed, nil
+}
+
+// prepareZeroHeightStaking follows the staking section of Cosmos SDK v0.53.6
+// simapp/export.go. Pending entries survive with zero creation heights; their
+// amounts, completion times, IDs and hold references remain owned by upstream.
+// Guru adds only its existing minimum-self-bond validator-set filter.
+func (app *App) prepareZeroHeightStaking(
+	ctx sdk.Context,
+	validators []stakingtypes.Validator,
+	allowed map[string]struct{},
+	receipt *zeroHeightExportReceipt,
+	witness *zeroHeightMutationWitness,
+) error {
+	var callbackErr error
+	if err := app.StakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) bool {
+		for i := range red.Entries {
+			red.Entries[i].CreationHeight = 0
+			receipt.RedelegationEntriesReset++
+		}
+		callbackErr = app.StakingKeeper.SetRedelegation(ctx, red)
+		return callbackErr != nil
+	}); err != nil {
+		return fmt.Errorf("iterate redelegations: %w", err)
+	}
+	if callbackErr != nil {
+		return fmt.Errorf("reset redelegation creation heights: %w", callbackErr)
+	}
+	if err := app.StakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) bool {
+		for i := range ubd.Entries {
+			ubd.Entries[i].CreationHeight = 0
+			receipt.UnbondingEntriesReset++
+		}
+		callbackErr = app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
+		return callbackErr != nil
+	}); err != nil {
+		return fmt.Errorf("iterate unbonding delegations: %w", err)
+	}
+	if callbackErr != nil {
+		return fmt.Errorf("reset unbonding creation heights: %w", callbackErr)
+	}
+
+	for _, validator := range validators {
+		if len(allowed) == 0 || validator.Jailed {
+			continue
+		}
+		if _, included := allowed[validator.OperatorAddress]; included {
+			continue
+		}
+		// The upstream allowlist only jails excluded validators. It does not
+		// unjail included validators. Jail also maintains the power index.
+		consensusAddress, err := validator.GetConsAddr()
+		if err != nil {
+			return fmt.Errorf("derive validator %s consensus address: %w", validator.OperatorAddress, err)
+		}
+		if err := app.StakingKeeper.Jail(ctx, consensusAddress); err != nil {
+			return fmt.Errorf("jail excluded validator %s: %w", validator.OperatorAddress, err)
+		}
+	}
+
+	// Retain the source time and queue keys while the SDK performs transitions,
+	// including rebonding an unbonding validator or starting a new unbonding.
+	if _, err := app.CustomStakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx); err != nil {
+		return fmt.Errorf("recalculate Guru validator set: %w", err)
+	}
+	updated, err := app.StakingKeeper.GetAllValidators(ctx)
+	if err != nil {
+		return fmt.Errorf("list recalculated validators: %w", err)
+	}
+	witness.StakingValidators = make(map[string]stakingtypes.Validator, len(updated))
+	for _, validator := range updated {
+		// Normalize after recalculation so newly unbonding validators also have
+		// height zero. Use upstream queue APIs to keep the isolated cache
+		// consistent with the height that InitGenesis will import.
+		if validator.IsUnbonding() {
+			if err := app.StakingKeeper.DeleteValidatorQueue(ctx, validator); err != nil {
+				return fmt.Errorf("remove source-height validator queue: %w", err)
+			}
+		}
+		validator.UnbondingHeight = 0
+		if err := app.StakingKeeper.SetValidator(ctx, validator); err != nil {
+			return fmt.Errorf("reset validator %s unbonding height: %w", validator.OperatorAddress, err)
+		}
+		if validator.IsUnbonding() {
+			if err := app.StakingKeeper.InsertUnbondingValidatorQueue(ctx, validator); err != nil {
+				return fmt.Errorf("insert zero-height validator queue: %w", err)
+			}
+		}
+		witness.StakingValidators[validator.OperatorAddress] = validator
+	}
+	return nil
+}
+
+func (app *App) validateExportInvariants(genesis GenesisState) error {
+	if err := app.validateStakingExportInvariants(genesis); err != nil {
+		return fmt.Errorf("staking: %w", err)
+	}
+	if err := app.validateDistributionExportInvariants(genesis); err != nil {
+		return fmt.Errorf("distribution: %w", err)
+	}
+	return nil
+}
+
+// validateStakingExportInvariants checks the read-only export assertions required
+// by the zero-height specification. Pool accounting matches SDK v0.53.6
+// staking/keeper.InitGenesis; this does not add staking lifecycle rules or
+// reconstruct upstream store indexes. The SDK's lightweight ValidateGenesis
+// does not compare bank and staking genesis documents.
+func (app *App) validateStakingExportInvariants(genesis GenesisState) error {
+	stakingGenesis := new(stakingtypes.GenesisState)
+	raw, ok := genesis[stakingtypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("staking genesis is missing")
+	}
+	if err := app.AppCodec().UnmarshalJSON(raw, stakingGenesis); err != nil {
+		return fmt.Errorf("decode staking genesis: %w", err)
+	}
+	if !stakingGenesis.Exported {
+		return fmt.Errorf("staking genesis is not marked as exported state")
+	}
+
+	bankGenesis := new(banktypes.GenesisState)
+	raw, ok = genesis[banktypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("bank genesis is missing")
+	}
+	if err := app.AppCodec().UnmarshalJSON(raw, bankGenesis); err != nil {
+		return fmt.Errorf("decode bank genesis: %w", err)
+	}
+
+	validators := make(map[string]stakingtypes.Validator, len(stakingGenesis.Validators))
+	delegationShares := make(
+		map[string]sdkmath.LegacyDec,
+		len(stakingGenesis.Validators),
+	)
+	bondedTokens := sdkmath.ZeroInt()
+	notBondedTokens := sdkmath.ZeroInt()
+	for _, validator := range stakingGenesis.Validators {
+		operatorBytes, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(
+			validator.OperatorAddress,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"invalid validator operator address %q: %w",
+				validator.OperatorAddress,
+				err,
+			)
+		}
+		key := string(operatorBytes)
+		if _, duplicate := validators[key]; duplicate {
+			return fmt.Errorf("duplicate validator operator address %q", validator.OperatorAddress)
+		}
+		validators[key] = validator
+		delegationShares[key] = sdkmath.LegacyZeroDec()
+		if validator.IsBonded() {
+			bondedTokens = bondedTokens.Add(validator.Tokens)
+		} else {
+			notBondedTokens = notBondedTokens.Add(validator.Tokens)
+		}
+	}
+	for _, delegation := range stakingGenesis.Delegations {
+		validatorBytes, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(
+			delegation.ValidatorAddress,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"invalid delegation validator address %q: %w",
+				delegation.ValidatorAddress,
+				err,
+			)
+		}
+		key := string(validatorBytes)
+		if _, found := validators[key]; !found {
+			return fmt.Errorf(
+				"delegation references missing validator %q",
+				delegation.ValidatorAddress,
+			)
+		}
+		delegationShares[key] = delegationShares[key].Add(delegation.Shares)
+	}
+	// InitGenesis checks the not-bonded pool against both tokens owned by
+	// unbonded/unbonding validators and balances that have already left a
+	// validator but are still waiting in an unbonding-delegation entry.
+	for _, unbonding := range stakingGenesis.UnbondingDelegations {
+		_, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(
+			unbonding.ValidatorAddress,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"invalid unbonding-delegation validator address %q: %w",
+				unbonding.ValidatorAddress,
+				err,
+			)
+		}
+		// A fully removed validator may still have pending delegator withdrawals.
+		// Upstream InitGenesis restores those entries without requiring the
+		// validator record to survive.
+		for _, entry := range unbonding.Entries {
+			if entry.Balance.IsNegative() {
+				return fmt.Errorf(
+					"unbonding delegation for %s has negative balance %s",
+					unbonding.ValidatorAddress,
+					entry.Balance,
+				)
+			}
+			notBondedTokens = notBondedTokens.Add(entry.Balance)
+		}
+	}
+	validatorKeys := make([]string, 0, len(validators))
+	for key := range validators {
+		validatorKeys = append(validatorKeys, key)
+	}
+	sort.Strings(validatorKeys)
+	for _, key := range validatorKeys {
+		validator := validators[key]
+		if !delegationShares[key].Equal(validator.DelegatorShares) {
+			return fmt.Errorf(
+				"validator %s delegation shares %s do not equal validator shares %s",
+				validator.OperatorAddress,
+				delegationShares[key],
+				validator.DelegatorShares,
+			)
+		}
+	}
+
+	bondedPoolAddress, err := app.AccountKeeper.AddressCodec().BytesToString(
+		authtypes.NewModuleAddress(stakingtypes.BondedPoolName),
+	)
+	if err != nil {
+		return fmt.Errorf("encode bonded pool address: %w", err)
+	}
+	notBondedPoolAddress, err := app.AccountKeeper.AddressCodec().BytesToString(
+		authtypes.NewModuleAddress(stakingtypes.NotBondedPoolName),
+	)
+	if err != nil {
+		return fmt.Errorf("encode not-bonded pool address: %w", err)
+	}
+	balances := make(map[string]sdk.Coins, len(bankGenesis.Balances))
+	for _, balance := range bankGenesis.Balances {
+		balances[balance.Address] = balance.Coins
+	}
+	bondDenom := stakingGenesis.Params.BondDenom
+	expectedBondedBalance := coinsForExportAmount(bondDenom, bondedTokens)
+	if actual := balances[bondedPoolAddress]; !actual.Equal(expectedBondedBalance) {
+		return fmt.Errorf(
+			"bonded pool balance %s does not equal expected balance %s",
+			actual,
+			expectedBondedBalance,
+		)
+	}
+	expectedNotBondedBalance := coinsForExportAmount(bondDenom, notBondedTokens)
+	if actual := balances[notBondedPoolAddress]; !actual.Equal(expectedNotBondedBalance) {
+		return fmt.Errorf(
+			"not-bonded pool balance %s does not equal expected balance %s",
+			actual,
+			expectedNotBondedBalance,
+		)
+	}
+
+	lastPowers := make(map[string]int64, len(stakingGenesis.LastValidatorPowers))
+	totalPower := sdkmath.ZeroInt()
+	for _, lastPower := range stakingGenesis.LastValidatorPowers {
+		addressBytes, err := app.StakingKeeper.ValidatorAddressCodec().StringToBytes(
+			lastPower.Address,
+		)
+		if err != nil {
+			return fmt.Errorf("invalid last validator address %q: %w", lastPower.Address, err)
+		}
+		key := string(addressBytes)
+		if _, duplicate := lastPowers[key]; duplicate {
+			return fmt.Errorf("duplicate last validator power for %q", lastPower.Address)
+		}
+		validator, found := validators[key]
+		if !found {
+			return fmt.Errorf("last validator power references missing validator %q", lastPower.Address)
+		}
+		if !validator.IsBonded() {
+			return fmt.Errorf(
+				"last validator power references non-bonded validator %q",
+				lastPower.Address,
+			)
+		}
+		expectedPower := validator.ConsensusPower(sdk.DefaultPowerReduction)
+		if lastPower.Power != expectedPower {
+			return fmt.Errorf(
+				"validator %s last power %d does not equal token-derived power %d",
+				lastPower.Address,
+				lastPower.Power,
+				expectedPower,
+			)
+		}
+		lastPowers[key] = lastPower.Power
+		totalPower = totalPower.AddRaw(lastPower.Power)
+	}
+	for _, key := range validatorKeys {
+		validator := validators[key]
+		_, active := lastPowers[key]
+		if validator.IsBonded() != active {
+			return fmt.Errorf(
+				"validator %s bonded status does not match the exported active set",
+				validator.OperatorAddress,
+			)
+		}
+	}
+	if !stakingGenesis.LastTotalPower.Equal(totalPower) {
+		return fmt.Errorf(
+			"last total power %s does not equal validator power sum %s",
+			stakingGenesis.LastTotalPower,
+			totalPower,
+		)
+	}
+
+	return nil
+}
+
+func (app *App) validateDistributionExportInvariants(genesis GenesisState) error {
+	raw, ok := genesis[distrtypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("distribution genesis is missing")
+	}
+	distributionGenesis := new(distrtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, distributionGenesis); err != nil {
+		return fmt.Errorf("decode distribution genesis: %w", err)
+	}
+
+	raw, ok = genesis[banktypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("bank genesis is missing")
+	}
+	bankGenesis := new(banktypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, bankGenesis); err != nil {
+		return fmt.Errorf("decode bank genesis: %w", err)
+	}
+
+	var moduleHoldings sdk.DecCoins
+	for _, rewards := range distributionGenesis.OutstandingRewards {
+		moduleHoldings = moduleHoldings.Add(rewards.OutstandingRewards...)
+	}
+	moduleHoldings = moduleHoldings.Add(distributionGenesis.FeePool.CommunityPool...)
+	expectedBalance, _ := moduleHoldings.TruncateDecimal()
+
+	distributionAddress, err := app.AccountKeeper.AddressCodec().BytesToString(
+		authtypes.NewModuleAddress(distrtypes.ModuleName),
+	)
+	if err != nil {
+		return fmt.Errorf("encode distribution module address: %w", err)
+	}
+	actualBalance := sdk.NewCoins()
+	for _, balance := range bankGenesis.Balances {
+		if balance.Address == distributionAddress {
+			actualBalance = balance.Coins
+			break
+		}
+	}
+	if !actualBalance.Equal(expectedBalance) {
+		return fmt.Errorf(
+			"module balance %s does not equal community pool plus outstanding rewards %s",
+			actualBalance,
+			expectedBalance,
+		)
+	}
+	return nil
+}
+
+func coinsForExportAmount(denom string, amount sdkmath.Int) sdk.Coins {
+	if amount.IsZero() {
+		return sdk.NewCoins()
+	}
+	return sdk.NewCoins(sdk.NewCoin(denom, amount))
+}
+
+func (app *App) validateZeroHeightPreflight(ctx sdk.Context, genesis GenesisState) error {
+	if err := app.validateZeroHeightModuleInventory(genesis); err != nil {
+		return err
+	}
+	if err := app.validateNoActiveIBCLifecycle(ctx, genesis); err != nil {
+		return err
+	}
+	if err := app.validateNoActiveGovernance(genesis); err != nil {
+		return err
+	}
+	plan, err := app.UpgradeKeeper.GetUpgradePlan(ctx)
+	switch {
+	case err == nil:
+		return fmt.Errorf(
+			"zero-height export blocked by pending software upgrade %q at height %d",
+			plan.Name,
+			plan.Height,
+		)
+	case !errors.Is(err, upgradetypes.ErrNoUpgradePlanFound):
+		return fmt.Errorf("read pending software upgrade: %w", err)
+	}
+
+	return app.validateEVMHistoryContract(genesis, false)
+}
+
+var zeroHeightHandledGenesisModules = map[string]struct{}{
+	"07-tendermint": {},
+	"auth":          {},
+	"authz":         {},
+	"bank":          {},
+	"consensus":     {},
+	"constitution":  {},
+	"distribution":  {},
+	"erc20":         {},
+	"evidence":      {},
+	"evm":           {},
+	"feegrant":      {},
+	"feemarket":     {},
+	"genutil":       {},
+	"gov":           {},
+	"ibc":           {},
+	"mint":          {},
+	"oracle":        {},
+	"slashing":      {},
+	"staking":       {},
+	"transfer":      {},
+	"upgrade":       {},
+	"vesting":       {},
+}
+
+// Every mounted persistent store must either round-trip through the named
+// genesis document or have an explicit external owner. The consensus keeper's
+// store is the sole exception: canonical CometBFT consensus params are carried
+// in the top-level genesis document and validated separately.
+var zeroHeightPersistentStoreGenesis = map[string]string{
+	"acc":          "auth",
+	"authz":        "authz",
+	"bank":         "bank",
+	"consensus":    "",
+	"constitution": "constitution",
+	"distribution": "distribution",
+	"erc20":        "erc20",
+	"evidence":     "evidence",
+	"evm":          "evm",
+	"feegrant":     "feegrant",
+	"feemarket":    "feemarket",
+	"gov":          "gov",
+	"ibc":          "ibc",
+	"mint":         "mint",
+	"oracle":       "oracle",
+	"slashing":     "slashing",
+	"staking":      "staking",
+	"transfer":     "transfer",
+	"upgrade":      "upgrade",
+}
+
+// validateHandledZeroHeightModules makes future persistent modules fail closed
+// until their height/time semantics are explicitly added to this inventory.
+func validateHandledZeroHeightModules(genesis GenesisState) error {
+	undefined := make([]string, 0)
+	for moduleName := range genesis {
+		if _, ok := zeroHeightHandledGenesisModules[moduleName]; !ok {
+			undefined = append(undefined, moduleName)
+		}
+	}
+	if len(undefined) != 0 {
+		sort.Strings(undefined)
+		return fmt.Errorf("zero-height policy is undefined for modules %q", undefined)
+	}
+	return nil
+}
+
+func (app *App) validateZeroHeightModuleInventory(genesis GenesisState) error {
+	if err := validateHandledZeroHeightModules(genesis); err != nil {
+		return err
+	}
+
+	unknownModules := make([]string, 0)
+	for _, moduleName := range app.ModuleManager.ModuleNames() {
+		if _, ok := zeroHeightHandledGenesisModules[moduleName]; !ok {
+			unknownModules = append(unknownModules, moduleName)
+		}
+	}
+	if len(unknownModules) != 0 {
+		sort.Strings(unknownModules)
+		return fmt.Errorf("zero-height policy is undefined for registered modules %q", unknownModules)
+	}
+
+	mountedStores := app.GetKVStoreKeys()
+	unknownStores := make([]string, 0)
+	for storeName := range mountedStores {
+		if _, ok := zeroHeightPersistentStoreGenesis[storeName]; !ok {
+			unknownStores = append(unknownStores, storeName)
+		}
+	}
+	if len(unknownStores) != 0 {
+		sort.Strings(unknownStores)
+		return fmt.Errorf("zero-height policy is undefined for persistent stores %q", unknownStores)
+	}
+
+	policyOnlyStores := make([]string, 0)
+	missingDocuments := make([]string, 0)
+	for storeName, genesisName := range zeroHeightPersistentStoreGenesis {
+		if _, mounted := mountedStores[storeName]; !mounted {
+			policyOnlyStores = append(policyOnlyStores, storeName)
+			continue
+		}
+		if genesisName == "" {
+			continue
+		}
+		if _, exported := genesis[genesisName]; !exported {
+			missingDocuments = append(missingDocuments, genesisName)
+		}
+	}
+	if len(policyOnlyStores) != 0 {
+		sort.Strings(policyOnlyStores)
+		return fmt.Errorf("zero-height persistent-store policy is stale for stores %q", policyOnlyStores)
+	}
+	if len(missingDocuments) != 0 {
+		sort.Strings(missingDocuments)
+		return fmt.Errorf(
+			"zero-height export is missing genesis documents for persistent stores %q",
+			missingDocuments,
+		)
+	}
+	return nil
+}
+
+func (app *App) validateNoActiveIBCLifecycle(ctx sdk.Context, genesis GenesisState) error {
+	raw, ok := genesis["ibc"]
+	if !ok {
+		return fmt.Errorf("ibc genesis is missing")
+	}
+	state := new(ibccoretypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, state); err != nil {
+		return fmt.Errorf("decode ibc genesis: %w", err)
+	}
+
+	clients := state.ClientGenesis
+	connections := state.ConnectionGenesis
+	channels := state.ChannelGenesis
+	clientsV2 := state.ClientV2Genesis
+	channelsV2 := state.ChannelV2Genesis
+
+	unsafeClients := make([]string, 0)
+	for _, client := range clients.Clients {
+		status := app.IBCKeeper.ClientKeeper.GetClientStatus(ctx, client.ClientId)
+		switch status {
+		case ibcexported.Frozen, ibcexported.Expired:
+			// Terminal clients are historical state and are preserved unchanged.
+		case ibcexported.Active:
+			unsafeClients = append(unsafeClients, client.ClientId+"(Active)")
+		default:
+			// Unknown, unauthorized, and future statuses cannot be classified as
+			// safely terminal, so the fail-closed policy applies.
+			unsafeClients = append(unsafeClients, client.ClientId+"("+string(status)+")")
+		}
+	}
+
+	unsafeConnections := make([]string, 0)
+	localhostCounterparty := connectiontypes.NewCounterparty(
+		ibcexported.LocalhostClientID,
+		ibcexported.LocalhostConnectionID,
+		commitmenttypes.NewMerklePrefix(
+			app.IBCKeeper.ConnectionKeeper.GetCommitmentPrefix().Bytes(),
+		),
+	)
+	canonicalLocalhost := connectiontypes.NewIdentifiedConnection(
+		ibcexported.LocalhostConnectionID,
+		connectiontypes.NewConnectionEnd(
+			connectiontypes.OPEN,
+			ibcexported.LocalhostClientID,
+			localhostCounterparty,
+			connectiontypes.GetCompatibleVersions(),
+			0,
+		),
+	)
+	for _, connection := range connections.Connections {
+		// IBC-Go v10 always exports its stateless localhost connection. It is
+		// not external continuity state and is recreated by normal InitGenesis.
+		if connection.Id == ibcexported.LocalhostConnectionID {
+			if !reflect.DeepEqual(connection, canonicalLocalhost) {
+				unsafeConnections = append(
+					unsafeConnections,
+					ibcexported.LocalhostConnectionID+"(non-canonical)",
+				)
+			}
+			continue
+		}
+		unsafeConnections = append(
+			unsafeConnections,
+			fmt.Sprintf("%s(%s)", connection.Id, connection.State.String()),
+		)
+	}
+
+	unsafeChannels := make([]string, 0)
+	for _, channel := range channels.Channels {
+		if channel.State == channeltypes.CLOSED {
+			continue
+		}
+		unsafeChannels = append(
+			unsafeChannels,
+			fmt.Sprintf("%s/%s(%s)", channel.PortId, channel.ChannelId, channel.State.String()),
+		)
+	}
+
+	sort.Strings(unsafeClients)
+	sort.Strings(unsafeConnections)
+	sort.Strings(unsafeChannels)
+	if len(unsafeClients) != 0 || len(unsafeConnections) != 0 || len(unsafeChannels) != 0 ||
+		len(channels.Commitments) != 0 || len(clientsV2.CounterpartyInfos) != 0 ||
+		len(channelsV2.Commitments) != 0 || len(channelsV2.AsyncPackets) != 0 {
+		return fmt.Errorf(
+			"zero-height export blocked by active or unclassified IBC lifecycle state: "+
+				"clients=%v connections=%v channels=%v packet_commitments=%d "+
+				"v2_counterparties=%d v2_commitments=%d v2_async_packets=%d",
+			unsafeClients,
+			unsafeConnections,
+			unsafeChannels,
+			len(channels.Commitments),
+			len(clientsV2.CounterpartyInfos),
+			len(channelsV2.Commitments),
+			len(channelsV2.AsyncPackets),
+		)
+	}
+
+	return nil
+}
+
+func (app *App) validateNoActiveGovernance(genesis GenesisState) error {
+	raw, ok := genesis[govtypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("governance genesis is missing")
+	}
+	state := new(govv1.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, state); err != nil {
+		return fmt.Errorf("decode governance genesis: %w", err)
+	}
+	unsafe := make([]string, 0)
+	for _, proposal := range state.Proposals {
+		if proposal == nil {
+			return fmt.Errorf("governance genesis contains a nil proposal")
+		}
+		switch proposal.Status {
+		case govv1.StatusPassed, govv1.StatusRejected, govv1.StatusFailed:
+			// Terminal proposals are preserved unchanged.
+		default:
+			unsafe = append(unsafe, fmt.Sprintf("%d(%s)", proposal.Id, proposal.Status.String()))
+		}
+	}
+	if len(unsafe) != 0 {
+		sort.Strings(unsafe)
+		return fmt.Errorf("zero-height export blocked by active or unclassified governance proposals %v", unsafe)
+	}
+	return nil
+}
+
+func (app *App) validateEVMHistoryContract(genesis GenesisState, requireEmpty bool) error {
+	raw, ok := genesis[evmtypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("evm genesis is missing")
+	}
+	state := new(evmtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, state); err != nil {
+		return fmt.Errorf("decode evm genesis: %w", err)
+	}
+	found := false
+	for _, account := range state.Accounts {
+		if common.HexToAddress(account.Address) != ethparams.HistoryStorageAddress {
+			continue
+		}
+		if found {
+			return fmt.Errorf("EIP-2935 history contract account is duplicated")
+		}
+		found = true
+		if !bytes.Equal(common.FromHex(account.Code), ethparams.HistoryStorageCode) {
+			return fmt.Errorf(
+				"EIP-2935 history contract code does not match the configured implementation",
+			)
+		}
+		if requireEmpty && len(account.Storage) != 0 {
+			return fmt.Errorf(
+				"zero-height restart contains %d EIP-2935 history slots",
+				len(account.Storage),
+			)
+		}
+	}
+	if !found {
+		return fmt.Errorf("EIP-2935 history contract account is missing")
+	}
+	return nil
+}
+
+func (app *App) transformZeroHeightGenesis(
+	genesis GenesisState,
+	receipt *zeroHeightExportReceipt,
+) error {
+	if receipt == nil {
+		return fmt.Errorf("zero-height export receipt cannot be nil")
+	}
+
+	if err := app.transformZeroHeightOracle(genesis, receipt); err != nil {
+		return err
+	}
+	if err := app.transformZeroHeightConstitution(genesis, receipt); err != nil {
+		return err
+	}
+	return app.transformZeroHeightEVM(genesis, receipt)
+}
+
+// transformZeroHeightEVM clears only the canonical history contract's storage.
+// Decoding into a fresh value keeps the source export and committed stores intact.
+func (app *App) transformZeroHeightEVM(genesis GenesisState, receipt *zeroHeightExportReceipt) error {
+	if err := app.validateEVMHistoryContract(genesis, false); err != nil {
+		return err
+	}
+	state := new(evmtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(genesis[evmtypes.ModuleName], state); err != nil {
+		return err
+	}
+	for i := range state.Accounts {
+		account := &state.Accounts[i]
+		if common.HexToAddress(account.Address) == ethparams.HistoryStorageAddress {
+			receipt.EVMHistorySlotsRemoved = len(account.Storage)
+			account.Storage = nil
+		}
+	}
+	encoded, err := app.AppCodec().MarshalJSON(state)
+	if err != nil {
+		return err
+	}
+	genesis[evmtypes.ModuleName] = encoded
+	return nil
+}
+
+func (app *App) validateZeroHeightEVMContinuity(source, target GenesisState) error {
+	if err := app.validateEVMHistoryContract(target, true); err != nil {
+		return err
+	}
+	expected := GenesisState{evmtypes.ModuleName: source[evmtypes.ModuleName]}
+	if err := app.transformZeroHeightEVM(expected, new(zeroHeightExportReceipt)); err != nil {
+		return err
+	}
+	var expectedJSON, targetJSON interface{}
+	// Compare JSON structurally without converting numeric values to float64.
+	decode := func(raw []byte, value *interface{}) error {
+		decoder := json.NewDecoder(bytes.NewReader(raw))
+		decoder.UseNumber()
+		return decoder.Decode(value)
+	}
+	if err := decode(expected[evmtypes.ModuleName], &expectedJSON); err != nil {
+		return err
+	}
+	if err := decode(target[evmtypes.ModuleName], &targetJSON); err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(expectedJSON, targetJSON) {
+		return fmt.Errorf("EVM genesis changed outside the approved EIP-2935 history storage reset")
+	}
+	return nil
+}
+
+func (app *App) transformZeroHeightOracle(
+	genesis GenesisState,
+	receipt *zeroHeightExportReceipt,
+) error {
+	raw, ok := genesis[oracletypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("oracle genesis is missing")
+	}
+	state := new(oracletypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, state); err != nil {
+		return fmt.Errorf("decode oracle genesis: %w", err)
+	}
+	for _, task := range state.Tasks {
+		if task == nil {
+			return fmt.Errorf("oracle genesis contains a nil task")
+		}
+		if task.SubmissionInterval == 0 {
+			return fmt.Errorf("oracle task %q has zero submission_interval", task.Symbol)
+		}
+	}
+	receipt.OracleTasksPreserved = len(state.Tasks)
+	receipt.OracleSchedulesRemoved = len(state.TaskSchedule)
+	receipt.OracleLatestValuesRemoved = len(state.LatestValues)
+	receipt.OracleHistoriesRemoved = len(state.History)
+	state.TaskSchedule = nil
+	state.LatestValues = nil
+	state.History = nil
+
+	encoded, err := app.AppCodec().MarshalJSON(state)
+	if err != nil {
+		return fmt.Errorf("encode oracle genesis: %w", err)
+	}
+	genesis[oracletypes.ModuleName] = encoded
+	return nil
+}
+
+func (app *App) transformZeroHeightConstitution(
+	genesis GenesisState,
+	receipt *zeroHeightExportReceipt,
+) error {
+	raw, ok := genesis[constitutiontypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("constitution genesis is missing")
+	}
+	state := new(constitutiontypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, state); err != nil {
+		return fmt.Errorf("decode constitution genesis: %w", err)
+	}
+	if state.PendingMinGasPrice != nil {
+		receipt.ConstitutionPendingRemoved = 1
+	}
+	state.PendingMinGasPrice = nil
+	encoded, err := app.AppCodec().MarshalJSON(state)
+	if err != nil {
+		return fmt.Errorf("encode constitution genesis: %w", err)
+	}
+	genesis[constitutiontypes.ModuleName] = encoded
+	return nil
+}
+
+func (app *App) validateZeroHeightEconomicContinuity(
+	source,
+	target GenesisState,
+	witness zeroHeightMutationWitness,
+) error {
+	moduleNames := make([]string, 0, len(source))
+	for moduleName := range source {
+		moduleNames = append(moduleNames, moduleName)
+	}
+	sort.Strings(moduleNames)
+	for _, moduleName := range moduleNames {
+		sourceState := source[moduleName]
+		sourceDocument := bytes.TrimSpace(sourceState)
+		if len(sourceDocument) == 0 {
+			return fmt.Errorf("source module %q genesis is empty", moduleName)
+		}
+		if !json.Valid(sourceDocument) {
+			return fmt.Errorf("source module %q genesis is invalid JSON", moduleName)
+		}
+		if sourceDocument[0] != '{' {
+			return fmt.Errorf("source module %q genesis must be a JSON object", moduleName)
+		}
+		targetState, ok := target[moduleName]
+		if !ok {
+			return fmt.Errorf("module %q disappeared during zero-height export", moduleName)
+		}
+		targetDocument := bytes.TrimSpace(targetState)
+		if len(targetDocument) == 0 {
+			return fmt.Errorf("target module %q genesis is empty", moduleName)
+		}
+		if !json.Valid(targetDocument) {
+			return fmt.Errorf("target module %q genesis is invalid JSON", moduleName)
+		}
+		if targetDocument[0] != '{' {
+			return fmt.Errorf("target module %q genesis must be a JSON object", moduleName)
+		}
+	}
+	targetModuleNames := make([]string, 0)
+	for moduleName := range target {
+		if _, ok := source[moduleName]; !ok {
+			targetModuleNames = append(targetModuleNames, moduleName)
+		}
+	}
+	if len(targetModuleNames) != 0 {
+		sort.Strings(targetModuleNames)
+		return fmt.Errorf(
+			"zero-height export introduced modules %q",
+			targetModuleNames,
+		)
+	}
+
+	sourceBankRaw, ok := source[banktypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("source bank genesis is missing")
+	}
+	targetBankRaw, ok := target[banktypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("target bank genesis is missing")
+	}
+	sourceBank := new(banktypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(sourceBankRaw, sourceBank); err != nil {
+		return fmt.Errorf("decode source bank genesis: %w", err)
+	}
+	targetBank := new(banktypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(targetBankRaw, targetBank); err != nil {
+		return fmt.Errorf("decode target bank genesis: %w", err)
+	}
+	if !sourceBank.Supply.Equal(targetBank.Supply) {
+		return fmt.Errorf("total supply changed from %s to %s", sourceBank.Supply, targetBank.Supply)
+	}
+	if err := validateZeroHeightBankContinuity(sourceBank, targetBank); err != nil {
+		return err
+	}
+	if err := app.validateZeroHeightBankMovements(
+		sourceBank,
+		targetBank,
+		witness.RewardPayouts,
+	); err != nil {
+		return err
+	}
+	if err := app.validateZeroHeightAuthContinuity(
+		source,
+		target,
+		sourceBank,
+		targetBank,
+		witness,
+	); err != nil {
+		return err
+	}
+	if _, ok := source[evmtypes.ModuleName]; !ok {
+		return fmt.Errorf("source EVM genesis is missing")
+	}
+	if _, ok := target[evmtypes.ModuleName]; !ok {
+		return fmt.Errorf("target EVM genesis is missing")
+	}
+	if err := app.validateZeroHeightEVMContinuity(source, target); err != nil {
+		return err
+	}
+
+	sourceFeeMarketRaw, ok := source[feemarkettypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("source feemarket genesis is missing")
+	}
+	targetFeeMarketRaw, ok := target[feemarkettypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("target feemarket genesis is missing")
+	}
+	sourceFeeMarket := new(feemarkettypes.GenesisState)
+	targetFeeMarket := new(feemarkettypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(
+		sourceFeeMarketRaw,
+		sourceFeeMarket,
+	); err != nil {
+		return fmt.Errorf("decode source feemarket genesis: %w", err)
+	}
+	if err := app.AppCodec().UnmarshalJSON(
+		targetFeeMarketRaw,
+		targetFeeMarket,
+	); err != nil {
+		return fmt.Errorf("decode target feemarket genesis: %w", err)
+	}
+	if !sourceFeeMarket.Params.MinGasPrice.Equal(targetFeeMarket.Params.MinGasPrice) {
+		return fmt.Errorf(
+			"current minimum gas price changed from %s to %s",
+			sourceFeeMarket.Params.MinGasPrice,
+			targetFeeMarket.Params.MinGasPrice,
+		)
+	}
+	if !bytes.Equal(source[feemarkettypes.ModuleName], target[feemarkettypes.ModuleName]) {
+		return fmt.Errorf("feemarket genesis changed during zero-height export")
+	}
+	if err := app.validateZeroHeightStakingContinuity(source, target, witness); err != nil {
+		return err
+	}
+	if err := app.validateZeroHeightDistributionContinuity(
+		source,
+		target,
+		witness.RewardPayouts,
+	); err != nil {
+		return err
+	}
+	if err := app.validateZeroHeightSlashingContinuity(source, target); err != nil {
+		return err
+	}
+	if err := app.validateZeroHeightOracleContinuity(source, target); err != nil {
+		return err
+	}
+	if err := app.validateZeroHeightConstitutionContinuity(source, target); err != nil {
+		return err
+	}
+
+	mutableModules := map[string]struct{}{
+		evmtypes.ModuleName:          {}, // canonical EIP-2935 history storage only
+		authtypes.ModuleName:         {}, // reward payout may create a plain recipient account
+		banktypes.ModuleName:         {}, // reward settlement moves balances but not supply
+		distrtypes.ModuleName:        {}, // upstream zero-height reward reset
+		stakingtypes.ModuleName:      {}, // upstream height/validator-set reset
+		slashingtypes.ModuleName:     {}, // upstream signing-window reset
+		oracletypes.ModuleName:       {}, // Guru-approved schedule/value reset
+		constitutiontypes.ModuleName: {}, // Guru-approved pending MGP removal
+	}
+	for _, moduleName := range moduleNames {
+		if _, mutable := mutableModules[moduleName]; mutable {
+			continue
+		}
+		targetState := target[moduleName]
+		if !bytes.Equal(source[moduleName], targetState) {
+			return fmt.Errorf(
+				"module %q genesis changed without an approved zero-height transformation",
+				moduleName,
+			)
+		}
+	}
+	return nil
+}
+
+func validateZeroHeightBankContinuity(
+	source,
+	target *banktypes.GenesisState,
+) error {
+	sourceConfiguration := *source
+	targetConfiguration := *target
+	sourceConfiguration.Balances = nil
+	targetConfiguration.Balances = nil
+	sourceConfiguration.Supply = nil
+	targetConfiguration.Supply = nil
+	if !reflect.DeepEqual(sourceConfiguration, targetConfiguration) {
+		return fmt.Errorf("bank configuration changed during zero-height export")
+	}
+	return nil
+}
+
+func (app *App) validateZeroHeightBankMovements(
+	sourceBank,
+	targetBank *banktypes.GenesisState,
+	rewardPayouts map[string]sdk.Coins,
+) error {
+	moduleAddress := func(moduleName string) (string, error) {
+		address, err := app.AccountKeeper.AddressCodec().BytesToString(
+			authtypes.NewModuleAddress(moduleName),
+		)
+		if err != nil {
+			return "", fmt.Errorf("encode %s module address: %w", moduleName, err)
+		}
+		return address, nil
+	}
+	distributionAddress, err := moduleAddress(distrtypes.ModuleName)
+	if err != nil {
+		return err
+	}
+	bondedPoolAddress, err := moduleAddress(stakingtypes.BondedPoolName)
+	if err != nil {
+		return err
+	}
+	notBondedPoolAddress, err := moduleAddress(stakingtypes.NotBondedPoolName)
+	if err != nil {
+		return err
+	}
+
+	sourceBalances := zeroHeightBankBalances(sourceBank)
+	targetBalances := zeroHeightBankBalances(targetBank)
+	expectedBalances := make(map[string]sdk.Coins, len(sourceBalances)+len(rewardPayouts))
+	for address, balance := range sourceBalances {
+		expectedBalances[address] = balance
+	}
+	rewardPayoutTotal := sdk.NewCoins()
+	payoutAddresses := make([]string, 0, len(rewardPayouts))
+	for address := range rewardPayouts {
+		payoutAddresses = append(payoutAddresses, address)
+	}
+	sort.Strings(payoutAddresses)
+	for _, address := range payoutAddresses {
+		payout := rewardPayouts[address]
+		if !payout.IsValid() || !payout.IsAllPositive() {
+			return fmt.Errorf("reward payout witness for %s is not positive and valid: %s", address, payout)
+		}
+		expectedBalances[address] = expectedBalances[address].Add(payout...)
+		rewardPayoutTotal = rewardPayoutTotal.Add(payout...)
+	}
+	distributionAfterPayout, negative := expectedBalances[distributionAddress].SafeSub(
+		rewardPayoutTotal...,
+	)
+	if negative {
+		return fmt.Errorf(
+			"reward payout witness %s exceeds source distribution balance %s",
+			rewardPayoutTotal,
+			expectedBalances[distributionAddress],
+		)
+	}
+	expectedBalances[distributionAddress] = distributionAfterPayout
+
+	seenAddresses := make(map[string]struct{}, len(expectedBalances)+len(targetBalances))
+	for address := range expectedBalances {
+		seenAddresses[address] = struct{}{}
+	}
+	for address := range sourceBalances {
+		seenAddresses[address] = struct{}{}
+	}
+	for address := range targetBalances {
+		seenAddresses[address] = struct{}{}
+	}
+	addresses := make([]string, 0, len(seenAddresses))
+	for address := range seenAddresses {
+		addresses = append(addresses, address)
+	}
+	sort.Strings(addresses)
+	for _, address := range addresses {
+		if address == bondedPoolAddress || address == notBondedPoolAddress {
+			continue
+		}
+		if !expectedBalances[address].Equal(targetBalances[address]) {
+			return fmt.Errorf(
+				"bank balance for %s is %s; expected %s from the recorded zero-height payouts",
+				address,
+				targetBalances[address],
+				expectedBalances[address],
+			)
+		}
+	}
+	expectedStakingPools := expectedBalances[bondedPoolAddress].Add(
+		expectedBalances[notBondedPoolAddress]...,
+	)
+	targetStakingPools := targetBalances[bondedPoolAddress].Add(
+		targetBalances[notBondedPoolAddress]...,
+	)
+	if !expectedStakingPools.Equal(targetStakingPools) {
+		return fmt.Errorf(
+			"staking pool balance group is %s; expected %s",
+			targetStakingPools,
+			expectedStakingPools,
+		)
+	}
+	return nil
+}
+
+func zeroHeightBankBalances(genesis *banktypes.GenesisState) map[string]sdk.Coins {
+	result := make(map[string]sdk.Coins, len(genesis.Balances))
+	for _, balance := range genesis.Balances {
+		result[balance.Address] = balance.Coins
+	}
+	return result
+}
+
+type zeroHeightAuthAccount struct {
+	account authtypes.GenesisAccount
+	typeURL string
+	value   []byte
+}
+
+func (app *App) validateZeroHeightAuthContinuity(
+	source,
+	target GenesisState,
+	sourceBank,
+	targetBank *banktypes.GenesisState,
+	witness zeroHeightMutationWitness,
+) error {
+	sourceState := new(authtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(source[authtypes.ModuleName], sourceState); err != nil {
+		return fmt.Errorf("decode source auth genesis: %w", err)
+	}
+	targetState := new(authtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(target[authtypes.ModuleName], targetState); err != nil {
+		return fmt.Errorf("decode target auth genesis: %w", err)
+	}
+	if !reflect.DeepEqual(sourceState.Params, targetState.Params) {
+		return fmt.Errorf("auth params changed during zero-height export")
+	}
+
+	indexAccounts := func(
+		label string,
+		state *authtypes.GenesisState,
+	) (map[string]zeroHeightAuthAccount, error) {
+		accounts, err := authtypes.UnpackAccounts(state.Accounts)
+		if err != nil {
+			return nil, fmt.Errorf("unpack %s auth accounts: %w", label, err)
+		}
+		indexed := make(map[string]zeroHeightAuthAccount, len(accounts))
+		for i, account := range accounts {
+			address, err := app.AccountKeeper.AddressCodec().BytesToString(account.GetAddress())
+			if err != nil {
+				return nil, fmt.Errorf("encode %s auth account address: %w", label, err)
+			}
+			if _, duplicate := indexed[address]; duplicate {
+				return nil, fmt.Errorf("%s auth account %s is duplicated", label, address)
+			}
+			indexed[address] = zeroHeightAuthAccount{
+				account: account,
+				typeURL: state.Accounts[i].TypeUrl,
+				value:   state.Accounts[i].Value,
+			}
+		}
+		return indexed, nil
+	}
+
+	sourceAccounts, err := indexAccounts("source", sourceState)
+	if err != nil {
+		return err
+	}
+	targetAccounts, err := indexAccounts("target", targetState)
+	if err != nil {
+		return err
+	}
+
+	sourceAddresses := make([]string, 0, len(sourceAccounts))
+	for address := range sourceAccounts {
+		sourceAddresses = append(sourceAddresses, address)
+	}
+	sort.Strings(sourceAddresses)
+	for _, address := range sourceAddresses {
+		targetAccount, ok := targetAccounts[address]
+		if !ok {
+			return fmt.Errorf("auth account %s disappeared during zero-height export", address)
+		}
+		sourceAccount := sourceAccounts[address]
+		if sourceAccount.typeURL != targetAccount.typeURL ||
+			!bytes.Equal(sourceAccount.value, targetAccount.value) {
+			return fmt.Errorf("auth account %s changed during zero-height export", address)
+		}
+	}
+
+	expectedNew := make(map[string]struct{}, len(witness.NewRewardAccounts))
+	for _, address := range witness.NewRewardAccounts {
+		if _, existed := sourceAccounts[address]; existed {
+			return fmt.Errorf("auth witness marks existing account %s as newly created", address)
+		}
+		if _, duplicate := expectedNew[address]; duplicate {
+			return fmt.Errorf("auth witness repeats newly created account %s", address)
+		}
+		expectedNew[address] = struct{}{}
+	}
+
+	targetAddresses := make([]string, 0, len(targetAccounts))
+	for address := range targetAccounts {
+		targetAddresses = append(targetAddresses, address)
+	}
+	sort.Strings(targetAddresses)
+	for _, address := range targetAddresses {
+		if _, existed := sourceAccounts[address]; existed {
+			continue
+		}
+		_, ok := expectedNew[address]
+		if !ok {
+			return fmt.Errorf("unapproved auth account %s was created", address)
+		}
+		baseAccount, ok := targetAccounts[address].account.(*authtypes.BaseAccount)
+		if !ok {
+			return fmt.Errorf("new reward account %s has type %s; expected BaseAccount", address, targetAccounts[address].typeURL)
+		}
+		if baseAccount.Address != address || baseAccount.PubKey != nil || baseAccount.Sequence != 0 {
+			return fmt.Errorf("new reward account %s has invalid base-account state", address)
+		}
+		payout := witness.RewardPayouts[address]
+		if payout.IsZero() {
+			return fmt.Errorf("new reward account %s has no recorded positive payout", address)
+		}
+	}
+	for _, address := range witness.NewRewardAccounts {
+		if _, ok := targetAccounts[address]; !ok {
+			return fmt.Errorf("recorded reward account %s was not created", address)
+		}
+	}
+
+	// The bank comparator fixes the exact payout delta; repeat the source-missing
+	// boundary here so auth additions cannot be justified by a detached witness.
+	sourceBalances := zeroHeightBankBalances(sourceBank)
+	targetBalances := zeroHeightBankBalances(targetBank)
+	for _, address := range witness.NewRewardAccounts {
+		expected := sourceBalances[address].Add(witness.RewardPayouts[address]...)
+		if !expected.Equal(targetBalances[address]) {
+			return fmt.Errorf("new reward account %s does not match its recorded bank payout", address)
+		}
+	}
+	return nil
+}
+
+func (app *App) validateZeroHeightDistributionContinuity(
+	source,
+	target GenesisState,
+	rewardPayouts map[string]sdk.Coins,
+) error {
+	sourceState := new(distrtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(source[distrtypes.ModuleName], sourceState); err != nil {
+		return fmt.Errorf("decode source distribution genesis: %w", err)
+	}
+	targetState := new(distrtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(target[distrtypes.ModuleName], targetState); err != nil {
+		return fmt.Errorf("decode target distribution genesis: %w", err)
+	}
+	targetStaking := new(stakingtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(target[stakingtypes.ModuleName], targetStaking); err != nil {
+		return fmt.Errorf("decode target staking genesis for distribution continuity: %w", err)
+	}
+
+	sourceRewardLedger := sourceState.FeePool.CommunityPool
+	for _, outstanding := range sourceState.OutstandingRewards {
+		sourceRewardLedger = sourceRewardLedger.Add(outstanding.OutstandingRewards...)
+	}
+	targetRewardLedger := targetState.FeePool.CommunityPool
+	for _, outstanding := range targetState.OutstandingRewards {
+		targetRewardLedger = targetRewardLedger.Add(outstanding.OutstandingRewards...)
+	}
+	payoutTotal := sdk.NewCoins()
+	for _, payout := range rewardPayouts {
+		payoutTotal = payoutTotal.Add(payout...)
+	}
+	targetRewardLedger = targetRewardLedger.Add(sdk.NewDecCoinsFromCoins(payoutTotal...)...)
+	if !sourceRewardLedger.Equal(targetRewardLedger) {
+		return fmt.Errorf(
+			"distribution decimal reward ledger changed from %s to %s including payouts %s",
+			sourceRewardLedger,
+			targetRewardLedger,
+			payoutTotal,
+		)
+	}
+	if err := validateZeroHeightDistributionTarget(targetState, targetStaking); err != nil {
+		return err
+	}
+
+	// Reward settlement and period rebuilding may change every reward record
+	// and the fee pool. Configuration, withdrawal routing, and proposer identity
+	// are not part of the upstream zero-height rewrite.
+	sourceState.FeePool = distrtypes.FeePool{}
+	targetState.FeePool = distrtypes.FeePool{}
+	sourceState.OutstandingRewards = nil
+	targetState.OutstandingRewards = nil
+	sourceState.ValidatorAccumulatedCommissions = nil
+	targetState.ValidatorAccumulatedCommissions = nil
+	sourceState.ValidatorHistoricalRewards = nil
+	targetState.ValidatorHistoricalRewards = nil
+	sourceState.ValidatorCurrentRewards = nil
+	targetState.ValidatorCurrentRewards = nil
+	sourceState.DelegatorStartingInfos = nil
+	targetState.DelegatorStartingInfos = nil
+	sourceState.ValidatorSlashEvents = nil
+	targetState.ValidatorSlashEvents = nil
+	if !reflect.DeepEqual(sourceState, targetState) {
+		return fmt.Errorf("distribution configuration or withdrawal routing changed during zero-height export")
+	}
+	return nil
+}
+
+// validateZeroHeightDistributionTarget checks the reset contract, not the SDK's
+// internal period allocation or reference-count algorithm. Those are exercised
+// by export/import and subsequent reward operations in the runtime tests.
+func validateZeroHeightDistributionTarget(
+	state *distrtypes.GenesisState,
+	_ *stakingtypes.GenesisState,
+) error {
+	for _, record := range state.OutstandingRewards {
+		if !record.OutstandingRewards.IsZero() {
+			return fmt.Errorf("target distribution outstanding rewards for %s are not reset", record.ValidatorAddress)
+		}
+	}
+	for _, record := range state.ValidatorAccumulatedCommissions {
+		if !record.Accumulated.Commission.IsZero() {
+			return fmt.Errorf("target distribution commissions for %s are not reset", record.ValidatorAddress)
+		}
+	}
+	for _, record := range state.ValidatorCurrentRewards {
+		if !record.Rewards.Rewards.IsZero() {
+			return fmt.Errorf("target distribution current rewards for %s are not reset", record.ValidatorAddress)
+		}
+	}
+	for _, record := range state.ValidatorHistoricalRewards {
+		if !record.Rewards.CumulativeRewardRatio.IsZero() {
+			return fmt.Errorf("target distribution historical rewards for %s are not reset", record.ValidatorAddress)
+		}
+	}
+	for _, record := range state.DelegatorStartingInfos {
+		if record.StartingInfo.Height != 0 {
+			return fmt.Errorf("target distribution starting height for %s is not reset", record.DelegatorAddress)
+		}
+	}
+	if len(state.ValidatorSlashEvents) != 0 {
+		return fmt.Errorf("target distribution contains stale validator slash events")
+	}
+	return nil
+}
+
+func (app *App) validateZeroHeightStakingContinuity(
+	source,
+	target GenesisState,
+	witness zeroHeightMutationWitness,
+) error {
+	sourceState := new(stakingtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(source[stakingtypes.ModuleName], sourceState); err != nil {
+		return fmt.Errorf("decode source staking genesis: %w", err)
+	}
+	targetState := new(stakingtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(target[stakingtypes.ModuleName], targetState); err != nil {
+		return fmt.Errorf("decode target staking genesis: %w", err)
+	}
+	if err := validateZeroHeightStakingTarget(targetState); err != nil {
+		return err
+	}
+
+	targetValidators := make(map[string]stakingtypes.Validator, len(targetState.Validators))
+	for _, validator := range targetState.Validators {
+		if _, duplicate := targetValidators[validator.OperatorAddress]; duplicate {
+			return fmt.Errorf("target staking validator %s is duplicated", validator.OperatorAddress)
+		}
+		targetValidators[validator.OperatorAddress] = validator
+	}
+	if len(sourceState.Validators) != len(targetValidators) {
+		return fmt.Errorf(
+			"staking validator count changed from %d to %d",
+			len(sourceState.Validators),
+			len(targetValidators),
+		)
+	}
+	for _, validator := range sourceState.Validators {
+		targetValidator, ok := targetValidators[validator.OperatorAddress]
+		if !ok {
+			return fmt.Errorf("staking validator %s disappeared during zero-height export", validator.OperatorAddress)
+		}
+		expectedJailed := validator.Jailed
+		if witness.JailAllowlistApplied {
+			_, allowed := witness.JailAllowedValidators[validator.OperatorAddress]
+			expectedJailed = validator.Jailed || !allowed
+		}
+		if targetValidator.Jailed != expectedJailed {
+			return fmt.Errorf(
+				"staking validator %s jailed state is %t; expected %t",
+				validator.OperatorAddress,
+				targetValidator.Jailed,
+				expectedJailed,
+			)
+		}
+		// The SDK keeper owns status transitions, completion times and unbonding
+		// IDs. Check its recorded result instead of reimplementing that state machine.
+		if expected, recorded := witness.StakingValidators[validator.OperatorAddress]; recorded {
+			// Compare serialized protobuf fields: JSON export/import can change
+			// nil slices and cached Any values without changing staking state.
+			if !bytes.Equal(app.AppCodec().MustMarshal(&targetValidator), app.AppCodec().MustMarshal(&expected)) {
+				return fmt.Errorf("staking validator %s differs from the upstream keeper result", validator.OperatorAddress)
+			}
+		} else if targetValidator.Status != validator.Status ||
+			!targetValidator.UnbondingTime.Equal(validator.UnbondingTime) ||
+			!reflect.DeepEqual(targetValidator.UnbondingIds, validator.UnbondingIds) {
+			return fmt.Errorf("staking validator %s lifecycle changed without an upstream keeper result", validator.OperatorAddress)
+		}
+	}
+
+	// Preserve validator economics and every pending delegation entry. Only the
+	// SDK zero-height fields and the recorded validator-set effects may differ.
+	sourceState.LastTotalPower = targetState.LastTotalPower
+	sourceState.LastValidatorPowers = targetState.LastValidatorPowers
+	for i := range sourceState.Validators {
+		validator := &sourceState.Validators[i]
+		targetValidator := targetValidators[validator.OperatorAddress]
+		validator.Jailed = targetValidator.Jailed
+		validator.Status = targetValidator.Status
+		validator.UnbondingTime = targetValidator.UnbondingTime
+		validator.UnbondingIds = targetValidator.UnbondingIds
+		validator.UnbondingHeight = 0
+	}
+	for i := range sourceState.UnbondingDelegations {
+		for j := range sourceState.UnbondingDelegations[i].Entries {
+			sourceState.UnbondingDelegations[i].Entries[j].CreationHeight = 0
+		}
+	}
+	for i := range sourceState.Redelegations {
+		for j := range sourceState.Redelegations[i].Entries {
+			sourceState.Redelegations[i].Entries[j].CreationHeight = 0
+		}
+	}
+	sort.Slice(sourceState.Validators, func(i, j int) bool {
+		return sourceState.Validators[i].OperatorAddress < sourceState.Validators[j].OperatorAddress
+	})
+	sort.Slice(targetState.Validators, func(i, j int) bool {
+		return targetState.Validators[i].OperatorAddress < targetState.Validators[j].OperatorAddress
+	})
+	if !reflect.DeepEqual(sourceState, targetState) {
+		return fmt.Errorf("staking state changed outside approved zero-height lifecycle fields")
+	}
+	return nil
+}
+
+func validateZeroHeightStakingTarget(state *stakingtypes.GenesisState) error {
+	for _, validator := range state.Validators {
+		if validator.UnbondingHeight != 0 {
+			return fmt.Errorf(
+				"target validator %s has nonzero unbonding height %d",
+				validator.OperatorAddress,
+				validator.UnbondingHeight,
+			)
+		}
+	}
+	for _, unbonding := range state.UnbondingDelegations {
+		for _, entry := range unbonding.Entries {
+			if entry.CreationHeight != 0 {
+				return fmt.Errorf("target unbonding delegation %s/%s has nonzero creation height %d", unbonding.DelegatorAddress, unbonding.ValidatorAddress, entry.CreationHeight)
+			}
+		}
+	}
+	for _, redelegation := range state.Redelegations {
+		for _, entry := range redelegation.Entries {
+			if entry.CreationHeight != 0 {
+				return fmt.Errorf("target redelegation %s/%s/%s has nonzero creation height %d", redelegation.DelegatorAddress, redelegation.ValidatorSrcAddress, redelegation.ValidatorDstAddress, entry.CreationHeight)
+			}
+		}
+	}
+	return nil
+}
+
+func (app *App) validateZeroHeightSlashingContinuity(source, target GenesisState) error {
+	sourceState, targetState := new(slashingtypes.GenesisState), new(slashingtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(source[slashingtypes.ModuleName], sourceState); err != nil {
+		return fmt.Errorf("decode source slashing genesis: %w", err)
+	}
+	if err := app.AppCodec().UnmarshalJSON(target[slashingtypes.ModuleName], targetState); err != nil {
+		return fmt.Errorf("decode target slashing genesis: %w", err)
+	}
+	sourceStaking, targetStaking := new(stakingtypes.GenesisState), new(stakingtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(source[stakingtypes.ModuleName], sourceStaking); err != nil {
+		return err
+	}
+	if err := app.AppCodec().UnmarshalJSON(target[stakingtypes.ModuleName], targetStaking); err != nil {
+		return err
+	}
+	if err := app.validateZeroHeightSlashingTarget(targetState, targetStaking); err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(sourceState.Params, targetState.Params) {
+		return fmt.Errorf("slashing state changed outside approved signing-window fields")
+	}
+	// Preserve each source record's tombstone and jail deadline. New records
+	// are permitted only for validators bonded by the upstream transition.
+	previous := make(map[string]slashingtypes.ValidatorSigningInfo, len(sourceState.SigningInfos))
+	for _, record := range sourceState.SigningInfos {
+		info := record.ValidatorSigningInfo
+		info.StartHeight, info.IndexOffset, info.MissedBlocksCounter = 0, 0, 0
+		previous[record.Address] = info
+	}
+	oldStatus := make(map[string]stakingtypes.BondStatus, len(sourceStaking.Validators))
+	for _, validator := range sourceStaking.Validators {
+		oldStatus[validator.OperatorAddress] = validator.Status
+	}
+	newlyBonded := make(map[string]bool)
+	for _, validator := range targetStaking.Validators {
+		status, existed := oldStatus[validator.OperatorAddress]
+		if !existed || status == stakingtypes.Bonded || !validator.IsBonded() {
+			continue
+		}
+		address, err := validator.GetConsAddr()
+		if err != nil {
+			return err
+		}
+		encoded, err := app.StakingKeeper.ConsensusAddressCodec().BytesToString(address)
+		if err != nil {
+			return err
+		}
+		newlyBonded[encoded] = true
+	}
+	for _, record := range targetState.SigningInfos {
+		info := record.ValidatorSigningInfo
+		if expected, existed := previous[record.Address]; existed {
+			if !reflect.DeepEqual(expected, info) {
+				return fmt.Errorf("slashing state changed outside approved signing-window fields")
+			}
+			delete(previous, record.Address)
+		} else if !newlyBonded[record.Address] || info.Tombstoned || !info.JailedUntil.Equal(time.Unix(0, 0)) {
+			return fmt.Errorf("target slashing state introduced an unapproved signing info %s", record.Address)
+		}
+	}
+	if len(previous) != 0 {
+		return fmt.Errorf("slashing state changed outside approved signing-window fields: source signing infos disappeared")
+	}
+	return nil
+}
+
+func (app *App) validateZeroHeightSlashingTarget(state *slashingtypes.GenesisState, stakingState *stakingtypes.GenesisState) error {
+	signingAddresses := make(map[string]bool, len(state.SigningInfos))
+	for _, record := range state.SigningInfos {
+		info := record.ValidatorSigningInfo
+		if signingAddresses[record.Address] || info.Address != record.Address {
+			return fmt.Errorf("target signing info %s is duplicated or has a mismatched address", record.Address)
+		}
+		if info.StartHeight != 0 || info.IndexOffset != 0 || info.MissedBlocksCounter != 0 {
+			return fmt.Errorf("target signing info %s was not reset", record.Address)
+		}
+		signingAddresses[record.Address] = true
+	}
+	for _, record := range state.MissedBlocks {
+		if len(record.MissedBlocks) != 0 {
+			return fmt.Errorf("target slashing missed-block window for %s is not empty", record.Address)
+		}
+	}
+	for _, validator := range stakingState.Validators {
+		if !validator.IsBonded() {
+			continue
+		}
+		address, err := validator.GetConsAddr()
+		if err != nil {
+			return err
+		}
+		encoded, err := app.StakingKeeper.ConsensusAddressCodec().BytesToString(address)
+		if err != nil {
+			return err
+		}
+		if !signingAddresses[encoded] {
+			return fmt.Errorf("target slashing state is missing signing info %s for active validator %s", encoded, validator.OperatorAddress)
+		}
+	}
+	return nil
+}
+
+func (app *App) validateZeroHeightOracleContinuity(source, target GenesisState) error {
+	sourceState := new(oracletypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(source[oracletypes.ModuleName], sourceState); err != nil {
+		return fmt.Errorf("decode source oracle genesis: %w", err)
+	}
+	targetState := new(oracletypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(target[oracletypes.ModuleName], targetState); err != nil {
+		return fmt.Errorf("decode target oracle genesis: %w", err)
+	}
+	if err := validateZeroHeightOracleTarget(targetState); err != nil {
+		return err
+	}
+	if len(targetState.TaskSchedule) != 0 {
+		return fmt.Errorf("target Oracle source schedules were not removed")
+	}
+	sourceState.LatestValues = nil
+	targetState.LatestValues = nil
+	sourceState.History = nil
+	targetState.History = nil
+	sourceState.TaskSchedule = nil
+	targetState.TaskSchedule = nil
+	if !reflect.DeepEqual(sourceState, targetState) {
+		return fmt.Errorf("oracle params or task definitions changed during zero-height export")
+	}
+	return nil
+}
+
+func validateZeroHeightOracleTarget(state *oracletypes.GenesisState) error {
+	if len(state.LatestValues) != 0 || len(state.History) != 0 {
+		return fmt.Errorf("target Oracle observations were not removed")
+	}
+	return nil
+}
+
+func (app *App) validateZeroHeightConstitutionContinuity(source, target GenesisState) error {
+	sourceState := new(constitutiontypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(source[constitutiontypes.ModuleName], sourceState); err != nil {
+		return fmt.Errorf("decode source constitution genesis: %w", err)
+	}
+	targetState := new(constitutiontypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(target[constitutiontypes.ModuleName], targetState); err != nil {
+		return fmt.Errorf("decode target constitution genesis: %w", err)
+	}
+	if err := validateZeroHeightConstitutionTarget(targetState); err != nil {
+		return err
+	}
+	sourceState.PendingMinGasPrice = nil
+	targetState.PendingMinGasPrice = nil
+	if !reflect.DeepEqual(sourceState, targetState) {
+		return fmt.Errorf("constitution state changed outside pending minimum gas price")
+	}
+	return nil
+}
+
+func validateZeroHeightConstitutionTarget(state *constitutiontypes.GenesisState) error {
+	if state.PendingMinGasPrice != nil {
+		return fmt.Errorf("target Constitution pending minimum gas price was not removed")
+	}
+	return nil
 }

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -1,0 +1,1907 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	sdkmath "cosmossdk.io/math"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/privval"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	dbm "github.com/cosmos/cosmos-db"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	connectiontypes "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
+	ibccoretypes "github.com/cosmos/ibc-go/v10/modules/core/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethparams "github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gurufinglobal/guru/v2/config"
+	constitutiontypes "github.com/gurufinglobal/guru/v2/x/constitution/types"
+	oracletypes "github.com/gurufinglobal/guru/v2/x/oracle/types"
+)
+
+// Test-only key for an isolated loopback node. Never use it on a real network.
+func exportRuntimeValidatorKey() cmted25519.PrivKey {
+	return cmted25519.GenPrivKeyFromSecret([]byte("guru-export-restart-test-only"))
+}
+
+type exportRestartFixture struct {
+	Export servertypes.ExportedApp
+	Time   time.Time
+}
+
+func testExportAppRestart(t *testing.T, exported servertypes.ExportedApp, sourceTime time.Time) {
+	t.Helper()
+	dir := t.TempDir()
+	// InitChain derives validators from staking genesis. Avoid encoding the
+	// CometBFT PubKey interface with encoding/json in this private fixture.
+	exported.Validators = nil
+	raw, err := json.Marshal(exportRestartFixture{exported, sourceTime})
+	require.NoError(t, err)
+	path := filepath.Join(dir, "export.json")
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, executable, "-test.run=^TestExportRestartProcess$", "-test.v")
+	command.Env = append(os.Environ(), "GURU_EXPORT_RESTART_FIXTURE="+path)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	t.Logf("fresh-process InitChain/blocks/time-based completion: %s", output)
+}
+
+// A separate process is necessary because Cosmos EVM seals process-global
+// configuration. This test executes real InitChain and committed ABCI blocks,
+// not a JSON-only validation or a replacement staking InitGenesis.
+func TestExportRestartProcess(t *testing.T) {
+	path := os.Getenv("GURU_EXPORT_RESTART_FIXTURE")
+	if path == "" {
+		t.Skip("subprocess helper")
+	}
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var fixture exportRestartFixture
+	require.NoError(t, json.Unmarshal(raw, &fixture))
+	application, err := New(Options{
+		Logger: log.NewNopLogger(), DB: dbm.NewMemDB(), LoadLatest: true,
+		HomePath: t.TempDir(), ChainID: "guru-test-1", EVMChainID: 9631,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, application.Close()) })
+	initialHeight := fixture.Export.Height
+	if initialHeight == 0 {
+		initialHeight = 1
+	}
+	_, err = application.InitChain(&abci.RequestInitChain{
+		ChainId: application.ChainID(), InitialHeight: initialHeight,
+		Time: fixture.Time, AppStateBytes: fixture.Export.AppState,
+		ConsensusParams: &fixture.Export.ConsensusParams,
+	})
+	require.NoError(t, err)
+	// The fork records the current header hash at height % HistoryServeWindow.
+	// Supply a nonzero hash to prove the cleared contract resumes recording.
+	restartedHash := common.HexToHash("0x2935")
+	_, err = application.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: initialHeight, Time: fixture.Time.Add(time.Second),
+		ProposerAddress: exportRuntimeValidatorKey().PubKey().Address(), Hash: restartedHash.Bytes(),
+	})
+	require.NoError(t, err)
+	_, err = application.Commit()
+	require.NoError(t, err)
+	ctx := committedContext(t, application)
+	require.Equal(t, restartedHash, application.EVMKeeper.GetHeaderHash(ctx, uint64(initialHeight)))
+	t.Logf("EIP-2935 rebuilt history height=%d hash=%s", initialHeight, restartedHash)
+	params, err := application.StakingKeeper.GetParams(ctx)
+	require.NoError(t, err)
+	stakingBefore := application.StakingKeeper.ExportGenesis(ctx)
+	pending := stakingBefore.UnbondingDelegations
+	withdrawals := make(map[string]sdkmath.Int)
+	balancesBefore := make(map[string]sdkmath.Int)
+	for _, ubd := range pending {
+		address, err := application.AccountKeeper.AddressCodec().StringToBytes(ubd.DelegatorAddress)
+		require.NoError(t, err)
+		balancesBefore[ubd.DelegatorAddress] = application.BankKeeper.GetBalance(ctx, address, params.BondDenom).Amount
+		if _, exists := withdrawals[ubd.DelegatorAddress]; !exists {
+			withdrawals[ubd.DelegatorAddress] = sdkmath.ZeroInt()
+		}
+		for _, entry := range ubd.Entries {
+			if entry.UnbondingOnHoldRefCount == 0 {
+				withdrawals[ubd.DelegatorAddress] = withdrawals[ubd.DelegatorAddress].Add(entry.Balance)
+			}
+			// Held-state migration is outside this upstream-only restart contract.
+			require.Zero(t, entry.UnbondingOnHoldRefCount)
+		}
+	}
+	// Advance real block time beyond all fixture completion times.
+	finalizeAndCommit(t, application, initialHeight+1,
+		fixture.Time.Add(params.UnbondingTime+24*time.Hour),
+		exportRuntimeValidatorKey().PubKey().Address(), nil)
+	ctx = committedContext(t, application)
+	for address, amount := range withdrawals {
+		decoded, err := application.AccountKeeper.AddressCodec().StringToBytes(address)
+		require.NoError(t, err)
+		require.True(t, application.BankKeeper.GetBalance(ctx, decoded, params.BondDenom).Amount.Equal(
+			balancesBefore[address].Add(amount)), "withdrawal balance did not arrive at %s", address)
+	}
+	stakingAfter := application.StakingKeeper.ExportGenesis(ctx)
+	remaining := stakingAfter.UnbondingDelegations
+	require.Empty(t, remaining, "unheld withdrawals did not complete")
+	redelegations := stakingAfter.Redelegations
+	require.Empty(t, redelegations, "unheld redelegations did not complete")
+	// Check economics after upstream InitGenesis and actual end-block queues.
+	result, err := application.ExportAppStateAndValidators(false, nil, nil)
+	require.NoError(t, err)
+	var genesis GenesisState
+	require.NoError(t, json.Unmarshal(result.AppState, &genesis))
+	require.NoError(t, application.validateExportInvariants(genesis))
+	t.Logf("initial_height=%d committed_height=%d pending_before=%d pending_after=%d app_hash=%X",
+		initialHeight, application.LastBlockHeight(), len(pending), len(remaining), application.LastCommitID().Hash)
+}
+
+// Optional real gurud/CometBFT smoke, run only by the IDC runtime command.
+// After restarting the source, export through the official CLI and restart a
+// fresh node from that exact output. cliGenesis prevents recursive re-export.
+func testExportNodeRestart(t *testing.T, exported servertypes.ExportedApp, sourceTime time.Time, cliGenesis ...string) {
+	t.Helper()
+	binary := os.Getenv("GURU_EXPORT_RUNTIME_BIN")
+	if binary == "" {
+		t.Log("real gurud restart NOT RUN: set GURU_EXPORT_RUNTIME_BIN via IDC runner")
+		return
+	}
+	root := os.Getenv("GURU_EXPORT_RUNTIME_ARTIFACTS")
+	require.NotEmpty(t, root, "runtime receipts require a persistent artifact directory")
+	require.True(t, filepath.IsAbs(root))
+	dir, err := os.MkdirTemp(root, fmt.Sprintf("height-%d-", exported.Height))
+	require.NoError(t, err)
+	home := filepath.Join(dir, "node")
+	run := func(args ...string) []byte {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		out, err := exec.CommandContext(ctx, binary, args...).CombinedOutput()
+		require.NoError(t, err, "%s", out)
+		return out
+	}
+	run("init", "export-restart", "--home", home, "--chain-id", "guru-test-1",
+		"--constitution-base-address", sdk.AccAddress(bytes.Repeat([]byte{1}, 20)).String(),
+		"--constitution-moderator-address", sdk.AccAddress(bytes.Repeat([]byte{2}, 20)).String())
+	// Match the CLI's legacy optional-field completion for SDK App exports.
+	consensus := exported.ConsensusParams
+	if consensus.Version == nil {
+		consensus.Version = &cmtproto.VersionParams{}
+	}
+	if consensus.Abci == nil {
+		consensus.Abci = &cmtproto.ABCIParams{}
+	}
+	params := cmttypes.ConsensusParamsFromProto(consensus)
+	doc := genutiltypes.AppGenesis{
+		AppName: "gurud", ChainID: "guru-test-1", GenesisTime: sourceTime,
+		InitialHeight: exported.Height, AppState: exported.AppState,
+		Consensus: &genutiltypes.ConsensusGenesis{Params: &params, Validators: exported.Validators},
+	}
+	genesisPath := filepath.Join(home, "config", "genesis.json")
+	require.NoError(t, doc.SaveAs(genesisPath))
+	if len(cliGenesis) != 0 {
+		raw, err := os.ReadFile(cliGenesis[0])
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(genesisPath, raw, 0o600))
+	}
+	pv := privval.NewFilePV(exportRuntimeValidatorKey(),
+		filepath.Join(home, "config", "priv_validator_key.json"),
+		filepath.Join(home, "data", "priv_validator_state.json"))
+	pv.Save()
+	configPath := filepath.Join(home, "config", "config.toml")
+	configBytes, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	configText := strings.ReplaceAll(string(configBytes), "timeout_commit = \"5s\"", "timeout_commit = \"200ms\"")
+	require.NoError(t, os.WriteFile(configPath, []byte(configText), 0o600))
+	appConfigPath := filepath.Join(home, "config", "app.toml")
+	appConfig, err := os.ReadFile(appConfigPath)
+	require.NoError(t, err)
+	oracleOffset := strings.Index(string(appConfig), "[oracle]")
+	require.NotEqual(t, -1, oracleOffset)
+	appConfigText := string(appConfig[:oracleOffset]) + strings.Replace(string(appConfig[oracleOffset:]), "enabled = true", "enabled = false", 1)
+	require.NoError(t, os.WriteFile(appConfigPath, []byte(appConfigText), 0o600))
+	freeAddress := func() string {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		address := listener.Addr().String()
+		require.NoError(t, listener.Close())
+		return address
+	}
+	rpc, p2p := freeAddress(), freeAddress()
+	client := &http.Client{Timeout: time.Second}
+	status := func() (int64, string) {
+		response, err := client.Get("http://" + rpc + "/status")
+		if err != nil {
+			return 0, ""
+		}
+		defer response.Body.Close()
+		var payload struct {
+			Result struct {
+				SyncInfo struct {
+					Height string `json:"latest_block_height"`
+					Hash   string `json:"latest_app_hash"`
+				} `json:"sync_info"`
+			} `json:"result"`
+		}
+		if json.NewDecoder(response.Body).Decode(&payload) != nil {
+			return 0, ""
+		}
+		height, _ := strconv.ParseInt(payload.Result.SyncInfo.Height, 10, 64)
+		return height, payload.Result.SyncInfo.Hash
+	}
+	initialHeight := exported.Height
+	if initialHeight == 0 {
+		initialHeight = 1
+	}
+	var previousHeight int64
+	for phase := 0; phase < 2; phase++ {
+		logPath := filepath.Join(dir, fmt.Sprintf("node-%d.log", phase))
+		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		require.NoError(t, err)
+		command := exec.Command(binary, "start", "--home", home,
+			"--chain-id", "guru-test-1", "--evm.evm-chain-id", "9631",
+			"--minimum-gas-prices", "0agxn", "--evm.min-tip", "0",
+			"--rpc.laddr", "tcp://"+rpc, "--p2p.laddr", "tcp://"+p2p,
+			"--grpc.enable=false", "--grpc-web.enable=false", "--api.enable=false",
+			"--json-rpc.enable=false")
+		command.Stdout, command.Stderr = logFile, logFile
+		require.NoError(t, command.Start())
+		exited := make(chan error, 1)
+		go func() { exited <- command.Wait() }()
+		stopped := false
+		stop := func() {
+			if stopped {
+				return
+			}
+			stopped = true
+			_ = command.Process.Signal(os.Interrupt)
+			select {
+			case <-exited:
+			case <-time.After(10 * time.Second):
+				_ = command.Process.Kill()
+				<-exited
+			}
+			_ = logFile.Close()
+		}
+		t.Cleanup(stop)
+		target := initialHeight + 2
+		if phase == 1 {
+			target = previousHeight + 2
+		}
+		deadline := time.NewTimer(75 * time.Second)
+		ticker := time.NewTicker(200 * time.Millisecond)
+		var height int64
+		var hash string
+	wait:
+		for {
+			select {
+			case err := <-exited:
+				stopped = true
+				_ = logFile.Close()
+				logBytes, _ := os.ReadFile(logPath)
+				t.Fatalf("node exited: %v\n%s", err, logBytes)
+			case <-deadline.C:
+				stop()
+				logBytes, _ := os.ReadFile(logPath)
+				t.Fatalf("node failed to reach height %d\n%s", target, logBytes)
+			case <-ticker.C:
+				height, hash = status()
+				if height >= target {
+					break wait
+				}
+			}
+		}
+		deadline.Stop()
+		ticker.Stop()
+		require.NotEmpty(t, hash)
+		stop()
+		previousHeight = height
+		t.Logf("gurud runtime phase=%d height=%d app_hash=%s artifacts=%s", phase, height, hash, dir)
+	}
+	raw, err := os.ReadFile(genesisPath)
+	require.NoError(t, err)
+	fixtureKind := "application-export"
+	if len(cliGenesis) != 0 {
+		fixtureKind = "official-cli-zero-height-export"
+	}
+	receipt := fmt.Sprintf("fixture=%s\ninitial_height=%d\nrestart_height=%d\ngenesis_sha256=%x\n", fixtureKind, initialHeight, previousHeight, sha256.Sum256(raw))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "receipt.txt"), []byte(receipt), 0o600))
+	if len(cliGenesis) != 0 {
+		t.Logf("official CLI zero-height genesis restarted successfully: %s", dir)
+		return
+	}
+	// Exercise the official command on the stopped node's committed database.
+	outPath := filepath.Join(dir, "zero-height.json")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, binary, "export", "--home", home,
+		"--for-zero-height", "--output-document", outPath).CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "official-cli-export.log"), out, 0o600))
+	cliDoc, err := genutiltypes.AppGenesisFromFile(outPath)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, cliDoc.InitialHeight)
+	require.NotNil(t, cliDoc.Consensus)
+	require.NotNil(t, cliDoc.Consensus.Params)
+	testExportNodeRestart(t, servertypes.ExportedApp{
+		AppState: cliDoc.AppState, Height: cliDoc.InitialHeight,
+		Validators: cliDoc.Consensus.Validators, ConsensusParams: cliDoc.Consensus.Params.ToProto(),
+	}, cliDoc.GenesisTime, outPath)
+}
+
+func TestZeroHeightStakingTargetValidatesHeightsWithoutBanningPendingEntries(t *testing.T) {
+	state := &stakingtypes.GenesisState{
+		Validators: []stakingtypes.Validator{{
+			Status: stakingtypes.Unbonding, UnbondingIds: []uint64{12}, UnbondingOnHoldRefCount: 1,
+		}},
+		UnbondingDelegations: []stakingtypes.UnbondingDelegation{{
+			Entries: []stakingtypes.UnbondingDelegationEntry{{UnbondingId: 13, UnbondingOnHoldRefCount: 1}},
+		}},
+		Redelegations: []stakingtypes.Redelegation{{
+			Entries: []stakingtypes.RedelegationEntry{{UnbondingId: 14, UnbondingOnHoldRefCount: 1}},
+		}},
+	}
+	require.NoError(t, validateZeroHeightStakingTarget(state))
+	state.UnbondingDelegations[0].Entries[0].CreationHeight = 4
+	require.ErrorContains(t, validateZeroHeightStakingTarget(state), "nonzero creation height 4")
+	state.UnbondingDelegations[0].Entries[0].CreationHeight = 0
+	state.Redelegations[0].Entries[0].CreationHeight = 5
+	require.ErrorContains(t, validateZeroHeightStakingTarget(state), "nonzero creation height 5")
+	state.Redelegations[0].Entries[0].CreationHeight = 0
+	require.NoError(t, validateZeroHeightStakingTarget(state))
+}
+
+// Called from the single application harness: Cosmos EVM configuration is
+// process-global. Every scenario uses a discarded cache of the committed app.
+func testZeroHeightUpstreamStaking(
+	t *testing.T,
+	application *App,
+	committed sdk.Context,
+	consensusParams cmtproto.ConsensusParams,
+) {
+	newSource := func(t *testing.T) (sdk.Context, stakingtypes.Validator, sdk.ValAddress) {
+		ctx, _ := committed.CacheContext()
+		validators, err := application.StakingKeeper.GetAllValidators(ctx)
+		require.NoError(t, err)
+		require.Len(t, validators, 1)
+		validator := validators[0]
+		require.True(t, validator.IsBonded())
+		operator, err := application.StakingKeeper.ValidatorAddressCodec().StringToBytes(validator.OperatorAddress)
+		require.NoError(t, err)
+		// Keep at least one voting-power unit after the pending withdrawals.
+		additional := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, sdk.DefaultPowerReduction))
+		require.NoError(t, application.BankKeeper.MintCoins(ctx, minttypes.ModuleName, additional))
+		require.NoError(t, application.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, sdk.AccAddress(operator), additional))
+		_, err = application.StakingKeeper.Delegate(ctx, sdk.AccAddress(operator), sdk.DefaultPowerReduction, stakingtypes.Unbonded, validator, true)
+		require.NoError(t, err)
+		_, err = application.CustomStakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
+		require.NoError(t, err)
+		validator, err = application.StakingKeeper.GetValidator(ctx, sdk.ValAddress(operator))
+		require.NoError(t, err)
+		consensusAddress, err := validator.GetConsAddr()
+		require.NoError(t, err)
+		require.NoError(t, application.SlashingKeeper.SetValidatorSigningInfo(ctx, consensusAddress,
+			slashingtypes.NewValidatorSigningInfo(consensusAddress, ctx.BlockHeight(), 0, time.Unix(0, 0), false, 0)))
+		return ctx, validator, sdk.ValAddress(operator)
+	}
+	addDestination := func(t *testing.T, ctx sdk.Context) sdk.ValAddress {
+		pubkey := ed25519.GenPrivKeyFromSecret([]byte("zero-height-upstream-destination")).PubKey()
+		operator := sdk.ValAddress(pubkey.Address())
+		encoded, err := application.StakingKeeper.ValidatorAddressCodec().BytesToString(operator)
+		require.NoError(t, err)
+		validator, err := stakingtypes.NewValidator(encoded, pubkey, stakingtypes.Description{})
+		require.NoError(t, err)
+		require.NoError(t, application.StakingKeeper.SetValidator(ctx, validator))
+		require.NoError(t, application.StakingKeeper.SetValidatorByConsAddr(ctx, validator))
+		require.NoError(t, application.StakingKeeper.SetValidatorByPowerIndex(ctx, validator))
+		require.NoError(t, application.DistrKeeper.Hooks().AfterValidatorCreated(ctx, operator))
+		return operator
+	}
+	export := func(t *testing.T, ctx sdk.Context, allowed []string) *stakingtypes.GenesisState {
+		before, err := application.ModuleManager.ExportGenesisForModules(ctx, application.AppCodec(), nil)
+		require.NoError(t, err)
+		result, err := application.exportZeroHeightGenesis(ctx, allowed, consensusParams)
+		require.NoError(t, err)
+		repeated, err := application.exportZeroHeightGenesis(ctx, allowed, consensusParams)
+		require.NoError(t, err)
+		require.Equal(t, result, repeated)
+		after, err := application.ModuleManager.ExportGenesisForModules(ctx, application.AppCodec(), nil)
+		require.NoError(t, err)
+		require.Equal(t, before, after, "export must not change its source cache")
+		var genesis GenesisState
+		require.NoError(t, json.Unmarshal(result.AppState, &genesis))
+		require.NoError(t, application.ValidateGenesisAtHeight(genesis, 1))
+		state := new(stakingtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(genesis[stakingtypes.ModuleName], state))
+		return state
+	}
+
+	t.Run("pending delegations retain upstream fields and completion queues", func(t *testing.T) {
+		ctx, validator, operator := newSource(t)
+		destination := addDestination(t, ctx)
+		shares, err := validator.SharesFromTokens(sdkmath.NewInt(7))
+		require.NoError(t, err)
+		_, _, err = application.StakingKeeper.Undelegate(ctx, sdk.AccAddress(operator), operator, shares)
+		require.NoError(t, err)
+		_, err = application.StakingKeeper.BeginRedelegation(ctx, sdk.AccAddress(operator), operator, destination, shares)
+		require.NoError(t, err)
+		_, err = application.CustomStakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
+		require.NoError(t, err)
+
+		unbonding, err := application.StakingKeeper.GetUnbondingDelegation(ctx, sdk.AccAddress(operator), operator)
+		require.NoError(t, err)
+		redelegation, err := application.StakingKeeper.GetRedelegation(ctx, sdk.AccAddress(operator), operator, destination)
+		require.NoError(t, err)
+		require.Len(t, unbonding.Entries, 1)
+		require.Len(t, redelegation.Entries, 1)
+		require.Positive(t, unbonding.Entries[0].CreationHeight)
+		require.Positive(t, redelegation.Entries[0].CreationHeight)
+
+		state := export(t, ctx, nil)
+		// Check the real upstream importer in a new process, including time-based
+		// completion of ordinary unheld entries.
+		restartCtx, _ := ctx.CacheContext()
+		_, _, err = application.StakingKeeper.Undelegate(restartCtx, sdk.AccAddress(operator), operator, shares)
+		require.NoError(t, err)
+		_, err = application.CustomStakingKeeper.ApplyAndReturnValidatorSetUpdates(restartCtx)
+		require.NoError(t, err)
+		result, err := application.exportZeroHeightGenesis(restartCtx, nil, consensusParams)
+		require.NoError(t, err)
+		testExportAppRestart(t, result, ctx.BlockTime())
+		unbonding.Entries[0].CreationHeight = 0
+		redelegation.Entries[0].CreationHeight = 0
+		require.Equal(t, []stakingtypes.UnbondingDelegation{unbonding}, state.UnbondingDelegations)
+		require.Equal(t, []stakingtypes.Redelegation{redelegation}, state.Redelegations)
+
+		// Inspect the transformed cache as well as JSON: creation-height resets
+		// must leave the upstream completion-time queue entries in place.
+		targetCtx, _ := ctx.CacheContext()
+		receipt, witness, err := application.prepareZeroHeightState(targetCtx, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, receipt.UnbondingEntriesReset)
+		require.Equal(t, 1, receipt.RedelegationEntriesReset)
+		queue, err := application.StakingKeeper.GetUBDQueueTimeSlice(targetCtx, unbonding.Entries[0].CompletionTime)
+		require.NoError(t, err)
+		require.NotEmpty(t, queue)
+		redQueue, err := application.StakingKeeper.GetRedelegationQueueTimeSlice(targetCtx, redelegation.Entries[0].CompletionTime)
+		require.NoError(t, err)
+		require.NotEmpty(t, redQueue)
+		require.NotEmpty(t, witness.StakingValidators)
+
+		// A timestamp edit is still rejected; using upstream does not authorize
+		// changing a pending withdrawal's economic or completion-time fields.
+		sourceGenesis, err := application.ModuleManager.ExportGenesisForModules(ctx, application.AppCodec(), nil)
+		require.NoError(t, err)
+		targetGenesis, err := application.ModuleManager.ExportGenesisForModules(targetCtx, application.AppCodec(), nil)
+		require.NoError(t, err)
+		require.NoError(t, application.validateZeroHeightStakingContinuity(
+			GenesisState(sourceGenesis), GenesisState(targetGenesis), witness))
+		state.UnbondingDelegations[0].Entries[0].CompletionTime = state.UnbondingDelegations[0].Entries[0].CompletionTime.Add(time.Second)
+		targetGenesis[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+		require.ErrorContains(t, application.validateZeroHeightStakingContinuity(
+			GenesisState(sourceGenesis), GenesisState(targetGenesis), witness),
+			"staking state changed outside approved zero-height lifecycle fields")
+	})
+
+	t.Run("upstream can rebond an unbonding validator", func(t *testing.T) {
+		ctx, validator, operator := newSource(t)
+		consensusAddress, err := validator.GetConsAddr()
+		require.NoError(t, err)
+		require.NoError(t, application.StakingKeeper.Jail(ctx, consensusAddress))
+		_, err = application.CustomStakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
+		require.NoError(t, err)
+		require.NoError(t, application.StakingKeeper.Unjail(ctx, consensusAddress))
+		source, err := application.StakingKeeper.GetValidator(ctx, operator)
+		require.NoError(t, err)
+		require.True(t, source.IsUnbonding())
+		require.NotEmpty(t, source.UnbondingIds)
+
+		state := export(t, ctx, nil)
+		require.Len(t, state.Validators, 1)
+		expected := source
+		expected.Status = stakingtypes.Bonded
+		expected.UnbondingHeight = 0
+		require.Equal(t, expected, state.Validators[0])
+	})
+
+	t.Run("nonzero historical counter does not block export", func(t *testing.T) {
+		ctx, _, _ := newSource(t)
+		id, err := application.StakingKeeper.IncrementUnbondingID(ctx)
+		require.NoError(t, err)
+		require.Positive(t, id)
+		state := export(t, ctx, nil)
+		require.Empty(t, state.UnbondingDelegations)
+		require.Empty(t, state.Redelegations)
+	})
+
+	t.Run("allowlist jails exclusions and preserves existing jail", func(t *testing.T) {
+		ctx, validator, operator := newSource(t)
+		destination := addDestination(t, ctx)
+		shares, err := validator.SharesFromTokens(sdkmath.NewInt(7))
+		require.NoError(t, err)
+		_, err = application.StakingKeeper.BeginRedelegation(ctx, sdk.AccAddress(operator), operator, destination, shares)
+		require.NoError(t, err)
+		_, err = application.CustomStakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
+		require.NoError(t, err)
+		dest, err := application.StakingKeeper.GetValidator(ctx, destination)
+		require.NoError(t, err)
+		destConsensus, err := dest.GetConsAddr()
+		require.NoError(t, err)
+		require.NoError(t, application.StakingKeeper.Jail(ctx, destConsensus))
+
+		targetCtx, _ := ctx.CacheContext()
+		_, witness, err := application.prepareZeroHeightState(targetCtx, []string{dest.OperatorAddress})
+		require.NoError(t, err)
+		excluded, err := application.StakingKeeper.GetValidator(targetCtx, operator)
+		require.NoError(t, err)
+		require.True(t, excluded.Jailed)
+		require.True(t, excluded.IsUnbonding())
+		require.Zero(t, excluded.UnbondingHeight)
+		require.NotEmpty(t, excluded.UnbondingIds)
+		params, err := application.StakingKeeper.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, ctx.BlockTime().Add(params.UnbondingTime), excluded.UnbondingTime)
+		included, err := application.StakingKeeper.GetValidator(targetCtx, destination)
+		require.NoError(t, err)
+		require.True(t, included.Jailed, "allowlist must not unjail an already jailed validator")
+		sourceGenesis, err := application.ModuleManager.ExportGenesisForModules(ctx, application.AppCodec(), nil)
+		require.NoError(t, err)
+		targetGenesis, err := application.ModuleManager.ExportGenesisForModules(targetCtx, application.AppCodec(), nil)
+		require.NoError(t, err)
+		require.NoError(t, application.validateZeroHeightStakingContinuity(
+			GenesisState(sourceGenesis), GenesisState(targetGenesis), witness))
+		require.NoError(t, application.validateExportInvariants(GenesisState(targetGenesis)))
+	})
+}
+
+func testApplicationExport(t *testing.T, application *App, blockTime time.Time, committedConsensusParams cmtproto.ConsensusParams, applicationLog *bytes.Buffer, cosmosSender sdk.AccAddress) {
+	exported, err := application.ExportAppStateAndValidators(false, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), exported.Height)
+	require.NotNil(t, exported.ConsensusParams.Abci)
+	require.Equal(t, int64(1), exported.ConsensusParams.Abci.VoteExtensionsEnableHeight)
+	var exportedGenesis GenesisState
+	require.NoError(t, json.Unmarshal(exported.AppState, &exportedGenesis))
+	require.NoError(t, application.ValidateGenesisAtHeight(exportedGenesis, exported.Height))
+	t.Run("normal export restarts in a fresh process", func(t *testing.T) {
+		testExportAppRestart(t, exported, blockTime)
+		testExportNodeRestart(t, exported, blockTime)
+	})
+	t.Run("staking export invariant includes active unbonding balances", func(t *testing.T) {
+		fixture := cloneGenesisState(exportedGenesis)
+		stakingFixture := new(stakingtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			fixture[stakingtypes.ModuleName],
+			stakingFixture,
+		))
+		require.NotEmpty(t, stakingFixture.Validators)
+		unbondingBalance := sdkmath.NewInt(7)
+		stakingFixture.UnbondingDelegations = append(
+			stakingFixture.UnbondingDelegations,
+			stakingtypes.UnbondingDelegation{
+				DelegatorAddress: cosmosSender.String(),
+				ValidatorAddress: stakingFixture.Validators[0].OperatorAddress,
+				Entries: []stakingtypes.UnbondingDelegationEntry{{
+					CreationHeight: 4,
+					CompletionTime: blockTime.Add(24 * time.Hour),
+					InitialBalance: unbondingBalance,
+					Balance:        unbondingBalance,
+					UnbondingId:    1,
+				}},
+			},
+		)
+		fixture[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(stakingFixture)
+
+		bankFixture := new(banktypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			fixture[banktypes.ModuleName],
+			bankFixture,
+		))
+		notBondedPoolAddress := authtypes.NewModuleAddress(stakingtypes.NotBondedPoolName).String()
+		foundNotBondedPool := false
+		for i := range bankFixture.Balances {
+			if bankFixture.Balances[i].Address == notBondedPoolAddress {
+				bankFixture.Balances[i].Coins = bankFixture.Balances[i].Coins.Add(
+					sdk.NewCoin(config.BaseDenom, unbondingBalance),
+				)
+				foundNotBondedPool = true
+			}
+		}
+		if !foundNotBondedPool {
+			bankFixture.Balances = append(bankFixture.Balances, banktypes.Balance{
+				Address: notBondedPoolAddress,
+				Coins:   sdk.NewCoins(sdk.NewCoin(config.BaseDenom, unbondingBalance)),
+			})
+		}
+		fixture[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(bankFixture)
+		require.NoError(t, application.validateStakingExportInvariants(fixture))
+
+		// SDK InitGenesis accounts for pending withdrawals even when their
+		// original validator record has already been removed.
+		removedOperator, err := application.StakingKeeper.ValidatorAddressCodec().BytesToString(
+			bytes.Repeat([]byte{0x6b}, 20),
+		)
+		require.NoError(t, err)
+		stakingFixture.UnbondingDelegations[0].ValidatorAddress = removedOperator
+		fixture[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(stakingFixture)
+		require.NoError(t, application.validateStakingExportInvariants(fixture))
+
+		bankFixture.Balances = slices.DeleteFunc(bankFixture.Balances, func(balance banktypes.Balance) bool {
+			return balance.Address == notBondedPoolAddress
+		})
+		fixture[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(bankFixture)
+		require.ErrorContains(
+			t,
+			application.validateStakingExportInvariants(fixture),
+			"not-bonded pool balance",
+		)
+	})
+	t.Run("staking export invariant rejects extra pool denominations", func(t *testing.T) {
+		fixture := cloneGenesisState(exportedGenesis)
+		bankFixture := new(banktypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			fixture[banktypes.ModuleName],
+			bankFixture,
+		))
+		bondedPoolAddress := authtypes.NewModuleAddress(stakingtypes.BondedPoolName).String()
+		found := false
+		for i := range bankFixture.Balances {
+			if bankFixture.Balances[i].Address == bondedPoolAddress {
+				bankFixture.Balances[i].Coins = bankFixture.Balances[i].Coins.Add(
+					sdk.NewInt64Coin("unexpected", 1),
+				)
+				found = true
+			}
+		}
+		require.True(t, found)
+		fixture[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(bankFixture)
+		require.ErrorContains(
+			t,
+			application.validateStakingExportInvariants(fixture),
+			"bonded pool balance",
+		)
+	})
+	t.Run("distribution export invariant rejects extra module denominations", func(t *testing.T) {
+		fixture := cloneGenesisState(exportedGenesis)
+		bankFixture := new(banktypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			fixture[banktypes.ModuleName],
+			bankFixture,
+		))
+		distributionAddress := authtypes.NewModuleAddress(distrtypes.ModuleName).String()
+		found := false
+		for i := range bankFixture.Balances {
+			if bankFixture.Balances[i].Address == distributionAddress {
+				bankFixture.Balances[i].Coins = bankFixture.Balances[i].Coins.Add(
+					sdk.NewInt64Coin("unexpected", 1),
+				)
+				found = true
+			}
+		}
+		if !found {
+			bankFixture.Balances = append(bankFixture.Balances, banktypes.Balance{
+				Address: distributionAddress,
+				Coins:   sdk.NewCoins(sdk.NewInt64Coin("unexpected", 1)),
+			})
+		}
+		fixture[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(bankFixture)
+		require.ErrorContains(
+			t,
+			application.validateDistributionExportInvariants(fixture),
+			"module balance",
+		)
+	})
+
+	_, err = application.ExportAppStateAndValidators(false, []string{"invalid"}, nil)
+	require.ErrorContains(t, err, "jail allowlist requires zero-height export")
+	_, err = application.ExportAppStateAndValidators(true, nil, []string{banktypes.ModuleName})
+	require.ErrorContains(t, err, "zero-height export requires a complete module export")
+	_, err = application.ExportAppStateAndValidators(true, []string{"invalid"}, nil)
+	require.Error(t, err)
+	_, err = application.ExportAppStateAndValidators(true, nil, nil)
+	require.NoError(t, err)
+
+	var validatedZeroGenesis GenesisState
+	t.Run("internal zero-height pipeline is isolated and emits bootable application state", func(t *testing.T) {
+		exportCtx, err := application.newExportContext(true)
+		require.NoError(t, err)
+		require.Equal(t, committedContext(t, application).BlockTime(), exportCtx.BlockTime())
+		require.Equal(t, application.LastBlockHeight(), exportCtx.BlockHeight())
+		before, err := application.ExportAppStateAndValidators(false, nil, nil)
+		require.NoError(t, err)
+
+		// Export real, nonempty EIP-2935 history without altering the source fixture.
+		sourceCtx, _ := committedContext(t, application).CacheContext()
+		historyKeys := make([]common.Hash, 0)
+		application.EVMKeeper.ForEachStorage(
+			sourceCtx,
+			ethparams.HistoryStorageAddress,
+			func(key, _ common.Hash) bool {
+				historyKeys = append(historyKeys, key)
+				return true
+			},
+		)
+		require.NotEmpty(t, historyKeys)
+		// The source fixture contains the signing state of a real bonded validator.
+		validators, err := application.StakingKeeper.GetAllValidators(sourceCtx)
+		require.NoError(t, err)
+		for _, validator := range validators {
+			if !validator.IsBonded() {
+				continue
+			}
+			address, err := validator.GetConsAddr()
+			require.NoError(t, err)
+			_, err = application.SlashingKeeper.GetValidatorSigningInfo(sourceCtx, address)
+			require.NoError(t, err)
+		}
+
+		zeroExport, err := application.exportZeroHeightGenesis(
+			sourceCtx,
+			nil,
+			committedConsensusParams,
+		)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), zeroExport.Height)
+		require.Equal(t, committedConsensusParams, zeroExport.ConsensusParams)
+		var zeroGenesis GenesisState
+		require.NoError(t, json.Unmarshal(zeroExport.AppState, &zeroGenesis))
+		validatedZeroGenesis = cloneGenesisState(zeroGenesis)
+		testExportAppRestart(t, zeroExport, blockTime)
+		testExportNodeRestart(t, zeroExport, blockTime)
+		require.NoError(t, application.ValidateGenesisAtHeight(
+			zeroGenesis,
+			zeroHeightEffectiveInitialHeight,
+		))
+		require.NoError(t, application.ValidateGenesisConsensusAtHeight(
+			zeroGenesis,
+			zeroHeightEffectiveInitialHeight,
+			&committedConsensusParams,
+		))
+		require.NoError(t, application.validateExportInvariants(zeroGenesis))
+
+		t.Run("preserved enabled task restarts with Oracle disabled", func(t *testing.T) {
+			taskCtx, _ := sourceCtx.CacheContext()
+			task := &oracletypes.OracleTask{
+				Symbol: "BTC/USD", ValueType: oracletypes.ValueType_VALUE_TYPE_NUMERIC,
+				Enabled: true, SubmissionInterval: 5,
+			}
+			require.NoError(t, application.OracleKeeper.SetTask(taskCtx, task))
+			target, err := application.exportZeroHeightGenesis(taskCtx, nil, committedConsensusParams)
+			require.NoError(t, err)
+			var state GenesisState
+			require.NoError(t, json.Unmarshal(target.AppState, &state))
+			oracleState := new(oracletypes.GenesisState)
+			require.NoError(t, application.AppCodec().UnmarshalJSON(state[oracletypes.ModuleName], oracleState))
+			require.Contains(t, oracleState.Tasks, task)
+			require.Empty(t, oracleState.TaskSchedule)
+			require.Empty(t, oracleState.LatestValues)
+			require.Empty(t, oracleState.History)
+			// This is an explicit target launch choice, not source E continuity.
+			target.ConsensusParams.Abci = &cmtproto.ABCIParams{}
+			require.NoError(t, application.ValidateGenesisConsensusAtHeight(state, 1, &target.ConsensusParams))
+			testExportAppRestart(t, target, blockTime)
+			testExportNodeRestart(t, target, blockTime)
+		})
+
+		after, err := application.ExportAppStateAndValidators(false, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, before, after)
+	})
+
+	t.Run("zero-height follows upstream staking lifecycle", func(t *testing.T) {
+		testZeroHeightUpstreamStaking(t, application,
+			committedContext(t, application).WithBlockTime(blockTime.Add(4*time.Second)),
+			committedConsensusParams)
+	})
+
+	t.Run("zero-height continuity rejects unapproved module mutations", func(t *testing.T) {
+		require.NotNil(t, validatedZeroGenesis)
+		emptyWitness := zeroHeightMutationWitness{}
+		require.NoError(t, application.validateZeroHeightEconomicContinuity(
+			validatedZeroGenesis,
+			cloneGenesisState(validatedZeroGenesis),
+			emptyWitness,
+		))
+
+		mutatedAuth := cloneGenesisState(validatedZeroGenesis)
+		mutatedAuthState := new(authtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			mutatedAuth[authtypes.ModuleName],
+			mutatedAuthState,
+		))
+		mutatedAuthState.Params.MaxMemoCharacters++
+		mutatedAuth[authtypes.ModuleName] = application.AppCodec().MustMarshalJSON(mutatedAuthState)
+		require.ErrorContains(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				validatedZeroGenesis,
+				mutatedAuth,
+				emptyWitness,
+			),
+			"auth params changed during zero-height export",
+		)
+
+		missingAuth := cloneGenesisState(validatedZeroGenesis)
+		delete(missingAuth, authtypes.ModuleName)
+		require.ErrorContains(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				validatedZeroGenesis,
+				missingAuth,
+				emptyWitness,
+			),
+			`module "auth" disappeared during zero-height export`,
+		)
+
+		missingOracle := cloneGenesisState(validatedZeroGenesis)
+		delete(missingOracle, oracletypes.ModuleName)
+		require.ErrorContains(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				validatedZeroGenesis,
+				missingOracle,
+				emptyWitness,
+			),
+			`module "oracle" disappeared during zero-height export`,
+		)
+
+		mutableOracle := cloneGenesisState(validatedZeroGenesis)
+		mutableOracleState := new(oracletypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			mutableOracle[oracletypes.ModuleName],
+			mutableOracleState,
+		))
+		mutableOracleState.TaskSchedule = nil
+		mutableOracle[oracletypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			mutableOracleState,
+		)
+		require.NoError(t, application.validateZeroHeightEconomicContinuity(
+			validatedZeroGenesis,
+			mutableOracle,
+			emptyWitness,
+		))
+
+		for _, tc := range []struct {
+			name   string
+			want   string
+			mutate func(GenesisState)
+		}{
+			{
+				name: "bank configuration",
+				want: "bank configuration changed",
+				mutate: func(target GenesisState) {
+					state := new(banktypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[banktypes.ModuleName], state))
+					state.Params.DefaultSendEnabled = !state.Params.DefaultSendEnabled
+					target[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "distribution configuration",
+				want: "distribution configuration or withdrawal routing changed",
+				mutate: func(target GenesisState) {
+					state := new(distrtypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[distrtypes.ModuleName], state))
+					state.Params.CommunityTax = sdkmath.LegacyOneDec()
+					target[distrtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "distribution fractional reward ledger",
+				want: "distribution decimal reward ledger changed",
+				mutate: func(target GenesisState) {
+					state := new(distrtypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[distrtypes.ModuleName], state))
+					state.FeePool.CommunityPool = state.FeePool.CommunityPool.Add(
+						sdk.NewDecCoinFromDec(
+							config.BaseDenom,
+							sdkmath.LegacyMustNewDecFromStr("0.5"),
+						),
+					)
+					target[distrtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "staking delegation",
+				want: "staking state changed outside approved zero-height lifecycle fields",
+				mutate: func(target GenesisState) {
+					state := new(stakingtypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[stakingtypes.ModuleName], state))
+					require.NotEmpty(t, state.Delegations)
+					state.Delegations[0].Shares = state.Delegations[0].Shares.Add(sdkmath.LegacyOneDec())
+					target[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "staking validator jail state",
+				want: "jailed state",
+				mutate: func(target GenesisState) {
+					state := new(stakingtypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[stakingtypes.ModuleName], state))
+					require.NotEmpty(t, state.Validators)
+					state.Validators[0].Jailed = !state.Validators[0].Jailed
+					target[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "staking validator completion time",
+				want: "lifecycle changed without an upstream keeper result",
+				mutate: func(target GenesisState) {
+					state := new(stakingtypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[stakingtypes.ModuleName], state))
+					require.NotEmpty(t, state.Validators)
+					state.Validators[0].UnbondingTime = state.Validators[0].UnbondingTime.Add(time.Second)
+					target[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "staking validator unbonding hold count",
+				want: "staking state changed outside approved zero-height lifecycle fields",
+				mutate: func(target GenesisState) {
+					state := new(stakingtypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[stakingtypes.ModuleName], state))
+					require.NotEmpty(t, state.Validators)
+					state.Validators[0].UnbondingOnHoldRefCount++
+					target[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "slashing configuration",
+				want: "slashing state changed outside approved signing-window fields",
+				mutate: func(target GenesisState) {
+					state := new(slashingtypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[slashingtypes.ModuleName], state))
+					state.Params.SignedBlocksWindow++
+					target[slashingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "oracle params",
+				want: "oracle params or task definitions changed",
+				mutate: func(target GenesisState) {
+					state := new(oracletypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[oracletypes.ModuleName], state))
+					require.NotNil(t, state.Params)
+					state.Params.HistoryLimit++
+					target[oracletypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+			{
+				name: "constitution base address",
+				want: "constitution state changed outside pending minimum gas price",
+				mutate: func(target GenesisState) {
+					state := new(constitutiontypes.GenesisState)
+					require.NoError(t, application.AppCodec().UnmarshalJSON(target[constitutiontypes.ModuleName], state))
+					state.BaseAddress += "-mutated"
+					target[constitutiontypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				target := cloneGenesisState(validatedZeroGenesis)
+				tc.mutate(target)
+				require.ErrorContains(
+					t,
+					application.validateZeroHeightEconomicContinuity(
+						validatedZeroGenesis,
+						target,
+						emptyWitness,
+					),
+					tc.want,
+				)
+			})
+		}
+
+		tombstoneSource := cloneGenesisState(validatedZeroGenesis)
+		tombstoneTarget := cloneGenesisState(validatedZeroGenesis)
+		for _, fixture := range []GenesisState{tombstoneSource, tombstoneTarget} {
+			state := new(slashingtypes.GenesisState)
+			require.NoError(t, application.AppCodec().UnmarshalJSON(fixture[slashingtypes.ModuleName], state))
+			state.SigningInfos = append(state.SigningInfos, slashingtypes.SigningInfo{
+				Address: "synthetic-consensus-address",
+				ValidatorSigningInfo: slashingtypes.ValidatorSigningInfo{
+					Address:    "synthetic-consensus-address",
+					Tombstoned: true,
+				},
+			})
+			state.MissedBlocks = append(state.MissedBlocks, slashingtypes.ValidatorMissedBlocks{
+				Address: "synthetic-consensus-address",
+			})
+			fixture[slashingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(state)
+		}
+		targetSlashing := new(slashingtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			tombstoneTarget[slashingtypes.ModuleName],
+			targetSlashing,
+		))
+		targetSlashing.SigningInfos[len(targetSlashing.SigningInfos)-1].ValidatorSigningInfo.Tombstoned = false
+		tombstoneTarget[slashingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(targetSlashing)
+		require.ErrorContains(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				tombstoneSource,
+				tombstoneTarget,
+				emptyWitness,
+			),
+			"slashing state changed outside approved signing-window fields",
+		)
+
+		unauthorizedBalanceMove := cloneGenesisState(validatedZeroGenesis)
+		bankState := new(banktypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			unauthorizedBalanceMove[banktypes.ModuleName],
+			bankState,
+		))
+		movedCoin := sdk.NewInt64Coin(config.BaseDenom, 1)
+		debited := false
+		for i := range bankState.Balances {
+			if bankState.Balances[i].Coins.AmountOf(config.BaseDenom).IsPositive() {
+				bankState.Balances[i].Coins = bankState.Balances[i].Coins.Sub(movedCoin)
+				debited = true
+				break
+			}
+		}
+		require.True(t, debited)
+		unauthorizedAddress := sdk.AccAddress(bytes.Repeat([]byte{0x7f}, 20)).String()
+		bankState.Balances = append(bankState.Balances, banktypes.Balance{
+			Address: unauthorizedAddress,
+			Coins:   sdk.NewCoins(movedCoin),
+		})
+		unauthorizedBalanceMove[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(bankState)
+		require.ErrorContains(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				validatedZeroGenesis,
+				unauthorizedBalanceMove,
+				emptyWitness,
+			),
+			"bank balance for",
+		)
+
+		t.Run("recorded payout may create only its exact base account", func(t *testing.T) {
+			source := cloneGenesisState(validatedZeroGenesis)
+			target := cloneGenesisState(validatedZeroGenesis)
+			payoutCoin := sdk.NewInt64Coin(config.BaseDenom, 1)
+			payout := sdk.NewCoins(payoutCoin)
+			newAddressBytes := sdk.AccAddress(bytes.Repeat([]byte{0x6a}, 20))
+			newAddress, err := application.AccountKeeper.AddressCodec().BytesToString(newAddressBytes)
+			require.NoError(t, err)
+			distributionAddress, err := application.AccountKeeper.AddressCodec().BytesToString(
+				authtypes.NewModuleAddress(distrtypes.ModuleName),
+			)
+			require.NoError(t, err)
+
+			sourceBank := new(banktypes.GenesisState)
+			require.NoError(t, application.AppCodec().UnmarshalJSON(
+				source[banktypes.ModuleName],
+				sourceBank,
+			))
+			debited := false
+			for i := range sourceBank.Balances {
+				balance := &sourceBank.Balances[i]
+				if balance.Address != distributionAddress &&
+					balance.Coins.AmountOf(config.BaseDenom).IsPositive() {
+					balance.Coins = balance.Coins.Sub(payoutCoin)
+					debited = true
+					break
+				}
+			}
+			require.True(t, debited)
+			distributionFound := false
+			for i := range sourceBank.Balances {
+				if sourceBank.Balances[i].Address == distributionAddress {
+					sourceBank.Balances[i].Coins = sourceBank.Balances[i].Coins.Add(payoutCoin)
+					distributionFound = true
+					break
+				}
+			}
+			if !distributionFound {
+				sourceBank.Balances = append(sourceBank.Balances, banktypes.Balance{
+					Address: distributionAddress,
+					Coins:   payout,
+				})
+			}
+			source[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(sourceBank)
+
+			targetBank := new(banktypes.GenesisState)
+			require.NoError(t, application.AppCodec().UnmarshalJSON(
+				source[banktypes.ModuleName],
+				targetBank,
+			))
+			for i := range targetBank.Balances {
+				if targetBank.Balances[i].Address == distributionAddress {
+					targetBank.Balances[i].Coins = targetBank.Balances[i].Coins.Sub(payoutCoin)
+					break
+				}
+			}
+			targetBank.Balances = append(targetBank.Balances, banktypes.Balance{
+				Address: newAddress,
+				Coins:   payout,
+			})
+			target[banktypes.ModuleName] = application.AppCodec().MustMarshalJSON(targetBank)
+
+			sourceDistribution := new(distrtypes.GenesisState)
+			require.NoError(t, application.AppCodec().UnmarshalJSON(
+				source[distrtypes.ModuleName],
+				sourceDistribution,
+			))
+			sourceDistribution.FeePool.CommunityPool = sourceDistribution.FeePool.CommunityPool.Add(
+				sdk.NewDecCoin(config.BaseDenom, sdkmath.OneInt()),
+			)
+			source[distrtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+				sourceDistribution,
+			)
+
+			targetAuth := new(authtypes.GenesisState)
+			require.NoError(t, application.AppCodec().UnmarshalJSON(
+				target[authtypes.ModuleName],
+				targetAuth,
+			))
+			accounts, err := authtypes.UnpackAccounts(targetAuth.Accounts)
+			require.NoError(t, err)
+			nextAccountNumber := uint64(0)
+			for _, account := range accounts {
+				if account.GetAccountNumber() >= nextAccountNumber {
+					nextAccountNumber = account.GetAccountNumber() + 1
+				}
+			}
+			newAccount := authtypes.NewBaseAccount(
+				newAddressBytes,
+				nil,
+				nextAccountNumber,
+				0,
+			)
+			newAccountAny, err := codectypes.NewAnyWithValue(newAccount)
+			require.NoError(t, err)
+			targetAuth.Accounts = append(targetAuth.Accounts, newAccountAny)
+			target[authtypes.ModuleName] = application.AppCodec().MustMarshalJSON(targetAuth)
+
+			witness := zeroHeightMutationWitness{
+				RewardPayouts:     map[string]sdk.Coins{newAddress: payout},
+				NewRewardAccounts: []string{newAddress},
+			}
+			require.NoError(t, application.validateZeroHeightEconomicContinuity(
+				source,
+				target,
+				witness,
+			))
+
+			newAccount.Sequence = 1
+			newAccountAny, err = codectypes.NewAnyWithValue(newAccount)
+			require.NoError(t, err)
+			targetAuth.Accounts[len(targetAuth.Accounts)-1] = newAccountAny
+			target[authtypes.ModuleName] = application.AppCodec().MustMarshalJSON(targetAuth)
+			require.ErrorContains(t, application.validateZeroHeightEconomicContinuity(
+				source,
+				target,
+				witness,
+			), "invalid base-account state")
+		})
+
+		introducedModules := cloneGenesisState(validatedZeroGenesis)
+		introducedModules["zzz-future-module"] = json.RawMessage(`{}`)
+		introducedModules["aaa-future-module"] = json.RawMessage(`{}`)
+		require.EqualError(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				validatedZeroGenesis,
+				introducedModules,
+				emptyWitness,
+			),
+			`zero-height export introduced modules ["aaa-future-module" "zzz-future-module"]`,
+		)
+
+		malformedBank := cloneGenesisState(validatedZeroGenesis)
+		malformedBank[banktypes.ModuleName] = json.RawMessage(`{`)
+		require.EqualError(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				validatedZeroGenesis,
+				malformedBank,
+				emptyWitness,
+			),
+			`target module "bank" genesis is invalid JSON`,
+		)
+
+		nullAuth := cloneGenesisState(validatedZeroGenesis)
+		nullAuth[authtypes.ModuleName] = json.RawMessage(`null`)
+		require.EqualError(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				validatedZeroGenesis,
+				nullAuth,
+				emptyWitness,
+			),
+			`target module "auth" genesis must be a JSON object`,
+		)
+
+		missingBankSource := cloneGenesisState(validatedZeroGenesis)
+		missingBankTarget := cloneGenesisState(validatedZeroGenesis)
+		delete(missingBankSource, banktypes.ModuleName)
+		delete(missingBankTarget, banktypes.ModuleName)
+		require.EqualError(
+			t,
+			application.validateZeroHeightEconomicContinuity(
+				missingBankSource,
+				missingBankTarget,
+				emptyWitness,
+			),
+			"source bank genesis is missing",
+		)
+	})
+
+	t.Run("zero-height Guru state transformation is deterministic and explicit", func(t *testing.T) {
+		fixture := cloneGenesisState(exportedGenesis)
+
+		oracleFixture := new(oracletypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			fixture[oracletypes.ModuleName],
+			oracleFixture,
+		))
+		originalOracleParams := oracleFixture.Params
+		oracleFixture.Tasks = []*oracletypes.OracleTask{
+			{
+				Symbol:             "ZZZ/USD",
+				ValueType:          oracletypes.ValueType_VALUE_TYPE_NUMERIC,
+				Enabled:            true,
+				SubmissionInterval: 5,
+			},
+			{
+				Symbol:             " aaa/usd ",
+				ValueType:          oracletypes.ValueType_VALUE_TYPE_NUMERIC,
+				Enabled:            true,
+				SubmissionInterval: 3,
+			},
+			{
+				Symbol:             "DISABLED/USD",
+				ValueType:          oracletypes.ValueType_VALUE_TYPE_NUMERIC,
+				Enabled:            false,
+				SubmissionInterval: 7,
+			},
+		}
+		oracleFixture.TaskSchedule = []*oracletypes.OracleTaskScheduleEntry{
+			{Symbol: "ZZZ/USD", Height: 100},
+		}
+		observed := &oracletypes.OracleValue{
+			Symbol:        "ZZZ/USD",
+			ValueType:     oracletypes.ValueType_VALUE_TYPE_NUMERIC,
+			Value:         "1.25",
+			BlockHeight:   4,
+			BlockTimeUnix: blockTime.Unix(),
+		}
+		oracleFixture.LatestValues = []*oracletypes.OracleValue{observed}
+		oracleFixture.History = []*oracletypes.OracleHistory{{
+			Symbol: "ZZZ/USD",
+			Values: []*oracletypes.OracleValue{observed},
+		}}
+		fixture[oracletypes.ModuleName] = application.AppCodec().MustMarshalJSON(oracleFixture)
+
+		constitutionFixture := new(constitutiontypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			fixture[constitutiontypes.ModuleName],
+			constitutionFixture,
+		))
+		constitutionFixture.PendingMinGasPrice = &constitutiontypes.MinGasPriceSchedule{
+			EffectiveHeight:                20,
+			ScheduledMinGasPrice:           "0.5",
+			SourceSymbol:                   "ZZZ/USD",
+			SourceValue:                    "0.5",
+			SourceOracleHeight:             4,
+			SourceSubmissionIntervalBlocks: 5,
+			PendingDelayBlocks:             16,
+			PendingDelayCapBlocks:          20,
+			RawMinGasPrice:                 "0.5",
+			PreviousMinGasPrice:            "1.0",
+		}
+		fixture[constitutiontypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			constitutionFixture,
+		)
+
+		originalEVM := slices.Clone(fixture[evmtypes.ModuleName])
+		receipt := zeroHeightExportReceipt{}
+		require.NoError(t, application.transformZeroHeightGenesis(fixture, &receipt))
+		// This helper rewrites only Guru-owned genesis documents. The full
+		// export path applies the SDK staking/slashing state transition first.
+		require.NoError(t, application.ValidateGenesis(fixture))
+		require.Equal(t, 3, receipt.OracleTasksPreserved)
+		require.Equal(t, 1, receipt.OracleSchedulesRemoved)
+		require.Equal(t, 1, receipt.OracleLatestValuesRemoved)
+		require.Equal(t, 1, receipt.OracleHistoriesRemoved)
+		require.Equal(t, 1, receipt.ConstitutionPendingRemoved)
+		require.NoError(t, application.validateZeroHeightEVMContinuity(
+			GenesisState{evmtypes.ModuleName: originalEVM}, fixture))
+
+		transformedOracle := new(oracletypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			fixture[oracletypes.ModuleName],
+			transformedOracle,
+		))
+		require.Equal(t, originalOracleParams, transformedOracle.Params)
+		require.Equal(t, oracleFixture.Tasks, transformedOracle.Tasks)
+		require.Empty(t, transformedOracle.LatestValues)
+		require.Empty(t, transformedOracle.History)
+		require.Empty(t, transformedOracle.TaskSchedule)
+
+		transformedConstitution := new(constitutiontypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			fixture[constitutiontypes.ModuleName],
+			transformedConstitution,
+		))
+		require.Nil(t, transformedConstitution.PendingMinGasPrice)
+
+		consensusParams := &cmtproto.ConsensusParams{Abci: &cmtproto.ABCIParams{
+			VoteExtensionsEnableHeight: 10,
+		}}
+		require.ErrorContains(t, application.ValidateGenesisConsensusAtHeight(
+			fixture, zeroHeightEffectiveInitialHeight, consensusParams,
+		), "initial Oracle schedule has 0 entries")
+		require.NoError(t, application.ValidateGenesisConsensusAtHeight(
+			fixture, zeroHeightEffectiveInitialHeight,
+			&cmtproto.ConsensusParams{Abci: &cmtproto.ABCIParams{}},
+		))
+		require.ErrorContains(t, application.ValidateGenesisConsensusAtHeight(
+			fixture, exported.Height, consensusParams,
+		), "configure target Oracle before startup")
+		// Operations prepares a fresh target schedule after export.
+		transformedOracle.TaskSchedule, err = buildInitialOracleSchedule(transformedOracle.Tasks, 10)
+		require.NoError(t, err)
+		fixture[oracletypes.ModuleName] = application.AppCodec().MustMarshalJSON(transformedOracle)
+		require.ErrorContains(t, application.ValidateGenesisConsensusAtHeight(
+			fixture, zeroHeightEffectiveInitialHeight,
+			&cmtproto.ConsensusParams{Abci: &cmtproto.ABCIParams{}},
+		), "disabled target Oracle must have an empty initial schedule")
+		require.NoError(t, application.ValidateGenesisConsensusAtHeight(
+			fixture,
+			zeroHeightEffectiveInitialHeight,
+			consensusParams,
+		))
+
+		require.NotNil(t, validatedZeroGenesis)
+		restartFixture := cloneGenesisState(validatedZeroGenesis)
+		staleDistribution := cloneGenesisState(restartFixture)
+		staleDistributionState := new(distrtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			staleDistribution[distrtypes.ModuleName],
+			staleDistributionState,
+		))
+		require.NotEmpty(t, staleDistributionState.OutstandingRewards)
+		staleDistributionState.OutstandingRewards[0].OutstandingRewards =
+			staleDistributionState.OutstandingRewards[0].OutstandingRewards.Add(
+				sdk.NewDecCoinFromDec(
+					config.BaseDenom,
+					sdkmath.LegacyMustNewDecFromStr("0.5"),
+				),
+			)
+		staleDistribution[distrtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			staleDistributionState,
+		)
+		require.ErrorContains(t, application.ValidateGenesisAtHeight(
+			staleDistribution,
+			zeroHeightEffectiveInitialHeight,
+		), "target distribution outstanding rewards")
+
+		staleOracle := cloneGenesisState(restartFixture)
+		staleOracleState := new(oracletypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			staleOracle[oracletypes.ModuleName],
+			staleOracleState,
+		))
+		staleOracleState.LatestValues = []*oracletypes.OracleValue{observed}
+		staleOracle[oracletypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			staleOracleState,
+		)
+		require.ErrorContains(t, application.ValidateGenesisAtHeight(
+			staleOracle,
+			zeroHeightEffectiveInitialHeight,
+		), "target Oracle observations were not removed")
+
+		pendingConstitution := cloneGenesisState(restartFixture)
+		pendingConstitutionState := new(constitutiontypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			pendingConstitution[constitutiontypes.ModuleName],
+			pendingConstitutionState,
+		))
+		pendingConstitutionState.PendingMinGasPrice = &constitutiontypes.MinGasPriceSchedule{
+			EffectiveHeight:                15,
+			ScheduledMinGasPrice:           "630000000000.000000000000000000",
+			SourceSymbol:                   config.MinGasPriceOracleSymbol,
+			SourceValue:                    "1.0",
+			SourceOracleHeight:             10,
+			SourceSubmissionIntervalBlocks: 5,
+			PendingDelayBlocks:             5,
+			PendingDelayCapBlocks:          constitutiontypes.MinGasPricePendingDelayCap,
+			RawMinGasPrice:                 constitutiontypes.MinGasPriceScaleFactor,
+			PreviousMinGasPrice:            "630000000000.000000000000000000",
+		}
+		pendingConstitution[constitutiontypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			pendingConstitutionState,
+		)
+		require.ErrorContains(t, application.ValidateGenesisAtHeight(
+			pendingConstitution,
+			zeroHeightEffectiveInitialHeight,
+		), "target Constitution pending minimum gas price was not removed")
+
+		nonzeroStakingHeight := cloneGenesisState(restartFixture)
+		nonzeroStakingState := new(stakingtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			nonzeroStakingHeight[stakingtypes.ModuleName],
+			nonzeroStakingState,
+		))
+		require.NotEmpty(t, nonzeroStakingState.Validators)
+		nonzeroStakingState.Validators[0].UnbondingHeight = 4
+		nonzeroStakingHeight[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			nonzeroStakingState,
+		)
+		require.ErrorContains(t, application.ValidateGenesisAtHeight(
+			nonzeroStakingHeight,
+			zeroHeightEffectiveInitialHeight,
+		), "has nonzero unbonding height 4")
+
+		pendingStaking := cloneGenesisState(restartFixture)
+		pendingStakingState := new(stakingtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			pendingStaking[stakingtypes.ModuleName],
+			pendingStakingState,
+		))
+		require.NotEmpty(t, pendingStakingState.Validators)
+		pendingStakingState.Validators[0].UnbondingIds = []uint64{1}
+		pendingStaking[stakingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			pendingStakingState,
+		)
+		// Upstream owns unbonding IDs; the zero-height boundary must not ban them.
+		require.NoError(t, application.ValidateGenesisAtHeight(
+			pendingStaking,
+			zeroHeightEffectiveInitialHeight,
+		))
+
+		staleSlashing := cloneGenesisState(restartFixture)
+		staleSlashingState := new(slashingtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			staleSlashing[slashingtypes.ModuleName],
+			staleSlashingState,
+		))
+		consensusAddress, err := nonzeroStakingState.Validators[0].GetConsAddr()
+		require.NoError(t, err)
+		encodedConsensusAddress, err := application.StakingKeeper.ConsensusAddressCodec().BytesToString(
+			consensusAddress,
+		)
+		require.NoError(t, err)
+		staleSlashingState.SigningInfos = []slashingtypes.SigningInfo{{
+			Address: encodedConsensusAddress,
+			ValidatorSigningInfo: slashingtypes.NewValidatorSigningInfo(
+				sdk.ConsAddress(consensusAddress),
+				0,
+				0,
+				time.Unix(0, 0),
+				false,
+				1,
+			),
+		}}
+		staleSlashingState.MissedBlocks = []slashingtypes.ValidatorMissedBlocks{{
+			Address: encodedConsensusAddress,
+		}}
+		staleSlashing[slashingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			staleSlashingState,
+		)
+		require.ErrorContains(t, application.ValidateGenesisAtHeight(
+			staleSlashing,
+			zeroHeightEffectiveInitialHeight,
+		), "target signing info")
+
+		missingActiveSlashing := cloneGenesisState(restartFixture)
+		missingActiveSlashingState := new(slashingtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			missingActiveSlashing[slashingtypes.ModuleName],
+			missingActiveSlashingState,
+		))
+		require.NotEmpty(t, missingActiveSlashingState.SigningInfos)
+		missingActiveSlashingState.SigningInfos = nil
+		missingActiveSlashingState.MissedBlocks = nil
+		missingActiveSlashing[slashingtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			missingActiveSlashingState,
+		)
+		require.ErrorContains(t, application.ValidateGenesisAtHeight(
+			missingActiveSlashing,
+			zeroHeightEffectiveInitialHeight,
+		), "missing signing info")
+
+		nonemptyRestartHistory := cloneGenesisState(restartFixture)
+		nonemptyRestartEVM := new(evmtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			nonemptyRestartHistory[evmtypes.ModuleName],
+			nonemptyRestartEVM,
+		))
+		historyFound := false
+		for i := range nonemptyRestartEVM.Accounts {
+			if common.HexToAddress(nonemptyRestartEVM.Accounts[i].Address) ==
+				ethparams.HistoryStorageAddress {
+				nonemptyRestartEVM.Accounts[i].Storage = evmtypes.Storage{
+					evmtypes.NewState(common.Hash{}, common.HexToHash("0x01")),
+				}
+				historyFound = true
+			}
+		}
+		require.True(t, historyFound)
+		nonemptyRestartHistory[evmtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			nonemptyRestartEVM,
+		)
+		require.ErrorContains(t, application.ValidateGenesisAtHeight(
+			nonemptyRestartHistory,
+			zeroHeightEffectiveInitialHeight,
+		), "EIP-2935")
+
+		require.ErrorContains(t, application.ValidateGenesisConsensusAtHeight(
+			fixture,
+			zeroHeightEffectiveInitialHeight,
+			nil,
+		), "consensus params are required")
+		require.ErrorContains(t, application.ValidateGenesisConsensusAtHeight(
+			fixture,
+			zeroHeightEffectiveInitialHeight,
+			&cmtproto.ConsensusParams{},
+		), "ABCI consensus params are required")
+		mismatchedSchedule := cloneGenesisState(fixture)
+		mismatchedOracle := new(oracletypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			mismatchedSchedule[oracletypes.ModuleName],
+			mismatchedOracle,
+		))
+		mismatchedOracle.TaskSchedule[0].Height++
+		mismatchedSchedule[oracletypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			mismatchedOracle,
+		)
+		require.ErrorContains(t, application.ValidateGenesisConsensusAtHeight(
+			mismatchedSchedule,
+			zeroHeightEffectiveInitialHeight,
+			consensusParams,
+		), "expected AAA/USD@13")
+		require.NoError(t, application.ValidateGenesisConsensusAtHeight(
+			mismatchedSchedule,
+			exported.Height,
+			nil,
+		))
+
+		zeroInterval := cloneGenesisState(exportedGenesis)
+		invalidOracle := new(oracletypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			zeroInterval[oracletypes.ModuleName],
+			invalidOracle,
+		))
+		invalidOracle.Tasks = []*oracletypes.OracleTask{{
+			Symbol:    "INVALID/USD",
+			ValueType: oracletypes.ValueType_VALUE_TYPE_NUMERIC,
+			Enabled:   true,
+		}}
+		zeroInterval[oracletypes.ModuleName] = application.AppCodec().MustMarshalJSON(invalidOracle)
+		require.ErrorContains(
+			t,
+			application.transformZeroHeightGenesis(
+				zeroInterval,
+				&zeroHeightExportReceipt{},
+			),
+			"zero submission_interval",
+		)
+
+		nonemptyHistory := cloneGenesisState(exportedGenesis)
+		evmFixture := new(evmtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			nonemptyHistory[evmtypes.ModuleName],
+			evmFixture,
+		))
+		nonemptyHistoryFound := false
+		for i := range evmFixture.Accounts {
+			if common.HexToAddress(evmFixture.Accounts[i].Address) == ethparams.HistoryStorageAddress {
+				nonemptyHistoryFound = true
+				evmFixture.Accounts[i].Storage = evmtypes.Storage{
+					evmtypes.NewState(common.Hash{}, common.HexToHash("0x01")),
+				}
+			}
+		}
+		require.True(t, nonemptyHistoryFound)
+		evmFixture.Accounts = append(evmFixture.Accounts, evmtypes.GenesisAccount{
+			Address: "0x0000000000000000000000000000000000123456", Code: "0x6000",
+			Storage: evmtypes.Storage{evmtypes.NewState(common.Hash{}, common.HexToHash("0x02"))},
+		})
+		nonemptyHistory[evmtypes.ModuleName] = application.AppCodec().MustMarshalJSON(evmFixture)
+		nonemptyEVM := slices.Clone(nonemptyHistory[evmtypes.ModuleName])
+		require.NoError(t, application.validateEVMHistoryContract(nonemptyHistory, false))
+		require.Equal(t, nonemptyEVM, nonemptyHistory[evmtypes.ModuleName])
+		historyReceipt := new(zeroHeightExportReceipt)
+		require.NoError(t, application.transformZeroHeightEVM(nonemptyHistory, historyReceipt))
+		require.Equal(t, 1, historyReceipt.EVMHistorySlotsRemoved)
+		require.NoError(t, application.validateEVMHistoryContract(nonemptyHistory, true))
+		require.NoError(t, application.validateZeroHeightEVMContinuity(
+			GenesisState{evmtypes.ModuleName: nonemptyEVM}, nonemptyHistory))
+		for _, mutation := range []string{"other storage", "other code", "history code", "history retained", "duplicate history", "missing history"} {
+			t.Run(mutation, func(t *testing.T) {
+				state := new(evmtypes.GenesisState)
+				require.NoError(t, application.AppCodec().UnmarshalJSON(nonemptyHistory[evmtypes.ModuleName], state))
+				for i := range state.Accounts {
+					if common.HexToAddress(state.Accounts[i].Address) != ethparams.HistoryStorageAddress {
+						continue
+					}
+					switch mutation {
+					case "history code":
+						state.Accounts[i].Code = "0x6000"
+					case "history retained":
+						state.Accounts[i].Storage = evmtypes.Storage{evmtypes.NewState(common.Hash{}, common.HexToHash("0x01"))}
+					case "duplicate history":
+						state.Accounts = append(state.Accounts, state.Accounts[i])
+					case "missing history":
+						state.Accounts = append(state.Accounts[:i], state.Accounts[i+1:]...)
+					}
+					break
+				}
+				if mutation == "other storage" {
+					state.Accounts[len(state.Accounts)-1].Storage = nil
+				}
+				if mutation == "other code" {
+					state.Accounts[len(state.Accounts)-1].Code = "0x6001"
+				}
+				target := GenesisState{evmtypes.ModuleName: application.AppCodec().MustMarshalJSON(state)}
+				require.Error(t, application.validateZeroHeightEVMContinuity(GenesisState{evmtypes.ModuleName: nonemptyEVM}, target))
+			})
+		}
+	})
+	t.Run("failed cached transformation leaves source export unchanged", func(t *testing.T) {
+		before, err := application.ExportAppStateAndValidators(false, nil, nil)
+		require.NoError(t, err)
+
+		sourceCtx := committedContext(t, application)
+		targetCtx, _ := sourceCtx.CacheContext()
+		_, _, err = application.prepareZeroHeightState(targetCtx, nil)
+		require.NoError(t, err)
+
+		invalid := cloneGenesisState(exportedGenesis)
+		invalidOracle := new(oracletypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			invalid[oracletypes.ModuleName],
+			invalidOracle,
+		))
+		invalidOracle.Tasks = []*oracletypes.OracleTask{{
+			Symbol:    "INVALID/USD",
+			ValueType: oracletypes.ValueType_VALUE_TYPE_NUMERIC,
+			Enabled:   true,
+		}}
+		invalid[oracletypes.ModuleName] = application.AppCodec().MustMarshalJSON(invalidOracle)
+		require.ErrorContains(
+			t,
+			application.transformZeroHeightGenesis(invalid, &zeroHeightExportReceipt{}),
+			"zero submission_interval",
+		)
+
+		after, err := application.ExportAppStateAndValidators(false, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, before.AppState, after.AppState)
+		require.Equal(t, before.Validators, after.Validators)
+		require.Equal(t, before.Height, after.Height)
+		require.Equal(t, before.ConsensusParams, after.ConsensusParams)
+	})
+
+	t.Run("zero-height preflight rejects unhandled continuity state", func(t *testing.T) {
+		unknownModule := cloneGenesisState(exportedGenesis)
+		unknownModule["zzz-future-height-state"] = json.RawMessage(`{}`)
+		unknownModule["aaa-future-height-state"] = json.RawMessage(`{}`)
+		require.EqualError(
+			t,
+			validateHandledZeroHeightModules(unknownModule),
+			`zero-height policy is undefined for modules ["aaa-future-height-state" "zzz-future-height-state"]`,
+		)
+
+		missingPersistentDocument := cloneGenesisState(exportedGenesis)
+		delete(missingPersistentDocument, banktypes.ModuleName)
+		require.EqualError(
+			t,
+			application.validateZeroHeightModuleInventory(missingPersistentDocument),
+			`zero-height export is missing genesis documents for persistent stores ["bank"]`,
+		)
+
+		ibcFixture := cloneGenesisState(exportedGenesis)
+		ibcGenesis := new(ibccoretypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			ibcFixture["ibc"],
+			ibcGenesis,
+		))
+		ibcGenesis.ClientGenesis.NextClientSequence = 1
+		ibcFixture["ibc"] = application.AppCodec().MustMarshalJSON(ibcGenesis)
+		require.NoError(
+			t,
+			application.validateNoActiveIBCLifecycle(committedContext(t, application), ibcFixture),
+		)
+		nonCanonicalLocalhost := cloneGenesisState(exportedGenesis)
+		nonCanonicalIBC := new(ibccoretypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			nonCanonicalLocalhost["ibc"],
+			nonCanonicalIBC,
+		))
+		localhostFound := false
+		for i := range nonCanonicalIBC.ConnectionGenesis.Connections {
+			if nonCanonicalIBC.ConnectionGenesis.Connections[i].Id ==
+				ibcexported.LocalhostConnectionID {
+				nonCanonicalIBC.ConnectionGenesis.Connections[i].State = connectiontypes.INIT
+				localhostFound = true
+			}
+		}
+		require.True(t, localhostFound)
+		nonCanonicalLocalhost["ibc"] = application.AppCodec().MustMarshalJSON(nonCanonicalIBC)
+		require.ErrorContains(
+			t,
+			application.validateNoActiveIBCLifecycle(
+				committedContext(t, application),
+				nonCanonicalLocalhost,
+			),
+			"connection-localhost(non-canonical)",
+		)
+		ibcGenesis.ChannelGenesis.Commitments = []channeltypes.PacketState{{
+			PortId:    "transfer",
+			ChannelId: "channel-0",
+			Sequence:  1,
+			Data:      []byte{0x01},
+		}}
+		ibcFixture["ibc"] = application.AppCodec().MustMarshalJSON(ibcGenesis)
+		require.ErrorContains(
+			t,
+			application.validateNoActiveIBCLifecycle(committedContext(t, application), ibcFixture),
+			"packet_commitments=1",
+		)
+
+		governanceFixture := cloneGenesisState(exportedGenesis)
+		governanceGenesis := new(govv1.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			governanceFixture[govtypes.ModuleName],
+			governanceGenesis,
+		))
+		governanceGenesis.Proposals = append(governanceGenesis.Proposals, &govv1.Proposal{
+			Id:     99,
+			Status: govv1.StatusVotingPeriod,
+		}, &govv1.Proposal{
+			Id:     100,
+			Status: govv1.StatusNil,
+		})
+		governanceFixture[govtypes.ModuleName] = application.AppCodec().MustMarshalJSON(
+			governanceGenesis,
+		)
+		require.ErrorContains(
+			t,
+			application.validateNoActiveGovernance(governanceFixture),
+			"99(PROPOSAL_STATUS_VOTING_PERIOD)",
+		)
+		require.ErrorContains(
+			t,
+			application.validateNoActiveGovernance(governanceFixture),
+			"100(PROPOSAL_STATUS_UNSPECIFIED)",
+		)
+
+		upgradeCtx, _ := committedContext(t, application).CacheContext()
+		require.NoError(t, application.UpgradeKeeper.ScheduleUpgrade(upgradeCtx, upgradetypes.Plan{
+			Name:   "pending-zero-height-test",
+			Height: application.LastBlockHeight() + 100,
+		}))
+		require.ErrorContains(
+			t,
+			application.validateZeroHeightPreflight(upgradeCtx, exportedGenesis),
+			"pending software upgrade",
+		)
+
+		evmMissingHistory := cloneGenesisState(exportedGenesis)
+		evmGenesis := new(evmtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			evmMissingHistory[evmtypes.ModuleName],
+			evmGenesis,
+		))
+		accounts := evmGenesis.Accounts[:0]
+		for _, account := range evmGenesis.Accounts {
+			if common.HexToAddress(account.Address) != ethparams.HistoryStorageAddress {
+				accounts = append(accounts, account)
+			}
+		}
+		evmGenesis.Accounts = accounts
+		evmMissingHistory[evmtypes.ModuleName] = application.AppCodec().MustMarshalJSON(evmGenesis)
+		require.ErrorContains(
+			t,
+			application.validateEVMHistoryContract(evmMissingHistory, false),
+			"EIP-2935 history contract account is missing",
+		)
+	})
+
+	t.Run("zero-height jail allowlist permits upstream bonded exclusion", func(t *testing.T) {
+		ctx := committedContext(t, application)
+		validators, err := application.StakingKeeper.GetAllValidators(ctx)
+		require.NoError(t, err)
+		bondedIndex := slices.IndexFunc(validators, func(validator stakingtypes.Validator) bool {
+			return validator.IsBonded()
+		})
+		require.NotEqual(t, -1, bondedIndex)
+
+		inactive := validators[bondedIndex]
+		inactiveOperator, err := application.StakingKeeper.ValidatorAddressCodec().BytesToString(
+			bytes.Repeat([]byte{0x7a}, 20),
+		)
+		require.NoError(t, err)
+		require.NotEqual(t, inactive.OperatorAddress, inactiveOperator)
+		inactive.OperatorAddress = inactiveOperator
+		inactive.Status = stakingtypes.Unbonded
+		validators = append(validators, inactive)
+
+		_, err = application.validateJailAllowlist(ctx, validators, []string{inactiveOperator})
+		require.NoError(t, err)
+	})
+
+	t.Run("zero-height jail allowlist cannot recover tombstoned validators", func(t *testing.T) {
+		tombstoneCtx, _ := committedContext(t, application).CacheContext()
+		exportedStaking := new(stakingtypes.GenesisState)
+		require.NoError(t, application.AppCodec().UnmarshalJSON(
+			exportedGenesis[stakingtypes.ModuleName],
+			exportedStaking,
+		))
+		require.NotEmpty(t, exportedStaking.Validators)
+		operator := exportedStaking.Validators[0].OperatorAddress
+		operatorBytes, err := application.StakingKeeper.ValidatorAddressCodec().StringToBytes(operator)
+		require.NoError(t, err)
+		validator, err := application.StakingKeeper.GetValidator(tombstoneCtx, operatorBytes)
+		require.NoError(t, err)
+		consensusAddress, err := validator.GetConsAddr()
+		require.NoError(t, err)
+		signingInfo, err := application.SlashingKeeper.GetValidatorSigningInfo(
+			tombstoneCtx,
+			consensusAddress,
+		)
+		if err != nil {
+			require.ErrorIs(t, err, slashingtypes.ErrNoSigningInfoFound)
+			signingInfo = slashingtypes.NewValidatorSigningInfo(
+				consensusAddress,
+				application.LastBlockHeight(),
+				0,
+				blockTime,
+				false,
+				0,
+			)
+		}
+		signingInfo.Tombstoned = true
+		require.NoError(t, application.SlashingKeeper.SetValidatorSigningInfo(
+			tombstoneCtx,
+			consensusAddress,
+			signingInfo,
+		))
+		validators, err := application.StakingKeeper.GetAllValidators(tombstoneCtx)
+		require.NoError(t, err)
+		_, err = application.validateJailAllowlist(tombstoneCtx, validators, []string{operator})
+		require.ErrorContains(t, err, "cannot unjail tombstoned validator")
+	})
+
+}

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"slices"
+	"sort"
 
 	sdkmath "cosmossdk.io/math"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
@@ -22,6 +26,8 @@ import (
 
 	"github.com/gurufinglobal/guru/v2/config"
 	constitutiontypes "github.com/gurufinglobal/guru/v2/x/constitution/types"
+	oraclekeeper "github.com/gurufinglobal/guru/v2/x/oracle/keeper"
+	oracletypes "github.com/gurufinglobal/guru/v2/x/oracle/types"
 )
 
 // GenesisState contains the module genesis documents consumed by InitChain.
@@ -156,6 +162,9 @@ func (app *App) ValidateGenesis(genesis GenesisState) error {
 // state-transition constraints that depend on its initial block height.
 func (app *App) ValidateGenesisAtHeight(genesis GenesisState, initialHeight int64) error {
 	if err := app.ValidateGenesis(genesis); err != nil {
+		return err
+	}
+	if err := app.validateZeroHeightRestartState(genesis, initialHeight); err != nil {
 		return err
 	}
 
@@ -404,4 +413,216 @@ func mustInt(value string) sdkmath.Int {
 		panic(fmt.Errorf("invalid integer constant %q", value))
 	}
 	return result
+}
+
+func (app *App) ValidateGenesisConsensusAtHeight(
+	genesis GenesisState,
+	initialHeight int64,
+	consensusParams *cmtproto.ConsensusParams,
+) error {
+	// Module validation permits an empty schedule as an export/configuration
+	// artifact. An active chain must never start with unscheduled enabled tasks,
+	// including ordinary and height-preserving genesis imports.
+	if consensusParams != nil && consensusParams.Abci != nil && consensusParams.Abci.VoteExtensionsEnableHeight > 0 {
+		state := new(oracletypes.GenesisState)
+		if err := app.AppCodec().UnmarshalJSON(genesis[oracletypes.ModuleName], state); err != nil {
+			return fmt.Errorf("decode oracle genesis: %w", err)
+		}
+		if len(state.TaskSchedule) == 0 {
+			for _, task := range state.Tasks {
+				if task.GetEnabled() {
+					return fmt.Errorf("initial Oracle schedule has 0 entries for enabled task %q; configure target Oracle before startup", task.GetSymbol())
+				}
+			}
+		}
+	}
+	if initialHeight != zeroHeightEffectiveInitialHeight {
+		return nil
+	}
+	stakingRaw, ok := genesis[stakingtypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("staking genesis is missing")
+	}
+	stakingState := new(stakingtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(stakingRaw, stakingState); err != nil {
+		return fmt.Errorf("decode staking genesis: %w", err)
+	}
+	if !stakingState.Exported {
+		return nil
+	}
+	if consensusParams == nil {
+		return fmt.Errorf("consensus params are required to validate the initial Oracle schedule")
+	}
+	if consensusParams.Abci == nil {
+		return fmt.Errorf("ABCI consensus params are required to validate the initial Oracle schedule")
+	}
+	voteExtensionsEnableHeight := consensusParams.Abci.VoteExtensionsEnableHeight
+	raw, ok := genesis[oracletypes.ModuleName]
+	if !ok {
+		return fmt.Errorf("oracle genesis is missing")
+	}
+	state := new(oracletypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(raw, state); err != nil {
+		return fmt.Errorf("decode oracle genesis: %w", err)
+	}
+	if voteExtensionsEnableHeight == 0 {
+		if len(state.TaskSchedule) != 0 {
+			return fmt.Errorf("disabled target Oracle must have an empty initial schedule")
+		}
+		return nil
+	}
+	expected, err := buildInitialOracleSchedule(state.Tasks, voteExtensionsEnableHeight)
+	if err != nil {
+		return err
+	}
+	if len(state.TaskSchedule) != len(expected) {
+		return fmt.Errorf(
+			"initial Oracle schedule has %d entries; expected %d from vote_extensions_enable_height %d",
+			len(state.TaskSchedule),
+			len(expected),
+			voteExtensionsEnableHeight,
+		)
+	}
+	for i := range expected {
+		actual := state.TaskSchedule[i]
+		if actual == nil {
+			return fmt.Errorf("initial Oracle schedule contains a nil entry at index %d", i)
+		}
+		if actual.Symbol != expected[i].Symbol || actual.Height != expected[i].Height {
+			return fmt.Errorf(
+				"initial Oracle schedule entry %d is %s@%d; expected %s@%d from vote_extensions_enable_height %d",
+				i,
+				actual.Symbol,
+				actual.Height,
+				expected[i].Symbol,
+				expected[i].Height,
+				voteExtensionsEnableHeight,
+			)
+		}
+	}
+	return nil
+}
+
+// validateZeroHeightRestartState rejects an edited or hand-built exported
+// genesis before InitGenesis can reintroduce source-height lifecycle state.
+// Consensus-owned Oracle scheduling is checked separately with the CometBFT
+// consensus parameters in ValidateGenesisConsensusAtHeight.
+func (app *App) validateZeroHeightRestartState(
+	genesis GenesisState,
+	initialHeight int64,
+) error {
+	if initialHeight != zeroHeightEffectiveInitialHeight {
+		return nil
+	}
+
+	stakingState := new(stakingtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(genesis[stakingtypes.ModuleName], stakingState); err != nil {
+		return fmt.Errorf("decode staking genesis for zero-height restart: %w", err)
+	}
+	if !stakingState.Exported {
+		return nil
+	}
+	if err := validateZeroHeightStakingTarget(stakingState); err != nil {
+		return fmt.Errorf("validate zero-height restart staking state: %w", err)
+	}
+	distributionState := new(distrtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(
+		genesis[distrtypes.ModuleName],
+		distributionState,
+	); err != nil {
+		return fmt.Errorf("decode distribution genesis for zero-height restart: %w", err)
+	}
+	if err := validateZeroHeightDistributionTarget(distributionState, stakingState); err != nil {
+		return fmt.Errorf("validate zero-height restart distribution state: %w", err)
+	}
+
+	oracleState := new(oracletypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(genesis[oracletypes.ModuleName], oracleState); err != nil {
+		return fmt.Errorf("decode oracle genesis for zero-height restart: %w", err)
+	}
+	if err := validateZeroHeightOracleTarget(oracleState); err != nil {
+		return fmt.Errorf("validate zero-height restart Oracle state: %w", err)
+	}
+
+	constitutionState := new(constitutiontypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(
+		genesis[constitutiontypes.ModuleName],
+		constitutionState,
+	); err != nil {
+		return fmt.Errorf("decode constitution genesis for zero-height restart: %w", err)
+	}
+	if err := validateZeroHeightConstitutionTarget(constitutionState); err != nil {
+		return fmt.Errorf("validate zero-height restart Constitution state: %w", err)
+	}
+	if err := app.validateEVMHistoryContract(genesis, true); err != nil {
+		return fmt.Errorf("validate zero-height restart EIP-2935 state: %w", err)
+	}
+
+	slashingState := new(slashingtypes.GenesisState)
+	if err := app.AppCodec().UnmarshalJSON(genesis[slashingtypes.ModuleName], slashingState); err != nil {
+		return fmt.Errorf("decode slashing genesis for zero-height restart: %w", err)
+	}
+	if err := app.validateZeroHeightSlashingTarget(slashingState, stakingState); err != nil {
+		return fmt.Errorf("validate zero-height restart slashing state: %w", err)
+	}
+	if err := app.validateExportInvariants(genesis); err != nil {
+		return fmt.Errorf("validate zero-height restart export invariants: %w", err)
+	}
+
+	return nil
+}
+
+// buildInitialOracleSchedule defines the target launch schedule, never the export transform.
+func buildInitialOracleSchedule(
+	tasks []*oracletypes.OracleTask,
+	voteExtensionsEnableHeight int64,
+) ([]*oracletypes.OracleTaskScheduleEntry, error) {
+	if voteExtensionsEnableHeight < 0 {
+		return nil, fmt.Errorf(
+			"vote extensions enable height cannot be negative: %d",
+			voteExtensionsEnableHeight,
+		)
+	}
+	baseHeight := zeroHeightEffectiveInitialHeight
+	if voteExtensionsEnableHeight > baseHeight {
+		baseHeight = voteExtensionsEnableHeight
+	}
+	schedule := make([]*oracletypes.OracleTaskScheduleEntry, 0, 2*len(tasks))
+	for _, task := range tasks {
+		if task == nil {
+			return nil, fmt.Errorf("oracle genesis contains a nil task")
+		}
+		if !task.Enabled {
+			continue
+		}
+		interval := int64(task.GetSubmissionInterval())
+		if interval == 0 {
+			return nil, fmt.Errorf(
+				"enabled oracle task %q has zero submission_interval",
+				task.Symbol,
+			)
+		}
+		if baseHeight > math.MaxInt64-(2*interval) {
+			return nil, fmt.Errorf("oracle task %q target schedule overflows int64", task.Symbol)
+		}
+		symbol := oraclekeeper.NormalizeSymbol(task.Symbol)
+		schedule = append(
+			schedule,
+			&oracletypes.OracleTaskScheduleEntry{
+				Symbol: symbol,
+				Height: baseHeight + interval,
+			},
+			&oracletypes.OracleTaskScheduleEntry{
+				Symbol: symbol,
+				Height: baseHeight + 2*interval,
+			},
+		)
+	}
+	sort.Slice(schedule, func(i, j int) bool {
+		if schedule[i].Symbol == schedule[j].Symbol {
+			return schedule[i].Height < schedule[j].Height
+		}
+		return schedule[i].Symbol < schedule[j].Symbol
+	})
+	return schedule, nil
 }

--- a/cmd/gurud/cmd/export_test.go
+++ b/cmd/gurud/cmd/export_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cosmossdk.io/log"
+	cmttypes "github.com/cometbft/cometbft/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppExportRejectsInvalidRequestsBeforeAppCreation(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		zero          bool
+		jail, modules []string
+		want          string
+	}{
+		{"jail without zero height", false, []string{"validator"}, nil, "jail allowlist requires zero-height export"},
+		{"partial export", true, nil, []string{"bank"}, "zero-height export requires a complete module export"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := appExport(log.NewNopLogger(), nil, nil, -1, tc.zero, tc.jail, nil, tc.modules)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestNormalExportUsesUpstreamGenesisSemantics(t *testing.T) {
+	homePath := t.TempDir()
+	configPath := filepath.Join(homePath, "config")
+	require.NoError(t, os.MkdirAll(configPath, 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(homePath, "data"), 0o700))
+
+	sourceGenesis := genutiltypes.AppGenesis{
+		ChainID:       "source-chain",
+		InitialHeight: 8,
+		AppHash:       []byte{0x01, 0x02, 0x03},
+		AppState:      json.RawMessage(`{"source":true}`),
+		Consensus: &genutiltypes.ConsensusGenesis{
+			Params: cmttypes.DefaultConsensusParams(),
+		},
+	}
+	sourceBytes, err := json.Marshal(sourceGenesis)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configPath, "genesis.json"), sourceBytes, 0o600))
+
+	params := cmttypes.DefaultConsensusParams()
+	params.Version.App = 17
+	params.ABCI.VoteExtensionsEnableHeight = 7
+	exporterCalled := false
+	exporter := func(
+		_ log.Logger,
+		database dbm.DB,
+		_ io.Writer,
+		_ int64,
+		forZeroHeight bool,
+		jailAllowedAddrs []string,
+		_ servertypes.AppOptions,
+		modulesToExport []string,
+	) (servertypes.ExportedApp, error) {
+		exporterCalled = true
+		require.False(t, forZeroHeight)
+		require.Empty(t, jailAllowedAddrs)
+		require.Empty(t, modulesToExport)
+		require.NoError(t, database.Close())
+		return servertypes.ExportedApp{
+			AppState:        json.RawMessage(`{"exported":true}`),
+			Height:          42,
+			ConsensusParams: params.ToProto(),
+		}, nil
+	}
+
+	command := server.ExportCmd(exporter, homePath)
+	var stdout bytes.Buffer
+	command.SetOut(&stdout)
+	command.SetArgs([]string{"--home", homePath})
+	serverContext := server.NewDefaultContext()
+	serverContext.Viper.Set(flags.FlagHome, homePath)
+	serverContext.Viper.Set(flags.FlagChainID, "different-runtime-chain")
+	ctx := context.WithValue(context.Background(), server.ServerContextKey, serverContext)
+	require.NoError(t, command.ExecuteContext(ctx))
+	require.True(t, exporterCalled)
+
+	var exportedGenesis genutiltypes.AppGenesis
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &exportedGenesis))
+	require.Equal(t, "source-chain", exportedGenesis.ChainID)
+	require.True(t, exportedGenesis.GenesisTime.IsZero())
+	require.Equal(t, []byte{0x01, 0x02, 0x03}, exportedGenesis.AppHash)
+	require.Equal(t, int64(42), exportedGenesis.InitialHeight)
+	require.JSONEq(t, `{"exported":true}`, string(exportedGenesis.AppState))
+	require.Zero(t, exportedGenesis.Consensus.Params.Version.App)
+	require.Zero(t, exportedGenesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight)
+}

--- a/cmd/gurud/cmd/genesis.go
+++ b/cmd/gurud/cmd/genesis.go
@@ -242,6 +242,14 @@ func newValidateGenesisCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("validate Guru application genesis: %w", err)
 			}
+			consensusParams := genesis.Consensus.Params.ToProto()
+			if err := application.ValidateGenesisConsensusAtHeight(
+				appState,
+				genesis.InitialHeight,
+				&consensusParams,
+			); err != nil {
+				return fmt.Errorf("validate consensus-dependent Guru genesis: %w", err)
+			}
 			_, err = fmt.Fprintf(command.OutOrStdout(), "File at %s is a valid Guru genesis file\n", genesisPath)
 			return err
 		},

--- a/cmd/gurud/cmd/runtime.go
+++ b/cmd/gurud/cmd/runtime.go
@@ -76,6 +76,10 @@ func appExport(
 	appOpts servertypes.AppOptions,
 	modulesToExport []string,
 ) (servertypes.ExportedApp, error) {
+	if err := app.ValidateExportRequest(forZeroHeight, jailAllowedAddrs, modulesToExport); err != nil {
+		return servertypes.ExportedApp{}, err
+	}
+
 	cfg, err := resolveRuntimeConfig(appOpts)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
@@ -99,11 +103,7 @@ func appExport(
 			return servertypes.ExportedApp{}, fmt.Errorf("load export height %d: %w", height, err)
 		}
 	}
-	return application.ExportAppStateAndValidators(
-		forZeroHeight,
-		jailAllowedAddrs,
-		modulesToExport,
-	)
+	return application.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport)
 }
 
 func newAppOptions(

--- a/x/oracle/genesis.go
+++ b/x/oracle/genesis.go
@@ -154,12 +154,15 @@ func (am AppModule) validateGenesisState(data *oracletypes.GenesisState) error {
 		}
 		scheduledTaskCounts[symbol]++
 	}
+	// An empty schedule is a valid export/configuration state with preserved
+	// tasks. The App validates consensus activation before allowing startup.
+	// A nonempty schedule must still include the full window for every enabled task.
 	for _, task := range data.GetTasks() {
 		if !task.GetEnabled() {
 			continue
 		}
 		symbol := oraclekeeper.NormalizeSymbol(task.GetSymbol())
-		if scheduledTaskCounts[symbol] < 2 {
+		if len(data.GetTaskSchedule()) != 0 && scheduledTaskCounts[symbol] < 2 {
 			return oracletypes.ErrInvalidTask.Wrapf("enabled task %q must have at least two schedule entries", symbol)
 		}
 	}

--- a/x/oracle/genesis_test.go
+++ b/x/oracle/genesis_test.go
@@ -110,6 +110,16 @@ func TestReadGenesisStateAcceptsCanonicalProtoJSON(t *testing.T) {
 	require.Equal(t, int64(80), genesis.GetLatestValues()[0].GetBlockTimeUnix())
 }
 
+func TestValidateGenesisAllowsUnscheduledTaskConfiguration(t *testing.T) {
+	state := &oracletypes.GenesisState{
+		Params: oraclekeeper.DefaultParams(),
+		Tasks:  []*oracletypes.OracleTask{genesisTask("BTC/USD", true, 5)},
+	}
+	require.NoError(t, (AppModule{}).validateGenesisState(state))
+	state.Tasks[0].SubmissionInterval = 0
+	require.Error(t, (AppModule{}).validateGenesisState(state))
+}
+
 func TestValidateGenesisRejectsInvalidTaskSchedule(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -148,13 +158,6 @@ func TestValidateGenesisRejectsInvalidTaskSchedule(t *testing.T) {
 				Params:       oraclekeeper.DefaultParams(),
 				Tasks:        []*oracletypes.OracleTask{genesisTask("BTC/USD", false, 5)},
 				TaskSchedule: []*oracletypes.OracleTaskScheduleEntry{{Symbol: "BTC/USD", Height: 8}},
-			},
-		},
-		{
-			name: "enabled task missing schedule",
-			genesis: &oracletypes.GenesisState{
-				Params: oraclekeeper.DefaultParams(),
-				Tasks:  []*oracletypes.OracleTask{genesisTask("BTC/USD", true, 5)},
 			},
 		},
 		{


### PR DESCRIPTION
# Description

Implement zero-height genesis export through the existing upstream export CLI, with application-level state preparation and genesis validation.

The export prepares a new genesis while preserving supported application state and resetting history and height-dependent state. Transformations run in a discarded cache context without committing changes to the source application store.

## Changes

### Export and state preparation

- Support full-state zero-height export through `ExportAppStateAndValidators`.
- Reject partial-module zero-height exports and jail allowlists used without `--for-zero-height`.
- Prepare staking, distribution, and slashing state for restart using the Cosmos SDK zero-height export flow as the baseline.
- Preserve pending unbonding and redelegation amounts, completion times, and entry identifiers while resetting their creation heights.
- Apply the jail allowlist while retaining existing jailed state.
- Preserve the current `min_gas_price` and clear `pending_min_gas_price`.
- Preserve Oracle parameters and task definitions while clearing schedules, latest results, and historical records.
- Clear EIP-2935 historical block-hash storage after checking the expected system contract code.
- Reject unsupported active IBC, governance, and pending upgrade state.

### Genesis validation and startup

- Validate source and transformed genesis state at their respective initial heights.
- Check staking, distribution, supply, and economic continuity during zero-height export.
- Validate Oracle scheduling against consensus vote-extension activation settings.
- Apply consensus-dependent genesis validation during both genesis validation and application initialization.
- Allow Oracle genesis with an empty schedule, with activation requirements enforced at the application level.
- Construct the export context from the loaded application state and committed block time.

### Test coverage

- Add normal-height and zero-height export coverage.
- Add checks for deterministic output and unchanged source state.
- Cover staking pools, pending staking entries, jail allowlists, and economic continuity.
- Cover unsupported state rejection and invalid export arguments.
- Add fresh-application initialization and restart coverage, including an optional node-process runtime test path.
- Update Oracle genesis validation tests for empty schedules.

## Review instructions

1. Review `app/export.go` for export orchestration, cached state preparation, supported-state checks, and economic continuity validation.
2. Review `app/genesis.go` and `app/app.go` for height-aware and consensus-dependent genesis validation.
3. Review `cmd/gurud/cmd/runtime.go` and `cmd/gurud/cmd/genesis.go` for export request validation and CLI integration.
4. Review `x/oracle/genesis.go` for empty-schedule handling and its application-level validation boundary.
5. Review the corresponding test changes for supported restart scenarios and rejection cases.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [ ] targeted the `main` branch — N/A: this PR targets `dev-2.1`.

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code — N/A: this PR changes production export and genesis initialization code.
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed